### PR TITLE
docs: clarify HomeAssistant alias settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ The B2500 Meter project can be installed and run in several ways depending on yo
 
    A) Using the Add-on Configuration Interface:
    - After installation, go to the add-on's Configuration tab
-   - For single-phase monitoring:
-     - Set the `Power Input Alias` and optionally the `Power Output Alias` to the entity IDs of your power sensors
-   - For three-phase monitoring:
-     - Set the `Power Input Alias` to a comma-separated list of three entity IDs (one for each phase)
-     - If using calculated power, also set the `Power Output Alias` to a comma-separated list of three entity IDs
-     - Example: `sensor.phase1,sensor.phase2,sensor.phase3`
+    - For single-phase monitoring:
+      - Set the `Power Input Entity ID` and optionally the `Power Output Entity ID` to the entity IDs of your power sensors
+    - For three-phase monitoring:
+      - Set the `Power Input Entity ID` to a comma-separated list of three entity IDs (one for each phase)
+      - If using calculated power, also set the `Power Output Entity ID` to a comma-separated list of three entity IDs
+      - Example: `sensor.phase1,sensor.phase2,sensor.phase3`
    - Set `Device Types` (comma-separated list) to the device types you want to emulate:
      - `ct001`: CT001 emulator
      - `shellypro3em`: Shelly Pro 3EM emulator (uses both ports 1010 and 2220 for compatibility with all B2500 firmware versions)
@@ -258,9 +258,9 @@ ACCESSTOKEN = YOUR_ACCESS_TOKEN
 CURRENT_POWER_ENTITY = ""|sensor.current_power|sensor.phase1,sensor.phase2,sensor.phase3
 # If False or Empty the power is not calculated - if empty False is Fallback
 POWER_CALCULATE = ""|True|False 
-# The entity or entities (comma-separated for 3-phase) that provide power input
+# The entity ID or IDs (comma-separated for 3-phase) that provide power input
 POWER_INPUT_ALIAS = ""|sensor.power_input|sensor.power_in_1,sensor.power_in_2,sensor.power_in_3
-# The entity or entities (comma-separated for 3-phase) that provide power output
+# The entity ID or IDs (comma-separated for 3-phase) that provide power output
 POWER_OUTPUT_ALIAS = ""|sensor.power_output|sensor.power_out_1,sensor.power_out_2,sensor.power_out_3
 # Is a Path Prefix needed?
 API_PATH_PREFIX = ""|/core
@@ -526,7 +526,7 @@ sensor.phase1,sensor.phase2,sensor.phase3
 
 A: 
 - `CURRENT_POWER_ENTITY`: For a single bidirectional sensor (positive/negative values)
-- `POWER_INPUT_ALIAS`/`POWER_OUTPUT_ALIAS`: For separate import/export sensors (with `POWER_CALCULATE = True`)
+  - `POWER_INPUT_ALIAS`/`POWER_OUTPUT_ALIAS`: Entity IDs for separate import/export sensors (with `POWER_CALCULATE = True`)
 
 ## Device and Firmware Specific
 

--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ The B2500 Meter project can be installed and run in several ways depending on yo
 
    A) Using the Add-on Configuration Interface:
    - After installation, go to the add-on's Configuration tab
-    - For single-phase monitoring:
-      - Set the `Power Input Entity ID` and optionally the `Power Output Entity ID` to the entity IDs of your power sensors
-    - For three-phase monitoring:
-      - Set the `Power Input Entity ID` to a comma-separated list of three entity IDs (one for each phase)
-      - If using calculated power, also set the `Power Output Entity ID` to a comma-separated list of three entity IDs
-      - Example: `sensor.phase1,sensor.phase2,sensor.phase3`
+   - For single-phase monitoring:
+     - Set the `Power Input Entity ID` and optionally the `Power Output Entity ID` to the entity IDs of your power sensors
+   - For three-phase monitoring:
+     - Set the `Power Input Entity ID` to a comma-separated list of three entity IDs (one for each phase)
+     - If using calculated power, also set the `Power Output Entity ID` to a comma-separated list of three entity IDs
+     - Example: `sensor.phase1,sensor.phase2,sensor.phase3`
    - Set `Device Types` (comma-separated list) to the device types you want to emulate:
      - `ct001`: CT001 emulator
      - `shellypro3em`: Shelly Pro 3EM emulator (uses both ports 1010 and 2220 for compatibility with all B2500 firmware versions)

--- a/config.ini.example
+++ b/config.ini.example
@@ -73,7 +73,7 @@ THROTTLE_INTERVAL = 0
 ## Single sensor mode - comma-separated list for multiple phases
 #CURRENT_POWER_ENTITY = sensor.phase1_power, sensor.phase2_power, sensor.phase3_power
 
-## Or for separate input/output sensors
+## Or for separate input/output sensors (use entity IDs)
 #POWER_CALCULATE = True
 #POWER_INPUT_ALIAS = sensor.phase1_input, sensor.phase2_input, sensor.phase3_input
 #POWER_OUTPUT_ALIAS = sensor.phase1_output, sensor.phase2_output, sensor.phase3_output

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -1,10 +1,10 @@
 configuration:
   power_input_alias:
-    name: Power Input Alias
-    description: "The alias of the sensor(s) that provide the current power input. For multi-phase setups, enter multiple sensors separated by commas (e.g., 'sensor.phase1_in,sensor.phase2_in,sensor.phase3_in')."
+    name: Power Input Entity ID
+    description: "The entity ID of the sensor(s) that provide the current power input. For multi-phase setups, enter multiple entity IDs separated by commas (e.g., 'sensor.phase1_in,sensor.phase2_in,sensor.phase3_in')."
   power_output_alias:
-    name: Power Output Alias
-    description: "The alias of the sensor(s) that provide the current power output. For multi-phase setups, enter multiple sensors separated by commas (e.g., 'sensor.phase1_out,sensor.phase2_out,sensor.phase3_out'). If you only have one sensor for both input and output, leave this empty."
+    name: Power Output Entity ID
+    description: "The entity ID of the sensor(s) that provide the current power output. For multi-phase setups, enter multiple entity IDs separated by commas (e.g., 'sensor.phase1_out,sensor.phase2_out,sensor.phase3_out'). If you only have one sensor for both input and output, leave this empty."
   poll_interval:
     name: Poll Interval
     description: "The interval in seconds at which the ct001 should poll the power input and output sensors. Usually you should leave this at 1 second. Ignore this if you are emulating a different device."


### PR DESCRIPTION
## Summary
- clarify that HomeAssistant alias fields expect sensor entity IDs
- update example configuration to mention entity IDs

## Testing
- `flake8` *(fails: many style errors in existing code)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b57b5ec3fc832ebe624387bc515d83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Clarified terminology to “Power Input Entity ID” / “Power Output Entity ID” across README, FAQ and examples.
  - Updated HOMEASSISTANT config wording to emphasize entity IDs, including multi‑phase examples.
  - Added four Shelly device types to the documented list: shellypro3em_old, shellypro3em_new, shellyemg3, shellyproem50.
  - Improved formatting and indentation for readability; clarified config.ini example for separate sensors.

- Style
  - Updated UI labels and descriptions to use “Entity ID” with clearer examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->