### PR TITLE
feat: add optional POWER_OFFSET and POWER_MULTIPLIER for any powermeter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## Next
 - Added support for `POWER_MULTIPLIER = 0` to allow nulling individual phases
 - Added sign-flip and phase-nulling examples to README
 - Improved power transform logging: replaced print statements with structured logger calls and emit phase-mismatch warnings only once per mismatch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+- Added support for `POWER_MULTIPLIER = 0` to allow nulling individual phases
+- Added sign-flip and phase-nulling examples to README
+- Improved power transform logging: replaced print statements with structured logger calls and emit phase-mismatch warnings only once per mismatch
+- Added validation that offsets and multipliers lists are non-empty in TransformedPowermeter
+- Fixed exception chaining in float list parsing to preserve original traceback
+
 ## 1.0.8
 - Added support for Modbus holding registers through new `REGISTER_TYPE` configuration option ([#173](https://github.com/tomquist/b2500-meter/pull/173))
 - Improved Shelly emulator with threaded UDP handling for better performance under concurrent requests when throttle interval is used ([#168](https://github.com/tomquist/b2500-meter/pull/168))

--- a/README.md
+++ b/README.md
@@ -168,12 +168,25 @@ IP = 192.168.1.100
 POWER_OFFSET = -50
 POWER_MULTIPLIER = 1.05
 
-# Per-phase values — one per phase (must match phase count)
+# Per-phase values — if the list length does not match the device phase count,
+# values are applied cyclically and a runtime warning is emitted
 [SHELLY_2]
 TYPE = 3EMPro
 IP = 192.168.1.101
 POWER_OFFSET = -50,-30,-40
 POWER_MULTIPLIER = 1.05,1.02,1.03
+
+# Flip the sign of all readings (e.g. when import/export polarity is reversed)
+[SHELLY_3]
+TYPE = 1PM
+IP = 192.168.1.102
+POWER_MULTIPLIER = -1
+
+# Null a single phase on a three-phase meter
+[SHELLY_4]
+TYPE = 3EMPro
+IP = 192.168.1.103
+POWER_MULTIPLIER = 1,0,1
 ```
 
 **Note:** Transforms are applied before CT001's sum/absolute value operations.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,38 @@ POLL_INTERVAL = 1
 THROTTLE_INTERVAL = 0
 ```
 
+### Value Transformation
+
+You can optionally apply a linear transformation to the power values returned by any powermeter. This is useful for calibrating readings (e.g., correcting a consistent offset) or scaling values (e.g., adjusting for a CT clamp ratio).
+
+The formula applied to each value is: `value * POWER_MULTIPLIER + POWER_OFFSET`
+
+For example, if your meter reads 1050W and you set `POWER_MULTIPLIER=0.95` and `POWER_OFFSET=-50`, the result is `1050 * 0.95 + (-50) = 947.5W`.
+
+Both settings are optional and can be added to any powermeter section:
+- `POWER_MULTIPLIER` — Scales each power value. Default: 1 (no scaling).
+- `POWER_OFFSET` — Added to each power value after the multiplier is applied. Default: 0 (no offset).
+
+For three-phase meters, you can specify a single value (applied to all phases) or comma-separated values (one per phase):
+
+```ini
+# Single value — applies to all phases
+[SHELLY_1]
+TYPE = 1PM
+IP = 192.168.1.100
+POWER_OFFSET = -50
+POWER_MULTIPLIER = 1.05
+
+# Per-phase values — one per phase (must match phase count)
+[SHELLY_2]
+TYPE = 3EMPro
+IP = 192.168.1.101
+POWER_OFFSET = -50,-30,-40
+POWER_MULTIPLIER = 1.05,1.02,1.03
+```
+
+**Note:** Transforms are applied before CT001's sum/absolute value operations.
+
 ### Shelly
 
 #### Shelly 1PM

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -24,6 +24,7 @@ from powermeter import (
     JsonHttpPowermeter,
     TQEnergyManager,
     ThrottledPowermeter,
+    TransformedPowermeter,
 )
 
 SHELLY_SECTION = "SHELLY"
@@ -56,6 +57,22 @@ class ClientFilter:
             return False
 
 
+def parse_float_list(value, key_name, section):
+    # type: (str, str, str) -> List[float]
+    tokens = [t.strip() for t in value.split(",")]
+    result = []
+    for token in tokens:
+        if not token:
+            continue
+        try:
+            result.append(float(token))
+        except ValueError:
+            raise ValueError(
+                f"Invalid {key_name} value '{token}' in section [{section}]"
+            )
+    return result if result else [0.0]
+
+
 def read_all_powermeter_configs(
     config: configparser.ConfigParser,
 ) -> List[Tuple[Powermeter, ClientFilter]]:
@@ -67,6 +84,30 @@ def read_all_powermeter_configs(
     for section in config.sections():
         powermeter = create_powermeter(section, config)
         if powermeter is not None:
+            # Apply power transform if configured
+            has_offset = config.has_option(section, "POWER_OFFSET")
+            has_multiplier = config.has_option(section, "POWER_MULTIPLIER")
+            if has_offset or has_multiplier:
+                offsets = parse_float_list(
+                    config.get(section, "POWER_OFFSET", fallback="0"),
+                    "POWER_OFFSET",
+                    section,
+                )
+                multipliers = parse_float_list(
+                    config.get(section, "POWER_MULTIPLIER", fallback="1"),
+                    "POWER_MULTIPLIER",
+                    section,
+                )
+                for m in multipliers:
+                    if m == 0:
+                        raise ValueError(
+                            f"POWER_MULTIPLIER cannot be 0 in section [{section}]"
+                        )
+                print(
+                    f"Applying power transform (multiplier={multipliers}, offset={offsets}) to {section}"
+                )
+                powermeter = TransformedPowermeter(powermeter, offsets, multipliers)
+
             section_throttle_interval = config.getfloat(
                 section, "THROTTLE_INTERVAL", fallback=global_throttle_interval
             )

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -66,10 +66,10 @@ def parse_float_list(value, key_name, section):
             continue
         try:
             result.append(float(token))
-        except ValueError:
+        except ValueError as err:
             raise ValueError(
                 f"Invalid {key_name} value '{token}' in section [{section}]"
-            )
+            ) from err
     return result if result else [0.0]
 
 
@@ -98,12 +98,7 @@ def read_all_powermeter_configs(
                     "POWER_MULTIPLIER",
                     section,
                 )
-                for m in multipliers:
-                    if m == 0:
-                        raise ValueError(
-                            f"POWER_MULTIPLIER cannot be 0 in section [{section}]"
-                        )
-                print(
+                logger.info(
                     f"Applying power transform (multiplier={multipliers}, offset={offsets}) to {section}"
                 )
                 powermeter = TransformedPowermeter(powermeter, offsets, multipliers)

--- a/config/config_loader_test.py
+++ b/config/config_loader_test.py
@@ -20,10 +20,11 @@ from config.config_loader import (
     create_mqtt_powermeter,
     create_json_http_powermeter,
     create_tq_em_powermeter,
+    parse_float_list,
 )
 import unittest
 from unittest.mock import patch, Mock
-from powermeter import ThrottledPowermeter
+from powermeter import ThrottledPowermeter, TransformedPowermeter
 
 
 def test_client_filter():
@@ -299,6 +300,112 @@ def test_read_all_powermeter_configs():
         # Some powermeters might fail due to connection issues, but the function should run
         assert isinstance(powermeters, list)
 
+    except Exception as e:
+        if "Connection" not in str(e) and "timed out" not in str(e):
+            raise
+
+
+def test_parse_float_list():
+    """Test parsing comma-separated float lists."""
+    assert parse_float_list("10", "KEY", "SECTION") == [10.0]
+    assert parse_float_list("1.5, 2.5, 3.5", "KEY", "SECTION") == [1.5, 2.5, 3.5]
+    assert parse_float_list("-50", "KEY", "SECTION") == [-50.0]
+    assert parse_float_list(" 10 , 20 ", "KEY", "SECTION") == [10.0, 20.0]
+    assert parse_float_list("", "KEY", "SECTION") == [0.0]
+
+
+def test_parse_float_list_invalid():
+    """Test that invalid float values raise ValueError with clear message."""
+    with pytest.raises(ValueError, match="Invalid POWER_OFFSET value 'abc'"):
+        parse_float_list("abc", "POWER_OFFSET", "SHELLY_1")
+
+
+def test_read_all_configs_with_power_transform():
+    """Test that POWER_OFFSET and POWER_MULTIPLIER wrap the powermeter."""
+    config = configparser.ConfigParser()
+    config["SCRIPT_1"] = {
+        "COMMAND": 'echo "100"',
+        "POWER_OFFSET": "-50",
+        "POWER_MULTIPLIER": "1.05",
+    }
+
+    try:
+        powermeters = read_all_powermeter_configs(config)
+        assert len(powermeters) == 1
+        pm, _ = powermeters[0]
+        assert isinstance(pm, TransformedPowermeter)
+        assert pm.offsets == [-50.0]
+        assert pm.multipliers == [1.05]
+    except Exception as e:
+        if "Connection" not in str(e) and "timed out" not in str(e):
+            raise
+
+
+def test_read_all_configs_with_per_phase_transform():
+    """Test per-phase offset and multiplier values."""
+    config = configparser.ConfigParser()
+    config["SCRIPT_1"] = {
+        "COMMAND": 'echo "100"',
+        "POWER_OFFSET": "-10,-20,-30",
+        "POWER_MULTIPLIER": "1.05,1.02,1.03",
+    }
+
+    try:
+        powermeters = read_all_powermeter_configs(config)
+        assert len(powermeters) == 1
+        pm, _ = powermeters[0]
+        assert isinstance(pm, TransformedPowermeter)
+        assert pm.offsets == [-10.0, -20.0, -30.0]
+        assert pm.multipliers == [1.05, 1.02, 1.03]
+    except Exception as e:
+        if "Connection" not in str(e) and "timed out" not in str(e):
+            raise
+
+
+def test_read_all_configs_offset_only():
+    """Test that setting only POWER_OFFSET wraps with default multiplier."""
+    config = configparser.ConfigParser()
+    config["SCRIPT_1"] = {
+        "COMMAND": 'echo "100"',
+        "POWER_OFFSET": "10",
+    }
+
+    try:
+        powermeters = read_all_powermeter_configs(config)
+        assert len(powermeters) == 1
+        pm, _ = powermeters[0]
+        assert isinstance(pm, TransformedPowermeter)
+        assert pm.offsets == [10.0]
+        assert pm.multipliers == [1.0]
+    except Exception as e:
+        if "Connection" not in str(e) and "timed out" not in str(e):
+            raise
+
+
+def test_read_all_configs_zero_multiplier_rejected():
+    """Test that a multiplier of 0 is rejected at config load time."""
+    config = configparser.ConfigParser()
+    config["SCRIPT_1"] = {
+        "COMMAND": 'echo "100"',
+        "POWER_MULTIPLIER": "0",
+    }
+
+    with pytest.raises(ValueError, match="POWER_MULTIPLIER cannot be 0"):
+        read_all_powermeter_configs(config)
+
+
+def test_read_all_configs_no_transform_when_not_configured():
+    """Test that no transform wrapper is applied when keys are absent."""
+    config = configparser.ConfigParser()
+    config["SCRIPT_1"] = {
+        "COMMAND": 'echo "100"',
+    }
+
+    try:
+        powermeters = read_all_powermeter_configs(config)
+        assert len(powermeters) == 1
+        pm, _ = powermeters[0]
+        assert not isinstance(pm, TransformedPowermeter)
     except Exception as e:
         if "Connection" not in str(e) and "timed out" not in str(e):
             raise

--- a/config/config_loader_test.py
+++ b/config/config_loader_test.py
@@ -329,16 +329,12 @@ def test_read_all_configs_with_power_transform():
         "POWER_MULTIPLIER": "1.05",
     }
 
-    try:
-        powermeters = read_all_powermeter_configs(config)
-        assert len(powermeters) == 1
-        pm, _ = powermeters[0]
-        assert isinstance(pm, TransformedPowermeter)
-        assert pm.offsets == [-50.0]
-        assert pm.multipliers == [1.05]
-    except Exception as e:
-        if "Connection" not in str(e) and "timed out" not in str(e):
-            raise
+    powermeters = read_all_powermeter_configs(config)
+    assert len(powermeters) == 1
+    pm, _ = powermeters[0]
+    assert isinstance(pm, TransformedPowermeter)
+    assert pm.offsets == [-50.0]
+    assert pm.multipliers == [1.05]
 
 
 def test_read_all_configs_with_per_phase_transform():
@@ -350,16 +346,12 @@ def test_read_all_configs_with_per_phase_transform():
         "POWER_MULTIPLIER": "1.05,1.02,1.03",
     }
 
-    try:
-        powermeters = read_all_powermeter_configs(config)
-        assert len(powermeters) == 1
-        pm, _ = powermeters[0]
-        assert isinstance(pm, TransformedPowermeter)
-        assert pm.offsets == [-10.0, -20.0, -30.0]
-        assert pm.multipliers == [1.05, 1.02, 1.03]
-    except Exception as e:
-        if "Connection" not in str(e) and "timed out" not in str(e):
-            raise
+    powermeters = read_all_powermeter_configs(config)
+    assert len(powermeters) == 1
+    pm, _ = powermeters[0]
+    assert isinstance(pm, TransformedPowermeter)
+    assert pm.offsets == [-10.0, -20.0, -30.0]
+    assert pm.multipliers == [1.05, 1.02, 1.03]
 
 
 def test_read_all_configs_offset_only():
@@ -370,28 +362,27 @@ def test_read_all_configs_offset_only():
         "POWER_OFFSET": "10",
     }
 
-    try:
-        powermeters = read_all_powermeter_configs(config)
-        assert len(powermeters) == 1
-        pm, _ = powermeters[0]
-        assert isinstance(pm, TransformedPowermeter)
-        assert pm.offsets == [10.0]
-        assert pm.multipliers == [1.0]
-    except Exception as e:
-        if "Connection" not in str(e) and "timed out" not in str(e):
-            raise
+    powermeters = read_all_powermeter_configs(config)
+    assert len(powermeters) == 1
+    pm, _ = powermeters[0]
+    assert isinstance(pm, TransformedPowermeter)
+    assert pm.offsets == [10.0]
+    assert pm.multipliers == [1.0]
 
 
-def test_read_all_configs_zero_multiplier_rejected():
-    """Test that a multiplier of 0 is rejected at config load time."""
+def test_read_all_configs_zero_multiplier_accepted():
+    """Test that a multiplier of 0 is accepted (e.g. to null a phase)."""
     config = configparser.ConfigParser()
     config["SCRIPT_1"] = {
         "COMMAND": 'echo "100"',
         "POWER_MULTIPLIER": "0",
     }
 
-    with pytest.raises(ValueError, match="POWER_MULTIPLIER cannot be 0"):
-        read_all_powermeter_configs(config)
+    powermeters = read_all_powermeter_configs(config)
+    assert len(powermeters) == 1
+    pm, _ = powermeters[0]
+    assert isinstance(pm, TransformedPowermeter)
+    assert pm.multipliers == [0.0]
 
 
 def test_read_all_configs_no_transform_when_not_configured():
@@ -401,11 +392,7 @@ def test_read_all_configs_no_transform_when_not_configured():
         "COMMAND": 'echo "100"',
     }
 
-    try:
-        powermeters = read_all_powermeter_configs(config)
-        assert len(powermeters) == 1
-        pm, _ = powermeters[0]
-        assert not isinstance(pm, TransformedPowermeter)
-    except Exception as e:
-        if "Connection" not in str(e) and "timed out" not in str(e):
-            raise
+    powermeters = read_all_powermeter_configs(config)
+    assert len(powermeters) == 1
+    pm, _ = powermeters[0]
+    assert not isinstance(pm, TransformedPowermeter)

--- a/powermeter/__init__.py
+++ b/powermeter/__init__.py
@@ -13,4 +13,5 @@ from .mqtt import MqttPowermeter
 from .json_http import JsonHttpPowermeter
 from .script import Script
 from .throttling import ThrottledPowermeter
+from .transform import TransformedPowermeter
 from .tq_em import TQEnergyManager

--- a/powermeter/transform.py
+++ b/powermeter/transform.py
@@ -1,0 +1,46 @@
+from typing import List
+from .base import Powermeter
+
+
+class TransformedPowermeter(Powermeter):
+    """
+    A wrapper around a powermeter that applies a linear transformation
+    (multiplier and offset) to each returned power value.
+
+    Formula per value: value * multiplier + offset
+
+    Supports per-phase configuration: if a single multiplier/offset is given,
+    it applies to all phases. If multiple values are given, each applies to
+    the corresponding phase.
+    """
+
+    def __init__(self, wrapped_powermeter, offsets, multipliers):
+        # type: (Powermeter, List[float], List[float]) -> None
+        self.wrapped_powermeter = wrapped_powermeter
+        self.offsets = offsets
+        self.multipliers = multipliers
+
+    def wait_for_message(self, timeout=5):
+        return self.wrapped_powermeter.wait_for_message(timeout)
+
+    def get_powermeter_watts(self):
+        # type: () -> List[float]
+        values = self.wrapped_powermeter.get_powermeter_watts()
+        result = []
+        for i, value in enumerate(values):
+            multiplier = self.multipliers[i % len(self.multipliers)]
+            offset = self.offsets[i % len(self.offsets)]
+            result.append(value * multiplier + offset)
+
+        if len(self.offsets) > 1 and len(self.offsets) != len(values):
+            print(
+                f"Warning: POWER_OFFSET has {len(self.offsets)} values but "
+                f"powermeter returned {len(values)} phases"
+            )
+        if len(self.multipliers) > 1 and len(self.multipliers) != len(values):
+            print(
+                f"Warning: POWER_MULTIPLIER has {len(self.multipliers)} values but "
+                f"powermeter returned {len(values)} phases"
+            )
+
+        return result

--- a/powermeter/transform.py
+++ b/powermeter/transform.py
@@ -1,5 +1,8 @@
+import logging
 from typing import List
 from .base import Powermeter
+
+logger = logging.getLogger(__name__)
 
 
 class TransformedPowermeter(Powermeter):
@@ -16,9 +19,15 @@ class TransformedPowermeter(Powermeter):
 
     def __init__(self, wrapped_powermeter, offsets, multipliers):
         # type: (Powermeter, List[float], List[float]) -> None
+        if not offsets:
+            raise ValueError("offsets must be a non-empty list")
+        if not multipliers:
+            raise ValueError("multipliers must be a non-empty list")
         self.wrapped_powermeter = wrapped_powermeter
         self.offsets = offsets
         self.multipliers = multipliers
+        self._offsets_mismatch_warned = False
+        self._multipliers_mismatch_warned = False
 
     def wait_for_message(self, timeout=5):
         return self.wrapped_powermeter.wait_for_message(timeout)
@@ -33,14 +42,25 @@ class TransformedPowermeter(Powermeter):
             result.append(value * multiplier + offset)
 
         if len(self.offsets) > 1 and len(self.offsets) != len(values):
-            print(
-                f"Warning: POWER_OFFSET has {len(self.offsets)} values but "
-                f"powermeter returned {len(values)} phases"
-            )
+            if not self._offsets_mismatch_warned:
+                logger.warning(
+                    "POWER_OFFSET has %d values but powermeter returned %d phases",
+                    len(self.offsets),
+                    len(values),
+                )
+                self._offsets_mismatch_warned = True
+        else:
+            self._offsets_mismatch_warned = False
+
         if len(self.multipliers) > 1 and len(self.multipliers) != len(values):
-            print(
-                f"Warning: POWER_MULTIPLIER has {len(self.multipliers)} values but "
-                f"powermeter returned {len(values)} phases"
-            )
+            if not self._multipliers_mismatch_warned:
+                logger.warning(
+                    "POWER_MULTIPLIER has %d values but powermeter returned %d phases",
+                    len(self.multipliers),
+                    len(values),
+                )
+                self._multipliers_mismatch_warned = True
+        else:
+            self._multipliers_mismatch_warned = False
 
         return result

--- a/powermeter/transform_test.py
+++ b/powermeter/transform_test.py
@@ -1,0 +1,101 @@
+import unittest
+from unittest.mock import Mock
+from .transform import TransformedPowermeter
+
+
+class TestTransformedPowermeter(unittest.TestCase):
+    def setUp(self):
+        self.mock_powermeter = Mock()
+
+    def test_identity_single_phase(self):
+        self.mock_powermeter.get_powermeter_watts.return_value = [500.0]
+        t = TransformedPowermeter(self.mock_powermeter, [0.0], [1.0])
+        self.assertEqual(t.get_powermeter_watts(), [500.0])
+
+    def test_identity_three_phase(self):
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+        t = TransformedPowermeter(self.mock_powermeter, [0.0], [1.0])
+        self.assertEqual(t.get_powermeter_watts(), [100.0, 200.0, 300.0])
+
+    def test_offset_only_broadcast(self):
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+        t = TransformedPowermeter(self.mock_powermeter, [10.0], [1.0])
+        self.assertEqual(t.get_powermeter_watts(), [110.0, 210.0, 310.0])
+
+    def test_negative_offset(self):
+        self.mock_powermeter.get_powermeter_watts.return_value = [1050.0]
+        t = TransformedPowermeter(self.mock_powermeter, [-50.0], [1.0])
+        self.assertEqual(t.get_powermeter_watts(), [1000.0])
+
+    def test_multiplier_only_broadcast(self):
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+        t = TransformedPowermeter(self.mock_powermeter, [0.0], [2.0])
+        self.assertEqual(t.get_powermeter_watts(), [200.0, 400.0, 600.0])
+
+    def test_both_offset_and_multiplier(self):
+        # 1050 * 0.95 + (-50) = 947.5
+        self.mock_powermeter.get_powermeter_watts.return_value = [1050.0]
+        t = TransformedPowermeter(self.mock_powermeter, [-50.0], [0.95])
+        result = t.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 947.5)
+
+    def test_negative_meter_values_with_multiplier(self):
+        self.mock_powermeter.get_powermeter_watts.return_value = [-100.0]
+        t = TransformedPowermeter(self.mock_powermeter, [0.0], [2.0])
+        self.assertEqual(t.get_powermeter_watts(), [-200.0])
+
+    def test_per_phase_offsets(self):
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+        t = TransformedPowermeter(self.mock_powermeter, [-10.0, -20.0, -30.0], [1.0])
+        self.assertEqual(t.get_powermeter_watts(), [90.0, 180.0, 270.0])
+
+    def test_per_phase_multipliers(self):
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+        t = TransformedPowermeter(self.mock_powermeter, [0.0], [1.05, 1.02, 1.03])
+        result = t.get_powermeter_watts()
+        self.assertAlmostEqual(result[0], 105.0)
+        self.assertAlmostEqual(result[1], 204.0)
+        self.assertAlmostEqual(result[2], 309.0)
+
+    def test_mixed_single_offset_per_phase_multipliers(self):
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
+        t = TransformedPowermeter(self.mock_powermeter, [10.0], [1.0, 2.0, 3.0])
+        self.assertEqual(t.get_powermeter_watts(), [110.0, 410.0, 910.0])
+
+    def test_phase_count_mismatch_does_not_crash(self):
+        """Per-phase count != returned value count should warn, not raise."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100.0]
+        t = TransformedPowermeter(self.mock_powermeter, [10.0, 20.0, 30.0], [1.0])
+        # Should not raise; uses cyclic indexing
+        result = t.get_powermeter_watts()
+        self.assertEqual(result, [110.0])
+
+    def test_int_values_from_powermeter(self):
+        """Many powermeters return int values; transform should handle them."""
+        self.mock_powermeter.get_powermeter_watts.return_value = [100, 200]
+        t = TransformedPowermeter(self.mock_powermeter, [0.5], [1.0])
+        self.assertEqual(t.get_powermeter_watts(), [100.5, 200.5])
+
+    def test_wait_for_message_passthrough(self):
+        t = TransformedPowermeter(self.mock_powermeter, [0.0], [1.0])
+        t.wait_for_message(timeout=30)
+        self.mock_powermeter.wait_for_message.assert_called_once()
+        call_args = self.mock_powermeter.wait_for_message.call_args
+        if call_args[1]:
+            self.assertEqual(call_args[1]["timeout"], 30)
+        else:
+            self.assertEqual(call_args[0][0], 30)
+
+    def test_wait_for_message_default_timeout(self):
+        t = TransformedPowermeter(self.mock_powermeter, [0.0], [1.0])
+        t.wait_for_message()
+        self.mock_powermeter.wait_for_message.assert_called_once()
+        call_args = self.mock_powermeter.wait_for_message.call_args
+        if call_args[1]:
+            self.assertEqual(call_args[1]["timeout"], 5)
+        else:
+            self.assertEqual(call_args[0][0], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/powermeter/transform_test.py
+++ b/powermeter/transform_test.py
@@ -86,6 +86,14 @@ class TestTransformedPowermeter(unittest.TestCase):
         else:
             self.assertEqual(call_args[0][0], 30)
 
+    def test_empty_offsets_raises(self):
+        with self.assertRaises(ValueError, msg="offsets must be a non-empty list"):
+            TransformedPowermeter(self.mock_powermeter, [], [1.0])
+
+    def test_empty_multipliers_raises(self):
+        with self.assertRaises(ValueError, msg="multipliers must be a non-empty list"):
+            TransformedPowermeter(self.mock_powermeter, [0.0], [])
+
     def test_wait_for_message_default_timeout(self):
         t = TransformedPowermeter(self.mock_powermeter, [0.0], [1.0])
         t.wait_for_message()


### PR DESCRIPTION
Add a TransformedPowermeter wrapper that applies a linear transformation
(value * multiplier + offset) to power readings in a powermeter-agnostic
way. Supports per-phase configuration via comma-separated values.

https://claude.ai/code/session_013Zx7xmdBe8ibxgqwNAPknj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Power reading calibration: Added `POWER_MULTIPLIER` and `POWER_OFFSET` configuration options to adjust power meter values using linear transformation (value × multiplier + offset).
  * Supports per-phase configuration or single values applied to all phases.

* **Documentation**
  * Extended README with new Value Transformation configuration section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->