### PR TITLE
Reduce throttling output noise by using debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `POWER_OFFSET` and `POWER_MULTIPLIER` transforms for any powermeter, including per-phase calibration, sign flipping, and phase nulling support ([#250](https://github.com/tomquist/b2500-meter/pull/250))
 - Improved power transform validation and logging, including support for `POWER_MULTIPLIER = 0`, one-time phase-mismatch warnings, and preserved exception chaining for invalid float lists ([#250](https://github.com/tomquist/b2500-meter/pull/250))
 - Added `LOG_LEVEL` environment variable support for Docker and CLI runs ([#174](https://github.com/tomquist/b2500-meter/pull/174))
+- Reduced throttling output noise by replacing unconditional `print` calls in `ThrottledPowermeter` with structured logging (`logger.debug` for routine wait/fetch/cache messages; failures remain at error level) ([#251](https://github.com/tomquist/b2500-meter/pull/251))
 - Improved Shelly UDP server robustness by adding socket timeouts to avoid hangs during shutdown and testing ([#233](https://github.com/tomquist/b2500-meter/pull/233))
 - Fixed Modbus `UNIT_ID` handling and clarified Home Assistant entity ID configuration in the docs ([#191](https://github.com/tomquist/b2500-meter/pull/191), [#195](https://github.com/tomquist/b2500-meter/pull/195))
 

--- a/powermeter/throttling.py
+++ b/powermeter/throttling.py
@@ -55,7 +55,8 @@ class ThrottledPowermeter(Powermeter):
                 # Not enough time has passed, wait for the remaining time
                 wait_time = self.throttle_interval - time_since_last_update
                 logger.debug(
-                    f"Throttling: Waiting {wait_time:.1f}s before fetching fresh values..."
+                    "Throttling: Waiting %.1fs before fetching fresh values...",
+                    wait_time,
                 )
                 time.sleep(wait_time)
                 current_time = time.time()  # Update current time after sleep
@@ -71,15 +72,19 @@ class ThrottledPowermeter(Powermeter):
                     else self.last_update_time
                 )
                 logger.debug(
-                    f"Throttling: Fetched fresh values after {total_interval:.1f}s interval: {values}"
+                    "Throttling: Fetched fresh values after %.1fs interval: %s",
+                    total_interval,
+                    values,
                 )
                 return values
             except Exception as e:
-                logger.error(f"Throttling: Error getting fresh values: {e}")
                 # Fall back to cached values if available, otherwise re-raise
                 if self.last_values is not None:
+                    logger.warning("Throttling: Error getting fresh values: %s", e)
                     logger.debug(
-                        f"Throttling: Using cached values due to error: {self.last_values}"
+                        "Throttling: Using cached values due to error: %s",
+                        self.last_values,
                     )
                     return self.last_values
+                logger.error("Throttling: Error getting fresh values: %s", e)
                 raise

--- a/powermeter/throttling.py
+++ b/powermeter/throttling.py
@@ -1,7 +1,11 @@
 import time
 import threading
+import logging
 from typing import List, Optional
 from .base import Powermeter
+
+
+logger = logging.getLogger(__name__)
 
 
 class ThrottledPowermeter(Powermeter):
@@ -50,7 +54,7 @@ class ThrottledPowermeter(Powermeter):
             if time_since_last_update < self.throttle_interval:
                 # Not enough time has passed, wait for the remaining time
                 wait_time = self.throttle_interval - time_since_last_update
-                print(
+                logger.debug(
                     f"Throttling: Waiting {wait_time:.1f}s before fetching fresh values..."
                 )
                 time.sleep(wait_time)
@@ -66,15 +70,15 @@ class ThrottledPowermeter(Powermeter):
                     if time_since_last_update < self.throttle_interval
                     else self.last_update_time
                 )
-                print(
+                logger.debug(
                     f"Throttling: Fetched fresh values after {total_interval:.1f}s interval: {values}"
                 )
                 return values
             except Exception as e:
-                print(f"Throttling: Error getting fresh values: {e}")
+                logger.error(f"Throttling: Error getting fresh values: {e}")
                 # Fall back to cached values if available, otherwise re-raise
                 if self.last_values is not None:
-                    print(
+                    logger.debug(
                         f"Throttling: Using cached values due to error: {self.last_values}"
                     )
                     return self.last_values


### PR DESCRIPTION
## Summary
- replace unconditional `print(...)` calls in `ThrottledPowermeter` with logger calls
- use `logger.debug(...)` for regular throttling wait/fetch/cache messages
- keep failures as `logger.error(...)`

This keeps normal runs quiet while preserving details when debug logging is enabled.

Fixes #239


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved logging and diagnostics across power-meter operations: replaced ad-hoc console output with structured logs, added clearer debug/warning/error messages for throttling, fetch attempts, and fallback scenarios—no change to public behavior or error-handling outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->