### PR TITLE
Fix type hints for Python 3.8 compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import configparser
 import argparse
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional
+from typing import Optional, List, Tuple
 from config.config_loader import read_all_powermeter_configs, ClientFilter
 from ct001 import CT001
 from powermeter import Powermeter
@@ -31,7 +31,7 @@ def run_device(
     device_type: str,
     cfg: configparser.ConfigParser,
     args: argparse.Namespace,
-    powermeters: list[(Powermeter, ClientFilter)],
+    powermeters: List[Tuple[Powermeter, ClientFilter]],
     device_id: Optional[str] = None,
 ):
     logger.debug(f"Starting device: {device_type}")

--- a/shelly/shelly.py
+++ b/shelly/shelly.py
@@ -1,6 +1,7 @@
 import socket
 import threading
 import json
+from typing import List, Tuple
 from config import ClientFilter
 from powermeter import Powermeter
 from config.logger import logger
@@ -8,7 +9,7 @@ from config.logger import logger
 
 class Shelly:
     def __init__(
-        self, powermeters: list[(Powermeter, ClientFilter)], udp_port: int, device_id
+        self, powermeters: List[Tuple[Powermeter, ClientFilter]], udp_port: int, device_id
     ):
         self._udp_port = udp_port
         self._device_id = device_id

--- a/shelly/shelly.py
+++ b/shelly/shelly.py
@@ -9,7 +9,10 @@ from config.logger import logger
 
 class Shelly:
     def __init__(
-        self, powermeters: List[Tuple[Powermeter, ClientFilter]], udp_port: int, device_id
+        self,
+        powermeters: List[Tuple[Powermeter, ClientFilter]],
+        udp_port: int,
+        device_id,
     ):
         self._udp_port = udp_port
         self._device_id = device_id

--- a/tests/test_no_pep585.py
+++ b/tests/test_no_pep585.py
@@ -3,20 +3,23 @@ import os
 
 ALLOWED_BUILTINS = {"list", "dict", "set", "tuple"}
 
+
 def test_no_pep585_generics():
     viols = []
     for root, _, files in os.walk(os.path.dirname(os.path.dirname(__file__))):
         for file in files:
-            if file.endswith('.py') and not file.startswith('test_'):
+            if file.endswith(".py") and not file.startswith("test_"):
                 path = os.path.join(root, file)
-                with open(path, 'r', encoding='utf-8') as f:
+                with open(path, "r", encoding="utf-8") as f:
                     source = f.read()
                 try:
                     tree = ast.parse(source)
                 except SyntaxError:
                     continue
                 for node in ast.walk(tree):
-                    if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
+                    if isinstance(node, ast.Subscript) and isinstance(
+                        node.value, ast.Name
+                    ):
                         if node.value.id in ALLOWED_BUILTINS:
                             viols.append(f"{path}:{node.lineno}")
     assert not viols, "PEP585 generics found: " + ", ".join(viols)

--- a/tests/test_no_pep585.py
+++ b/tests/test_no_pep585.py
@@ -1,0 +1,22 @@
+import ast
+import os
+
+ALLOWED_BUILTINS = {"list", "dict", "set", "tuple"}
+
+def test_no_pep585_generics():
+    viols = []
+    for root, _, files in os.walk(os.path.dirname(os.path.dirname(__file__))):
+        for file in files:
+            if file.endswith('.py') and not file.startswith('test_'):
+                path = os.path.join(root, file)
+                with open(path, 'r', encoding='utf-8') as f:
+                    source = f.read()
+                try:
+                    tree = ast.parse(source)
+                except SyntaxError:
+                    continue
+                for node in ast.walk(tree):
+                    if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name):
+                        if node.value.id in ALLOWED_BUILTINS:
+                            viols.append(f"{path}:{node.lineno}")
+    assert not viols, "PEP585 generics found: " + ", ".join(viols)


### PR DESCRIPTION
## Summary
- fix List/Tuple annotations in `main.py` and `shelly/shelly.py`
- add regression test ensuring no builtin generics remain

## Testing
- `pytest -q`