### PR TITLE
Fix Shelly UDP test hang by adding socket timeout

### DIFF
--- a/shelly/shelly.py
+++ b/shelly/shelly.py
@@ -118,12 +118,16 @@ class Shelly:
 
     def udp_server(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.settimeout(1.0)
         sock.bind(("", self._udp_port))
         logger.info(f"Shelly emulator listening on UDP port {self._udp_port}...")
 
         try:
             while not self._stop:
-                data, addr = sock.recvfrom(1024)
+                try:
+                    data, addr = sock.recvfrom(1024)
+                except TimeoutError:
+                    continue
                 self._executor.submit(self._handle_request, sock, data, addr)
 
         finally:

--- a/shelly/shelly_udp_test.py
+++ b/shelly/shelly_udp_test.py
@@ -55,9 +55,6 @@ class TestShellyUDP(unittest.TestCase):
             self.assertLess(duration, 0.6)
         finally:
             client.close()
-            # send dummy packet to unblock server if waiting on recv
-            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-                s.sendto(b"{}", ("127.0.0.1", port))
             shelly.stop()
 
 


### PR DESCRIPTION
## Summary
- add a 1s timeout to the Shelly UDP server socket so the loop can periodically check `_stop`
- remove the dummy-packet test workaround that is no longer needed

## Why
`recvfrom()` could block indefinitely, so `stop()` could hang on `thread.join()`, causing pytest to stall near completion.

## Testing
- updated `shelly_udp_test` to rely on timeout-based shutdown behavior
