### PR TITLE
feat: optional Marstek managed fake-device registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,12 @@ THROTTLE_INTERVAL = 0
 Optional Marstek cloud auto-registration:
 - **MARSTEK.ENABLE** — auto-create/check managed fake CT device(s) at startup
 - **MARSTEK.MAILBOX / PASSWORD** — credentials used to call Marstek API
-- Managed fake devices always use prefix `acde48` (not configurable)
 - For `ct002` a managed `HME-4` device is ensured, for `ct003` a managed `HME-3` device.
 - Device fields created by b2500-meter:
-  - `devid == mac` (random lowercase hex, prefix `acde48`)
+  - `devid == mac` (random lowercase hex)
   - `bluetooth_name = MST-SMR_<last4(mac)>`
   - `name = B2500-Meter CT002` / `B2500-Meter CT003`
-- If a matching managed `acde48` device of expected type already exists, no new device is created.
+- If a matching managed device of expected type already exists, no new device is created.
 
 ### Shelly
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ POLL_INTERVAL = 1
 THROTTLE_INTERVAL = 0
 ```
 
+Optional Marstek cloud auto-registration:
+- **MARSTEK.ENABLE** — auto-create/check managed fake CT device(s) at startup
+- **MARSTEK.MAILBOX / PASSWORD** — credentials used to call Marstek API
+- **MARSTEK.MAC_PREFIX** — generated fake device prefix (default `acde48`)
+- For `ct002` a managed `HME-4` device is ensured, for `ct003` a managed `HME-3` device.
+- Device fields created by b2500-meter:
+  - `devid == mac` (random lowercase hex, prefix `acde48`)
+  - `bluetooth_name = MST-SMR_<last4(mac)>`
+  - `name = B2500-Meter CT002` / `B2500-Meter CT003`
+- If a matching managed `acde48` device of expected type already exists, no new device is created.
+
 ### Shelly
 
 #### Shelly 1PM

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ THROTTLE_INTERVAL = 0
 Optional Marstek cloud auto-registration:
 - **MARSTEK.ENABLE** — auto-create/check managed fake CT device(s) at startup
 - **MARSTEK.MAILBOX / PASSWORD** — credentials used to call Marstek API
-- **MARSTEK.MAC_PREFIX** — generated fake device prefix (default `acde48`)
+- Managed fake devices always use prefix `acde48` (not configurable)
 - For `ct002` a managed `HME-4` device is ensured, for `ct003` a managed `HME-3` device.
 - Device fields created by b2500-meter:
   - `devid == mac` (random lowercase hex, prefix `acde48`)

--- a/config.ini.example
+++ b/config.ini.example
@@ -23,8 +23,7 @@ THROTTLE_INTERVAL = 0
 #BASE_URL = https://eu.hamedata.com
 #MAILBOX = your@email.example
 #PASSWORD = your_password
-## Prefix for generated managed fake devices (must be 6 lowercase hex chars)
-#MAC_PREFIX = acde48
+## Prefix is fixed to acde48 for managed fake devices.
 ## Used for add-device request
 #TIMEZONE = Europe/Berlin
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -17,6 +17,17 @@ POLL_INTERVAL = 1
 # Can be overridden per powermeter section
 THROTTLE_INTERVAL = 0
 
+#[MARSTEK]
+## Optional: auto-register managed fake CT devices in Marstek cloud on startup.
+#ENABLE = False
+#BASE_URL = https://eu.hamedata.com
+#MAILBOX = your@email.example
+#PASSWORD = your_password
+## Prefix for generated managed fake devices (must be 6 lowercase hex chars)
+#MAC_PREFIX = acde48
+## Used for add-device request
+#TIMEZONE = Europe/Berlin
+
 #[SHELLY]
 #TYPE = 1PM #PLUS1PM #EM #3EM #3EMPRO
 #IP = 192.168.1.100

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -40,9 +40,6 @@ options:
   marstek_enable: false
   marstek_mailbox: ""
   marstek_password: ""
-  marstek_base_url: "https://eu.hamedata.com"
-  marstek_timezone: "Europe/Berlin"
-  marstek_mac_prefix: "acde48"
   log_level: "info"
 schema:
   power_input_alias: str
@@ -54,8 +51,5 @@ schema:
   marstek_enable: bool?
   marstek_mailbox: str?
   marstek_password: password?
-  marstek_base_url: str?
-  marstek_timezone: str?
-  marstek_mac_prefix: str?
   log_level: list(critical|error|warning|info|debug)
   custom_config: str?

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -37,6 +37,12 @@ options:
   disable_absolute_values: false
   device_types: "shellypro3em"
   throttle_interval: 0
+  marstek_enable: false
+  marstek_mailbox: ""
+  marstek_password: ""
+  marstek_base_url: "https://eu.hamedata.com"
+  marstek_timezone: "Europe/Berlin"
+  marstek_mac_prefix: "acde48"
   log_level: "info"
 schema:
   power_input_alias: str
@@ -45,5 +51,11 @@ schema:
   disable_absolute_values: bool
   device_types: str
   throttle_interval: float(0,)
+  marstek_enable: bool?
+  marstek_mailbox: str?
+  marstek_password: password?
+  marstek_base_url: str?
+  marstek_timezone: str?
+  marstek_mac_prefix: str?
   log_level: list(critical|error|warning|info|debug)
   custom_config: str?

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -37,7 +37,7 @@ options:
   disable_absolute_values: false
   device_types: "shellypro3em"
   throttle_interval: 0
-  marstek_enable: false
+  marstek_auto_register_ct_device: false
   marstek_mailbox: ""
   marstek_password: ""
   log_level: "info"
@@ -48,7 +48,7 @@ schema:
   disable_absolute_values: bool
   device_types: str
   throttle_interval: float(0,)
-  marstek_enable: bool?
+  marstek_auto_register_ct_device: bool?
   marstek_mailbox: str?
   marstek_password: password?
   log_level: list(critical|error|warning|info|debug)

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -46,12 +46,12 @@ else
         echo "THROTTLE_INTERVAL=$(bashio::config 'throttle_interval')"
         echo "ENABLE_HEALTH_CHECK=true"
         echo ""
-        marstek_enable="false"
-        if bashio::config.has_value 'marstek_enable'; then
-            marstek_enable="$(bashio::config 'marstek_enable')"
+        marstek_auto_register_ct_device="false"
+        if bashio::config.has_value 'marstek_auto_register_ct_device'; then
+            marstek_auto_register_ct_device="$(bashio::config 'marstek_auto_register_ct_device')"
         fi
 
-        if [ "$marstek_enable" = "true" ] && bashio::config.has_value 'marstek_mailbox' && bashio::config.has_value 'marstek_password'; then
+        if [ "$marstek_auto_register_ct_device" = "true" ] && bashio::config.has_value 'marstek_mailbox' && bashio::config.has_value 'marstek_password'; then
             echo "[MARSTEK]"
             echo "ENABLE=True"
             echo "BASE_URL=https://eu.hamedata.com"

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -46,6 +46,22 @@ else
         echo "THROTTLE_INTERVAL=$(bashio::config 'throttle_interval')"
         echo "ENABLE_HEALTH_CHECK=true"
         echo ""
+        marstek_enable="false"
+        if bashio::config.has_value 'marstek_enable'; then
+            marstek_enable="$(bashio::config 'marstek_enable')"
+        fi
+
+        if [ "$marstek_enable" = "true" ] && bashio::config.has_value 'marstek_mailbox' && bashio::config.has_value 'marstek_password'; then
+            echo "[MARSTEK]"
+            echo "ENABLE=True"
+            echo "BASE_URL=$(bashio::config 'marstek_base_url')"
+            echo "MAILBOX=$(bashio::config 'marstek_mailbox')"
+            echo "PASSWORD=$(bashio::config 'marstek_password')"
+            echo "TIMEZONE=$(bashio::config 'marstek_timezone')"
+            echo "MAC_PREFIX=$(bashio::config 'marstek_mac_prefix')"
+            echo ""
+        fi
+
         echo "[HOMEASSISTANT]"
         echo "IP=supervisor"
         echo "PORT=80"

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -54,11 +54,10 @@ else
         if [ "$marstek_enable" = "true" ] && bashio::config.has_value 'marstek_mailbox' && bashio::config.has_value 'marstek_password'; then
             echo "[MARSTEK]"
             echo "ENABLE=True"
-            echo "BASE_URL=$(bashio::config 'marstek_base_url')"
+            echo "BASE_URL=https://eu.hamedata.com"
             echo "MAILBOX=$(bashio::config 'marstek_mailbox')"
             echo "PASSWORD=$(bashio::config 'marstek_password')"
-            echo "TIMEZONE=$(bashio::config 'marstek_timezone')"
-            echo "MAC_PREFIX=$(bashio::config 'marstek_mac_prefix')"
+            echo "TIMEZONE=Europe/Berlin"
             echo ""
         fi
 

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -32,6 +32,14 @@ wait_for_homeassistant() {
 
 CONFIG="/app/config.ini"
 
+print_redacted_config() {
+    sed -E \
+        -e 's/^(MAILBOX=).*/\1REDACTED/' \
+        -e 's/^(PASSWORD=).*/\1REDACTED/' \
+        -e 's/^(ACCESSTOKEN=).*/\1REDACTED/' \
+        "$1"
+}
+
 # Check if custom config is provided
 if bashio::config.has_value 'custom_config' && [ -f "/config/$(bashio::config 'custom_config')" ]; then
     bashio::log.info "Using custom config file: $(bashio::config 'custom_config')"
@@ -77,7 +85,7 @@ else
     } > "$CONFIG"
 fi
 
-cat "$CONFIG"
+print_redacted_config "$CONFIG"
 
 # Wait for Home Assistant to be ready before starting
 wait_for_homeassistant

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -25,7 +25,7 @@ configuration:
     description: "Optional. Name of a custom config.ini file to use instead of the UI configuration. The file must be placed in the add-on's configuration directory."
   marstek_auto_register_ct_device:
     name: Auto-register Managed CT Device (Marstek)
-    description: "If enabled, the add-on signs in to your Marstek account at startup and ensures one managed fake CT device exists for each emulated CT type (ct002 -> HME-4, ct003 -> HME-3). It only creates devices with the fixed prefix 'acde48' and reuses an existing matching one instead of creating duplicates."
+    description: "If enabled, the add-on signs in to your Marstek account at startup and ensures one managed fake CT device exists for each emulated CT type (ct002 -> HME-4, ct003 -> HME-3). Existing matching devices are reused to avoid duplicates."
   marstek_mailbox:
     name: Marstek Account Email
     description: "Email address used to sign in to your Marstek account for managed CT device registration."

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -23,3 +23,12 @@ configuration:
   custom_config:
     name: Custom Config
     description: "Optional. Name of a custom config.ini file to use instead of the UI configuration. The file must be placed in the add-on's configuration directory."
+  marstek_auto_register_ct_device:
+    name: Auto-register Managed CT Device (Marstek)
+    description: "If enabled, the add-on signs in to your Marstek account at startup and ensures one managed fake CT device exists for each emulated CT type (ct002 -> HME-4, ct003 -> HME-3). It only creates devices with the fixed prefix 'acde48' and reuses an existing matching one instead of creating duplicates."
+  marstek_mailbox:
+    name: Marstek Account Email
+    description: "Email address used to sign in to your Marstek account for managed CT device registration."
+  marstek_password:
+    name: Marstek Account Password
+    description: "Password used to sign in to your Marstek account for managed CT device registration."

--- a/main.py
+++ b/main.py
@@ -145,7 +145,9 @@ def main():
     parser.add_argument(
         "-c", "--config", default="config.ini", help="Path to the configuration file"
     )
-    parser.add_argument("-t", "--skip-powermeter-test", action="store_true", default=None)
+    parser.add_argument(
+        "-t", "--skip-powermeter-test", action="store_true", default=None
+    )
     parser.add_argument(
         "-d",
         "--device-types",
@@ -242,7 +244,6 @@ def main():
         password = cfg.get("MARSTEK", "PASSWORD", fallback="")
         base_url = cfg.get("MARSTEK", "BASE_URL", fallback="https://eu.hamedata.com")
         timezone_name = cfg.get("MARSTEK", "TIMEZONE", fallback="Europe/Berlin")
-        mac_prefix = cfg.get("MARSTEK", "MAC_PREFIX", fallback="acde48")
 
         if not mailbox or not password:
             logger.warning(
@@ -254,7 +255,6 @@ def main():
                 mailbox=mailbox,
                 password=password,
                 timezone=timezone_name,
-                mac_prefix=mac_prefix,
             )
             try:
                 for dt in ("ct002", "ct003"):

--- a/main.py
+++ b/main.py
@@ -265,6 +265,21 @@ def main():
             except Exception as exc:
                 logger.error("Unexpected Marstek auto-registration error: %s", exc)
 
+    # ct002/ct003 are registration markers only in this branch and must not be enqueued.
+    runtime_pairs = [
+        (dt, did)
+        for dt, did in zip(device_types, device_ids)
+        if dt not in ("ct002", "ct003")
+    ]
+    runtime_device_types = [dt for dt, _ in runtime_pairs]
+    runtime_device_ids = [did for _, did in runtime_pairs]
+
+    if len(runtime_device_types) != len(device_types):
+        logger.info(
+            "Skipping registration-only device markers from runtime queue: %s",
+            [dt for dt in device_types if dt in ("ct002", "ct003")],
+        )
+
     # Create powermeter
     powermeters = read_all_powermeter_configs(cfg)
     if not skip_test:
@@ -273,9 +288,13 @@ def main():
 
     # Run devices in parallel
     try:
-        with ThreadPoolExecutor(max_workers=len(device_types)) as executor:
+        if not runtime_device_types:
+            logger.warning("No runnable device types configured after filtering.")
+            return
+
+        with ThreadPoolExecutor(max_workers=len(runtime_device_types)) as executor:
             futures = []
-            for device_type, device_id in zip(device_types, device_ids):
+            for device_type, device_id in zip(runtime_device_types, runtime_device_ids):
                 futures.append(
                     executor.submit(
                         run_device, device_type, cfg, args, powermeters, device_id

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from shelly import Shelly
 from collections import OrderedDict
 from config.logger import logger, setLogLevel
 from health_service import start_health_service, stop_health_service
+from marstek_api import MarstekConfig, ensure_managed_fake_device, MarstekApiError
 
 
 def test_powermeter(powermeter: Powermeter, client_filter: ClientFilter):
@@ -233,7 +234,37 @@ def main():
             logger.info("Health check service started successfully")
         else:
             logger.error("Failed to start health check service")
-    
+
+    # Optional Marstek cloud registration for managed fake CT devices
+    marstek_enabled = cfg.getboolean("MARSTEK", "ENABLE", fallback=False)
+    if marstek_enabled:
+        mailbox = cfg.get("MARSTEK", "MAILBOX", fallback="")
+        password = cfg.get("MARSTEK", "PASSWORD", fallback="")
+        base_url = cfg.get("MARSTEK", "BASE_URL", fallback="https://eu.hamedata.com")
+        timezone_name = cfg.get("MARSTEK", "TIMEZONE", fallback="Europe/Berlin")
+        mac_prefix = cfg.get("MARSTEK", "MAC_PREFIX", fallback="acde48")
+
+        if not mailbox or not password:
+            logger.warning(
+                "MARSTEK.ENABLE is true, but MAILBOX/PASSWORD missing; skipping fake-device auto-registration"
+            )
+        else:
+            marstek_cfg = MarstekConfig(
+                base_url=base_url,
+                mailbox=mailbox,
+                password=password,
+                timezone=timezone_name,
+                mac_prefix=mac_prefix,
+            )
+            try:
+                for dt in ("ct002", "ct003"):
+                    if dt in device_types:
+                        ensure_managed_fake_device(marstek_cfg, dt)
+            except MarstekApiError as exc:
+                logger.error("Marstek auto-registration failed: %s", exc)
+            except Exception as exc:
+                logger.error("Unexpected Marstek auto-registration error: %s", exc)
+
     # Create powermeter
     powermeters = read_all_powermeter_configs(cfg)
     if not skip_test:

--- a/marstek_api.py
+++ b/marstek_api.py
@@ -1,0 +1,229 @@
+import hashlib
+import json
+import random
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MarstekConfig:
+    base_url: str
+    mailbox: str
+    password: str
+    timezone: str = "Europe/Berlin"
+    mac_prefix: str = "acde48"
+
+
+class MarstekApiError(Exception):
+    pass
+
+
+def _http_get_json(url: str, params: Dict[str, Any], headers: Dict[str, str] = None):
+    query = urllib.parse.urlencode(params)
+    full_url = f"{url}?{query}"
+    req = urllib.request.Request(full_url, headers=headers or {}, method="GET")
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        body = resp.read().decode("utf-8", errors="replace")
+        code = resp.status
+    try:
+        payload = json.loads(body)
+    except Exception:
+        raise MarstekApiError(f"Non-JSON response from {url}: {body[:200]}")
+
+    if code < 200 or code >= 300:
+        raise MarstekApiError(f"HTTP {code} from {url}: {payload}")
+    return payload
+
+
+def _random_hex(n: int) -> str:
+    return "".join(random.choice("0123456789abcdef") for _ in range(n))
+
+
+def _desired_type(device_type: str) -> str:
+    return "HME-4" if device_type == "ct002" else "HME-3"
+
+
+def _desired_name(device_type: str) -> str:
+    return "B2500-Meter CT002" if device_type == "ct002" else "B2500-Meter CT003"
+
+
+def _is_managed_prefix(value: str, mac_prefix: str) -> bool:
+    return isinstance(value, str) and value.lower().startswith(mac_prefix.lower())
+
+
+def _fetch_token_and_devices(cfg: MarstekConfig) -> Tuple[str, List[Dict[str, Any]]]:
+    pwd_md5 = hashlib.md5(cfg.password.encode("utf-8")).hexdigest()
+    token_url = f"{cfg.base_url.rstrip('/')}/app/Solar/v2_get_device.php"
+    token_resp = _http_get_json(token_url, {"mailbox": cfg.mailbox, "pwd": pwd_md5})
+
+    if str(token_resp.get("code")) != "2" or not token_resp.get("token"):
+        raise MarstekApiError(
+            f"Token fetch failed (code={token_resp.get('code')}): {token_resp.get('msg')}"
+        )
+
+    token = token_resp["token"]
+    solar_devices = (
+        token_resp.get("data") if isinstance(token_resp.get("data"), list) else []
+    )
+
+    list_url = f"{cfg.base_url.rstrip('/')}/ems/api/v1/getDeviceList"
+    list_resp = _http_get_json(
+        list_url,
+        {"mailbox": cfg.mailbox, "token": token},
+        headers={"User-Agent": "Dart/2.19 (dart:io)"},
+    )
+    ems_devices = (
+        list_resp.get("data") if isinstance(list_resp.get("data"), list) else []
+    )
+
+    by_devid = {
+        d.get("devid", ""): d
+        for d in ems_devices
+        if isinstance(d, dict) and d.get("devid")
+    }
+
+    merged = []
+    for d in solar_devices:
+        if not isinstance(d, dict):
+            continue
+        did = d.get("devid", "")
+        e = by_devid.get(did, {})
+        merged.append(
+            {
+                "devid": did,
+                "name": d.get("name") or e.get("name"),
+                "sn": d.get("sn"),
+                "mac": d.get("mac") or e.get("mac"),
+                "type": d.get("type") or e.get("type"),
+                "access": d.get("access"),
+                "bluetooth_name": d.get("bluetooth_name"),
+                "version": e.get("version"),
+                "salt": e.get("salt"),
+            }
+        )
+
+    return token, merged
+
+
+def _find_existing_managed_device(
+    devices: List[Dict[str, Any]], expected_type: str, mac_prefix: str
+) -> Optional[Dict[str, Any]]:
+    for d in devices:
+        devid = str(d.get("devid", "")).lower()
+        mac = str(d.get("mac", "")).lower()
+        dtype = str(d.get("type", ""))
+        if dtype != expected_type:
+            continue
+        if _is_managed_prefix(devid, mac_prefix) and _is_managed_prefix(
+            mac, mac_prefix
+        ):
+            return d
+    return None
+
+
+def _generate_new_id(existing_devices: List[Dict[str, Any]], mac_prefix: str) -> str:
+    existing = {
+        str(d.get("devid", "")).lower()
+        for d in existing_devices
+        if isinstance(d, dict) and d.get("devid")
+    }
+    existing |= {
+        str(d.get("mac", "")).lower()
+        for d in existing_devices
+        if isinstance(d, dict) and d.get("mac")
+    }
+
+    prefix = mac_prefix.lower()
+    if len(prefix) != 6 or any(c not in "0123456789abcdef" for c in prefix):
+        raise MarstekApiError("MAC_PREFIX must be exactly 6 lowercase hex chars")
+
+    for _ in range(200):
+        candidate = f"{prefix}{_random_hex(6)}"
+        if candidate not in existing:
+            return candidate
+    raise MarstekApiError("Could not generate unique managed MAC/DEVID")
+
+
+def _add_device(
+    cfg: MarstekConfig,
+    token: str,
+    device_type: str,
+    devid_mac: str,
+):
+    add_url = f"{cfg.base_url.rstrip('/')}/app/Solar/v2_add_device.php"
+    type_value = _desired_type(device_type)
+    suffix = devid_mac[-4:]
+    payload = {
+        "name": _desired_name(device_type),
+        "mailbox": cfg.mailbox,
+        "devid": devid_mac,
+        "mac": devid_mac,
+        "type": type_value,
+        "token": token,
+        "access": "1",
+        "bluetooth_name": f"MST-SMR_{suffix}",
+        "position": "{}",
+        "timeZone": cfg.timezone,
+    }
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "token": token,
+        "User-Agent": "Dart/2.19 (dart:io)",
+    }
+    resp = _http_get_json(add_url, payload, headers=headers)
+    code = str(resp.get("code", ""))
+    if code not in ("1", "2"):
+        raise MarstekApiError(
+            f"Add device failed for {device_type} (code={code}): {resp.get('msg')}"
+        )
+    return resp
+
+
+def ensure_managed_fake_device(
+    cfg: MarstekConfig, device_type: str
+) -> Optional[Dict[str, Any]]:
+    if device_type not in ("ct002", "ct003"):
+        return None
+
+    token, devices = _fetch_token_and_devices(cfg)
+    expected_type = _desired_type(device_type)
+
+    existing = _find_existing_managed_device(devices, expected_type, cfg.mac_prefix)
+    if existing:
+        logger.info(
+            "Marstek managed %s already exists (devid=%s, mac=%s, type=%s)",
+            device_type,
+            existing.get("devid"),
+            existing.get("mac"),
+            existing.get("type"),
+        )
+        return existing
+
+    new_id = _generate_new_id(devices, cfg.mac_prefix)
+    logger.info(
+        "Creating managed fake %s device in Marstek cloud (devid=mac=%s, type=%s)",
+        device_type,
+        new_id,
+        expected_type,
+    )
+    _add_device(cfg, token, device_type, new_id)
+
+    # Re-fetch once for confirmation and return created record
+    _, refreshed_devices = _fetch_token_and_devices(cfg)
+    created = _find_existing_managed_device(
+        refreshed_devices, expected_type, cfg.mac_prefix
+    )
+    if not created:
+        logger.warning(
+            "Created %s device but could not confirm it in refreshed list", device_type
+        )
+        return None
+    return created

--- a/marstek_api.py
+++ b/marstek_api.py
@@ -11,13 +11,15 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+MANAGED_MAC_PREFIX = "acde48"
+
+
 @dataclass
 class MarstekConfig:
     base_url: str
     mailbox: str
     password: str
     timezone: str = "Europe/Berlin"
-    mac_prefix: str = "acde48"
 
 
 class MarstekApiError(Exception):
@@ -53,8 +55,8 @@ def _desired_name(device_type: str) -> str:
     return "B2500-Meter CT002" if device_type == "ct002" else "B2500-Meter CT003"
 
 
-def _is_managed_prefix(value: str, mac_prefix: str) -> bool:
-    return isinstance(value, str) and value.lower().startswith(mac_prefix.lower())
+def _is_managed_prefix(value: str) -> bool:
+    return isinstance(value, str) and value.lower().startswith(MANAGED_MAC_PREFIX)
 
 
 def _fetch_token_and_devices(cfg: MarstekConfig) -> Tuple[str, List[Dict[str, Any]]]:
@@ -112,7 +114,7 @@ def _fetch_token_and_devices(cfg: MarstekConfig) -> Tuple[str, List[Dict[str, An
 
 
 def _find_existing_managed_device(
-    devices: List[Dict[str, Any]], expected_type: str, mac_prefix: str
+    devices: List[Dict[str, Any]], expected_type: str
 ) -> Optional[Dict[str, Any]]:
     for d in devices:
         devid = str(d.get("devid", "")).lower()
@@ -120,14 +122,12 @@ def _find_existing_managed_device(
         dtype = str(d.get("type", ""))
         if dtype != expected_type:
             continue
-        if _is_managed_prefix(devid, mac_prefix) and _is_managed_prefix(
-            mac, mac_prefix
-        ):
+        if _is_managed_prefix(devid) and _is_managed_prefix(mac):
             return d
     return None
 
 
-def _generate_new_id(existing_devices: List[Dict[str, Any]], mac_prefix: str) -> str:
+def _generate_new_id(existing_devices: List[Dict[str, Any]]) -> str:
     existing = {
         str(d.get("devid", "")).lower()
         for d in existing_devices
@@ -139,9 +139,7 @@ def _generate_new_id(existing_devices: List[Dict[str, Any]], mac_prefix: str) ->
         if isinstance(d, dict) and d.get("mac")
     }
 
-    prefix = mac_prefix.lower()
-    if len(prefix) != 6 or any(c not in "0123456789abcdef" for c in prefix):
-        raise MarstekApiError("MAC_PREFIX must be exactly 6 lowercase hex chars")
+    prefix = MANAGED_MAC_PREFIX
 
     for _ in range(200):
         candidate = f"{prefix}{_random_hex(6)}"
@@ -196,7 +194,7 @@ def ensure_managed_fake_device(
     token, devices = _fetch_token_and_devices(cfg)
     expected_type = _desired_type(device_type)
 
-    existing = _find_existing_managed_device(devices, expected_type, cfg.mac_prefix)
+    existing = _find_existing_managed_device(devices, expected_type)
     if existing:
         logger.info(
             "Marstek managed %s already exists (devid=%s, mac=%s, type=%s)",
@@ -207,7 +205,7 @@ def ensure_managed_fake_device(
         )
         return existing
 
-    new_id = _generate_new_id(devices, cfg.mac_prefix)
+    new_id = _generate_new_id(devices)
     logger.info(
         "Creating managed fake %s device in Marstek cloud (devid=mac=%s, type=%s)",
         device_type,
@@ -218,9 +216,7 @@ def ensure_managed_fake_device(
 
     # Re-fetch once for confirmation and return created record
     _, refreshed_devices = _fetch_token_and_devices(cfg)
-    created = _find_existing_managed_device(
-        refreshed_devices, expected_type, cfg.mac_prefix
-    )
+    created = _find_existing_managed_device(refreshed_devices, expected_type)
     if not created:
         logger.warning(
             "Created %s device but could not confirm it in refreshed list", device_type

--- a/marstek_api.py
+++ b/marstek_api.py
@@ -3,6 +3,7 @@ import json
 import random
 import urllib.parse
 import urllib.request
+import urllib.error
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -30,16 +31,34 @@ def _http_get_json(url: str, params: Dict[str, Any], headers: Dict[str, str] = N
     query = urllib.parse.urlencode(params)
     full_url = f"{url}?{query}"
     req = urllib.request.Request(full_url, headers=headers or {}, method="GET")
-    with urllib.request.urlopen(req, timeout=20) as resp:
-        body = resp.read().decode("utf-8", errors="replace")
-        code = resp.status
+
+    code = None
+    body = ""
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            code = resp.status
+    except urllib.error.HTTPError as exc:
+        code = exc.code
+        try:
+            body = exc.read().decode("utf-8", errors="replace")
+        except Exception:
+            body = str(exc)
+    except urllib.error.URLError as exc:
+        raise MarstekApiError(
+            f"Network error calling {full_url}: {exc.reason}"
+        ) from exc
+    except Exception as exc:
+        raise MarstekApiError(f"Unexpected error calling {full_url}: {exc}") from exc
+
     try:
         payload = json.loads(body)
     except Exception:
-        raise MarstekApiError(f"Non-JSON response from {url}: {body[:200]}")
+        snippet = body[:200] if body else "<empty>"
+        raise MarstekApiError(f"Non-JSON response from {full_url}: {snippet}")
 
-    if code < 200 or code >= 300:
-        raise MarstekApiError(f"HTTP {code} from {url}: {payload}")
+    if code is None or code < 200 or code >= 300:
+        raise MarstekApiError(f"HTTP {code} from {full_url}: {payload}")
     return payload
 
 

--- a/tests/test_marstek_api.py
+++ b/tests/test_marstek_api.py
@@ -21,9 +21,7 @@ def test_find_existing_managed_device_matches_prefix_and_type():
         {"devid": "ffffffffffff", "mac": "ffffffffffff", "type": "HME-3"},
     ]
 
-    found = _find_existing_managed_device(
-        devices, expected_type="HME-4", mac_prefix="acde48"
-    )
+    found = _find_existing_managed_device(devices, expected_type="HME-4")
     assert found is not None
     assert found["devid"] == "acde48aaaaaa"
 
@@ -33,9 +31,7 @@ def test_find_existing_managed_device_ignores_wrong_type():
         {"devid": "acde48aaaaaa", "mac": "acde48aaaaaa", "type": "HME-3"},
     ]
 
-    found = _find_existing_managed_device(
-        devices, expected_type="HME-4", mac_prefix="acde48"
-    )
+    found = _find_existing_managed_device(devices, expected_type="HME-4")
     assert found is None
 
 
@@ -45,7 +41,7 @@ def test_generate_new_id_uses_prefix_and_avoids_collisions():
         {"devid": "acde48bbbbbb", "mac": "acde48bbbbbb"},
     ]
 
-    new_id = _generate_new_id(devices, mac_prefix="acde48")
+    new_id = _generate_new_id(devices)
     assert new_id.startswith("acde48")
     assert len(new_id) == 12
     assert new_id not in {"acde48aaaaaa", "acde48bbbbbb"}

--- a/tests/test_marstek_api.py
+++ b/tests/test_marstek_api.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from marstek_api import (
+    _desired_type,
+    _find_existing_managed_device,
+    _generate_new_id,
+)
+
+
+def test_desired_type_mapping():
+    assert _desired_type("ct002") == "HME-4"
+    assert _desired_type("ct003") == "HME-3"
+
+
+def test_find_existing_managed_device_matches_prefix_and_type():
+    devices = [
+        {"devid": "acde48aaaaaa", "mac": "acde48aaaaaa", "type": "HME-4"},
+        {"devid": "ffffffffffff", "mac": "ffffffffffff", "type": "HME-3"},
+    ]
+
+    found = _find_existing_managed_device(
+        devices, expected_type="HME-4", mac_prefix="acde48"
+    )
+    assert found is not None
+    assert found["devid"] == "acde48aaaaaa"
+
+
+def test_find_existing_managed_device_ignores_wrong_type():
+    devices = [
+        {"devid": "acde48aaaaaa", "mac": "acde48aaaaaa", "type": "HME-3"},
+    ]
+
+    found = _find_existing_managed_device(
+        devices, expected_type="HME-4", mac_prefix="acde48"
+    )
+    assert found is None
+
+
+def test_generate_new_id_uses_prefix_and_avoids_collisions():
+    devices = [
+        {"devid": "acde48aaaaaa", "mac": "acde48aaaaaa"},
+        {"devid": "acde48bbbbbb", "mac": "acde48bbbbbb"},
+    ]
+
+    new_id = _generate_new_id(devices, mac_prefix="acde48")
+    assert new_id.startswith("acde48")
+    assert len(new_id) == 12
+    assert new_id not in {"acde48aaaaaa", "acde48bbbbbb"}


### PR DESCRIPTION
Clean PR with only the Marstek managed fake-device registration feature.

Includes:
- new marstek_api.py
- startup integration in main.py behind [MARSTEK] config
- addon config/run wiring for optional Marstek credentials
- docs/example updates
- focused unit tests (tests/test_marstek_api.py)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Marstek cloud auto-registration for managed fake CT devices (configurable enable, mailbox, password, base URL, timezone, and device prefix).

* **Documentation**
  * README and example configs updated with Marstek integration and startup auto-registration guidance.

* **Configuration**
  * Add-on options expose Marstek settings and emit a MARSTEK block at startup when enabled and credentials provided.

* **Tests**
  * Added tests covering Marstek helper behaviors (device detection and ID generation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->