### PR TITLE
Fix Modbus unit id parameter for PyModbus 3.6

### DIFF
--- a/powermeter/modbus.py
+++ b/powermeter/modbus.py
@@ -61,7 +61,7 @@ class ModbusPowermeter(Powermeter):
 
     def get_powermeter_watts(self):
         read = getattr(self.client, self._read_method)
-        result = read(self.address, self.count, unit=self.unit_id)
+        result = read(self.address, self.count, slave=self.unit_id)
         if result.isError():
             raise Exception("Error reading Modbus data")
         decoder = BinaryPayloadDecoder.fromRegisters(

--- a/powermeter/modbus_test.py
+++ b/powermeter/modbus_test.py
@@ -14,6 +14,7 @@ class TestPowermeters(unittest.TestCase):
         modbuspowermeter = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
         self.assertEqual(modbuspowermeter.get_powermeter_watts(), [500.0])
         MockModbusTcpClient.assert_called_with("192.168.1.14", port=502)
+        mock_client.read_holding_registers.assert_called_once_with(0, 1, slave=1)
 
     @patch("powermeter.modbus.ModbusTcpClient")
     def test_modbuspowermeter_float32(self, MockModbusTcpClient):
@@ -32,6 +33,7 @@ class TestPowermeters(unittest.TestCase):
             word_order="BIG",
         )
         self.assertEqual(modbuspowermeter.get_powermeter_watts(), [10.0])
+        mock_client.read_holding_registers.assert_called_once_with(0, 2, slave=1)
 
     @patch("powermeter.modbus.ModbusTcpClient")
     def test_modbuspowermeter_input_registers(self, MockModbusTcpClient):
@@ -43,7 +45,7 @@ class TestPowermeters(unittest.TestCase):
             "192.168.1.14", 502, 1, 0, 1, register_type="INPUT"
         )
         self.assertEqual(modbuspowermeter.get_powermeter_watts(), [500.0])
-        mock_client.read_input_registers.assert_called_once()
+        mock_client.read_input_registers.assert_called_once_with(0, 1, slave=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Use `slave` parameter when reading Modbus registers so unit ID is honored
- Extend Modbus powermeter tests to assert correct `slave` argument

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad974b2bc832e9320db6bd46f4f86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Modbus communication to use the proper slave identifier, improving compatibility with more devices and preventing read failures when retrieving power data.

* **Tests**
  * Strengthened tests to verify exact Modbus read parameters (addresses, counts, and slave ID) for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->