### PR TITLE
Fix Modbus client initialization

### DIFF
--- a/powermeter/modbus.py
+++ b/powermeter/modbus.py
@@ -9,7 +9,7 @@ class ModbusPowermeter(Powermeter):
         self.unit_id = unit_id
         self.address = address
         self.count = count
-        self.client = ModbusTcpClient(host, port)
+        self.client = ModbusTcpClient(host, port=port)
 
     def get_powermeter_watts(self):
         result = self.client.read_holding_registers(

--- a/powermeter/modbus_test.py
+++ b/powermeter/modbus_test.py
@@ -13,6 +13,7 @@ class TestPowermeters(unittest.TestCase):
 
         modbuspowermeter = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
         self.assertEqual(modbuspowermeter.get_powermeter_watts(), [500])
+        MockModbusTcpClient.assert_called_with("192.168.1.14", port=502)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- fix ModbusTcpClient port argument usage
- ensure Modbus powermeter initialises correctly
- check port argument in Modbus test
