### PR TITLE
Drop concurrent UDP requests per sender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next
+- Dropped overlapping Shelly UDP requests per sender to avoid throttling-related backlog ([#218](https://github.com/tomquist/b2500-meter/issues/218))
+
 ## 1.0.8
 - Added support for Modbus holding registers through new `REGISTER_TYPE` configuration option ([#173](https://github.com/tomquist/b2500-meter/pull/173))
 - Improved Shelly emulator with threaded UDP handling for better performance under concurrent requests when throttle interval is used ([#168](https://github.com/tomquist/b2500-meter/pull/168))

--- a/shelly/shelly.py
+++ b/shelly/shelly.py
@@ -23,6 +23,8 @@ class Shelly:
         self._value_mutex = threading.Lock()
         self._executor = ThreadPoolExecutor(max_workers=5)
         self._send_lock = threading.Lock()
+        self._in_flight_lock = threading.Lock()
+        self._in_flight_senders = set()
 
     def _calculate_derived_values(self, power):
         decimal_point_enforcer = 0.001
@@ -116,6 +118,13 @@ class Shelly:
         except Exception as e:
             logger.error(f"Error processing message: {e}")
 
+    def _handle_request_with_tracking(self, sock, data, addr):
+        try:
+            self._handle_request(sock, data, addr)
+        finally:
+            with self._in_flight_lock:
+                self._in_flight_senders.discard(addr[0])
+
     def udp_server(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.bind(("", self._udp_port))
@@ -124,7 +133,17 @@ class Shelly:
         try:
             while not self._stop:
                 data, addr = sock.recvfrom(1024)
-                self._executor.submit(self._handle_request, sock, data, addr)
+                with self._in_flight_lock:
+                    if addr[0] in self._in_flight_senders:
+                        logger.debug(
+                            "Discarding request from %s; previous request still in progress",
+                            addr[0],
+                        )
+                        continue
+                    self._in_flight_senders.add(addr[0])
+                self._executor.submit(
+                    self._handle_request_with_tracking, sock, data, addr
+                )
 
         finally:
             sock.close()

--- a/shelly/shelly_udp_test.py
+++ b/shelly/shelly_udp_test.py
@@ -17,7 +17,12 @@ class DummyPowermeter(Powermeter):
 
 class TestShellyUDP(unittest.TestCase):
     def test_multiple_requests_with_throttling(self):
-        pm = ThrottledPowermeter(DummyPowermeter(), throttle_interval=0.2)
+        class SlowPowermeter(DummyPowermeter):
+            def get_powermeter_watts(self):
+                time.sleep(0.2)
+                return super().get_powermeter_watts()
+
+        pm = ThrottledPowermeter(SlowPowermeter(), throttle_interval=0.2)
         cf = ClientFilter([IPv4Network("127.0.0.1/32")])
 
         tmp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -29,6 +34,7 @@ class TestShellyUDP(unittest.TestCase):
         shelly.start()
         try:
             client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            client.settimeout(0.3)
             responses = []
 
             def send_req(i):
@@ -39,8 +45,6 @@ class TestShellyUDP(unittest.TestCase):
                     "params": {"id": 0},
                 }
                 client.sendto(json.dumps(req).encode(), ("127.0.0.1", port))
-                data, _ = client.recvfrom(1024)
-                responses.append(json.loads(data.decode())["id"])
 
             threads = []
             start = time.time()
@@ -50,8 +54,14 @@ class TestShellyUDP(unittest.TestCase):
                 threads.append(t)
             for t in threads:
                 t.join()
+            while True:
+                try:
+                    data, _ = client.recvfrom(1024)
+                except socket.timeout:
+                    break
+                responses.append(json.loads(data.decode())["id"])
             duration = time.time() - start
-            self.assertEqual(sorted(responses), [0, 1, 2])
+            self.assertEqual(len(responses), 1)
             self.assertLess(duration, 0.6)
         finally:
             client.close()


### PR DESCRIPTION
### Motivation
- Prevent overlapping UDP requests from the same client from queuing and leaking resources when throttling is enabled.
- Ensure a single in-flight request per sender so slow powermeter handlers don't cause backlog or unexpected concurrent handling.

### Description
- Add per-sender in-flight tracking with `self._in_flight_senders` protected by `self._in_flight_lock` in `shelly/shelly.py`.
- Introduce `_handle_request_with_tracking` to call the existing handler and always remove the sender from the in-flight set after handling completes.
- Update `udp_server` to check and add the sender to the in-flight set before submitting work and to log and discard overlapping requests from the same `addr[0]`.
- Update `shelly/shelly_udp_test.py` to use a `SlowPowermeter`, set a client timeout with `client.settimeout(0.3)`, collect responses after issuing concurrent requests, and assert only one response is received during a throttled overlap.
- Move the Shelly UDP throttling fix note into the `## Next` section of `CHANGELOG.md`.

### Testing
- Ran `pytest -q shelly/shelly_udp_test.py` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d200d0bd8832e8ee7c8fb0a97b700)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent processing of overlapping UDP requests from the same sender, eliminating backlog and throttling-related issues for improved responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->