### PR TITLE
Add VERIFY_SSL option for HomeWizard powermeter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent notes
+
+Before finishing Python changes, run (from repo root, with dev deps):
+
+```bash
+pipenv run black .
+pipenv run python3 -m flake8 --select BLK **/*.py
+pipenv run python3 -m pytest
+```
+
+CI runs the same `flake8 --select BLK` and `pytest` steps; `black .` keeps formatting aligned so BLK passes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next
+- Added optional `VERIFY_SSL` for the HomeWizard powermeter to disable TLS certificate verification when needed on trusted networks
 - Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231))
 - Switched the Home Assistant powermeter integration from REST polling to the WebSocket API and improved missing/non-numeric sensor state handling ([#232](https://github.com/tomquist/b2500-meter/pull/232), [#193](https://github.com/tomquist/b2500-meter/pull/193))
 - Added optional Marstek cloud auto-registration for managed fake `ct002` and `ct003` devices at startup ([#237](https://github.com/tomquist/b2500-meter/pull/237))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
 ## Next
-- Added optional `VERIFY_SSL` for the HomeWizard powermeter to disable TLS certificate verification when needed on trusted networks
-- Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231))
+- Added HomeWizard P1 powermeter support via the device WebSocket API with token and serial configuration ([#231](https://github.com/tomquist/b2500-meter/pull/231)), including optional `VERIFY_SSL` to disable TLS certificate verification on trusted networks when needed ([#254](https://github.com/tomquist/b2500-meter/pull/254))
 - Switched the Home Assistant powermeter integration from REST polling to the WebSocket API and improved missing/non-numeric sensor state handling ([#232](https://github.com/tomquist/b2500-meter/pull/232), [#193](https://github.com/tomquist/b2500-meter/pull/193))
 - Added optional Marstek cloud auto-registration for managed fake `ct002` and `ct003` devices at startup ([#237](https://github.com/tomquist/b2500-meter/pull/237))
 - Added battery activity info logs for Shelly emulation to report detection, inactivity, and reconnection events ([#241](https://github.com/tomquist/b2500-meter/pull/241))

--- a/README.md
+++ b/README.md
@@ -449,6 +449,20 @@ IP = 192.168.1.100
 #TIMEOUT = 5.0 (Optional)
 ```
 
+### HomeWizard
+
+Reads a [HomeWizard](https://www.homewizard.com/) P1 dongle (or compatible device) over the local **WebSocket** API (`wss://`). Obtain a token once via `POST /api/user` while confirming on the device; see the [HomeWizard API docs](https://api-documentation.homewizard.com/docs/v2/).
+
+```ini
+[HOMEWIZARD]
+IP = 192.168.1.110
+TOKEN = YOUR_32_CHAR_HEX_TOKEN
+SERIAL = your_device_serial
+# Optional: disable TLS certificate verification on a trusted LAN if verification fails (default True)
+# VERIFY_SSL = True
+# THROTTLE_INTERVAL = 0
+```
+
 ### Modbus
 
 ```ini

--- a/config.ini.example
+++ b/config.ini.example
@@ -160,6 +160,9 @@ THROTTLE_INTERVAL = 0
 #IP = 192.168.1.110
 #TOKEN = YOUR_32_CHAR_HEX_TOKEN
 #SERIAL = your_device_serial
+## Verify server TLS using the bundled HomeWizard CA (default True).
+## Set False only if you get certificate errors on a trusted LAN (insecure).
+#VERIFY_SSL = True
 ## Per-powermeter throttling override (optional)
 #THROTTLE_INTERVAL = 0
 

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -383,4 +383,5 @@ def create_homewizard_powermeter(
         config.get(section, "IP", fallback=""),
         config.get(section, "TOKEN", fallback=""),
         config.get(section, "SERIAL", fallback=""),
+        verify_ssl=config.getboolean(section, "VERIFY_SSL", fallback=True),
     )

--- a/health_service.py
+++ b/health_service.py
@@ -13,40 +13,44 @@ from config.logger import logger
 
 class HealthCheckHandler(BaseHTTPRequestHandler):
     """HTTP handler for health check endpoints."""
-    
+
     def do_GET(self):
         """Handle GET requests to health check endpoints."""
         # Normalize path to handle trailing slashes
-        normalized_path = self.path.rstrip('/')
-        if normalized_path in ['/health', '/api']:
-            logger.debug(f"Health check request received from {self.client_address[0]}:{self.client_address[1]}")
+        normalized_path = self.path.rstrip("/")
+        if normalized_path in ["/health", "/api"]:
+            logger.debug(
+                f"Health check request received from {self.client_address[0]}:{self.client_address[1]}"
+            )
             self.send_response(200)
-            self.send_header('Content-type', 'application/json')
-            self.send_header('Cache-Control', 'no-cache')
+            self.send_header("Content-type", "application/json")
+            self.send_header("Cache-Control", "no-cache")
             self.end_headers()
             response = b'{"status": "healthy", "service": "b2500-meter"}'
             self.wfile.write(response)
         else:
-            logger.debug(f"Invalid request {self.path} from {self.client_address[0]}:{self.client_address[1]}")
+            logger.debug(
+                f"Invalid request {self.path} from {self.client_address[0]}:{self.client_address[1]}"
+            )
             self.send_response(404)
-            self.send_header('Content-type', 'application/json')
+            self.send_header("Content-type", "application/json")
             self.end_headers()
             response = b'{"error": "Not Found"}'
             self.wfile.write(response)
-    
+
     def do_HEAD(self):
         """Handle HEAD requests (some health checkers use HEAD)."""
         # Normalize path to handle trailing slashes
-        normalized_path = self.path.rstrip('/')
-        if normalized_path in ['/health', '/api']:
+        normalized_path = self.path.rstrip("/")
+        if normalized_path in ["/health", "/api"]:
             self.send_response(200)
-            self.send_header('Content-type', 'application/json')
-            self.send_header('Cache-Control', 'no-cache')
+            self.send_header("Content-type", "application/json")
+            self.send_header("Cache-Control", "no-cache")
             self.end_headers()
         else:
             self.send_response(404)
             self.end_headers()
-    
+
     def log_message(self, format, *args):
         """Suppress default HTTP server logging to avoid spam."""
         pass
@@ -54,73 +58,77 @@ class HealthCheckHandler(BaseHTTPRequestHandler):
 
 class HealthCheckService:
     """Health check service manager."""
-    
-    def __init__(self, port=52500, bind_address='0.0.0.0'):
+
+    def __init__(self, port=52500, bind_address="0.0.0.0"):
         self.port = port
         self.bind_address = bind_address
         self.server = None
         self.server_thread = None
         self._running = False
-    
+
     def start(self):
         """Start the health check HTTP server."""
         if self._running:
             logger.warning("Health check service is already running")
             return False
-        
+
         try:
             self.server = HTTPServer((self.bind_address, self.port), HealthCheckHandler)
             self.server_thread = threading.Thread(
-                target=self._run_server, 
-                name="HealthCheckService",
-                daemon=True
+                target=self._run_server, name="HealthCheckService", daemon=True
             )
             self.server_thread.start()
-            
+
             # Give the server a moment to start and verify it's working
             time.sleep(0.5)
             if not self.server_thread.is_alive():
                 logger.error("Health check service thread failed to start")
                 return False
-                
+
             self._running = True
-            logger.info(f"Health check service started on {self.bind_address}:{self.port}")
-            
+            logger.info(
+                f"Health check service started on {self.bind_address}:{self.port}"
+            )
+
             # Test the endpoint to ensure it's working
             if self.test_endpoint():
                 logger.debug("Health check endpoint test passed")
             else:
-                logger.warning("Health check endpoint test failed, but service is running")
-                
+                logger.warning(
+                    "Health check endpoint test failed, but service is running"
+                )
+
             return True
         except OSError as e:
             if e.errno == 98:  # Address already in use
-                logger.error(f"Port {self.port} is already in use. Health check service not started.")
+                logger.error(
+                    f"Port {self.port} is already in use. Health check service not started."
+                )
             else:
                 logger.error(f"Failed to bind to {self.bind_address}:{self.port}: {e}")
             return False
         except Exception as e:
             logger.error(f"Failed to start health check service: {e}")
             return False
-    
+
     def stop(self):
         """Stop the health check HTTP server."""
         if not self._running:
             return
-        
+
         try:
             if self.server:
                 self.server.shutdown()
                 self.server.server_close()
-            
+
             if self.server_thread and self.server_thread.is_alive():
                 self.server_thread.join(timeout=5.0)
-            
+
             self._running = False
             logger.info("Health check service stopped")
         except Exception as e:
             logger.error(f"Error stopping health check service: {e}")
-    
+
     def _run_server(self):
         """Run the HTTP server (internal method)."""
         try:
@@ -128,16 +136,16 @@ class HealthCheckService:
         except Exception as e:
             if self._running:  # Only log if we weren't intentionally shut down
                 logger.error(f"Health check server error: {e}")
-    
+
     def is_running(self):
         """Check if the health check service is running."""
         return self._running and self.server_thread and self.server_thread.is_alive()
-    
+
     def test_endpoint(self):
         """Test the health check endpoint (for debugging)."""
         import urllib.request
         import urllib.error
-        
+
         try:
             url = f"http://{self.bind_address}:{self.port}/health"
             with urllib.request.urlopen(url, timeout=5) as response:
@@ -151,23 +159,23 @@ class HealthCheckService:
 _health_service = None
 
 
-def start_health_service(port=52500, bind_address='0.0.0.0'):
+def start_health_service(port=52500, bind_address="0.0.0.0"):
     """
     Start the global health check service.
-    
+
     Args:
         port (int): Port to bind to (default: 52500)
         bind_address (str): Address to bind to (default: 'localhost')
-    
+
     Returns:
         bool: True if started successfully, False otherwise
     """
     global _health_service
-    
+
     if _health_service and _health_service.is_running():
         logger.debug("Health service already running")
         return True
-    
+
     _health_service = HealthCheckService(port=port, bind_address=bind_address)
     return _health_service.start()
 
@@ -175,7 +183,7 @@ def start_health_service(port=52500, bind_address='0.0.0.0'):
 def stop_health_service():
     """Stop the global health check service."""
     global _health_service
-    
+
     if _health_service:
         _health_service.stop()
         _health_service = None
@@ -189,4 +197,5 @@ def is_health_service_running():
 
 # Cleanup on module exit
 import atexit
-atexit.register(stop_health_service) 
+
+atexit.register(stop_health_service)

--- a/powermeter/homewizard.py
+++ b/powermeter/homewizard.py
@@ -15,12 +15,19 @@ CA_CERT_PATH = os.path.join(os.path.dirname(__file__), "homewizard_ca.pem")
 
 
 class HomeWizardPowermeter(Powermeter):
-    def __init__(self, ip, token, serial):
+    def __init__(self, ip, token, serial, verify_ssl=True):
         self.ip = ip
         self.token = token
         self.serial = serial
+        self._verify_ssl = verify_ssl
         self.values = None
         self._lock = threading.Lock()
+
+        if not verify_ssl:
+            logger.warning(
+                "HomeWizard: TLS certificate verification is disabled "
+                "(VERIFY_SSL=False); use only on a trusted LAN"
+            )
 
         url = f"wss://{self.ip}/api/ws"
         self.ws = websocket.WebSocketApp(
@@ -41,9 +48,13 @@ class HomeWizardPowermeter(Powermeter):
 
     def _build_sslopt(self):
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        ssl_context.load_verify_locations(CA_CERT_PATH)
-        ssl_context.check_hostname = True
-        ssl_context.verify_mode = ssl.CERT_REQUIRED
+        if self._verify_ssl:
+            ssl_context.load_verify_locations(CA_CERT_PATH)
+            ssl_context.check_hostname = True
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
+        else:
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
         return {
             "context": ssl_context,
             "server_hostname": f"appliance/p1dongle/{self.serial}",

--- a/powermeter/homewizard_test.py
+++ b/powermeter/homewizard_test.py
@@ -1,4 +1,5 @@
 import json
+import ssl
 import unittest
 from unittest.mock import patch, MagicMock
 
@@ -6,10 +7,10 @@ from .homewizard import HomeWizardPowermeter
 
 
 class TestHomeWizardPowermeter(unittest.TestCase):
-    def _create_powermeter(self):
+    def _create_powermeter(self, **kwargs):
         with patch("powermeter.homewizard.websocket.WebSocketApp"):
             with patch("powermeter.homewizard.threading.Thread"):
-                pm = HomeWizardPowermeter("192.168.1.1", "ABCD1234", "aabbccddee")
+                pm = HomeWizardPowermeter("192.168.1.1", "ABCD1234", "aabbccddee", **kwargs)
         return pm
 
     def test_on_message_authorization_requested(self):
@@ -161,6 +162,21 @@ class TestHomeWizardPowermeter(unittest.TestCase):
             ),
         )
         self.assertEqual(pm.get_powermeter_watts(), [-1500])
+
+    def test_verify_ssl_disabled_skips_certificate_validation(self):
+        pm = self._create_powermeter(verify_ssl=False)
+        sslopt = pm._build_sslopt()
+        self.assertEqual(sslopt["context"].verify_mode, ssl.CERT_NONE)
+        self.assertFalse(sslopt["context"].check_hostname)
+        self.assertEqual(
+            sslopt["server_hostname"], "appliance/p1dongle/aabbccddee"
+        )
+
+    def test_verify_ssl_default_validates_certificate(self):
+        pm = self._create_powermeter()
+        sslopt = pm._build_sslopt()
+        self.assertEqual(sslopt["context"].verify_mode, ssl.CERT_REQUIRED)
+        self.assertTrue(sslopt["context"].check_hostname)
 
 
 if __name__ == "__main__":

--- a/powermeter/homewizard_test.py
+++ b/powermeter/homewizard_test.py
@@ -10,7 +10,9 @@ class TestHomeWizardPowermeter(unittest.TestCase):
     def _create_powermeter(self, **kwargs):
         with patch("powermeter.homewizard.websocket.WebSocketApp"):
             with patch("powermeter.homewizard.threading.Thread"):
-                pm = HomeWizardPowermeter("192.168.1.1", "ABCD1234", "aabbccddee", **kwargs)
+                pm = HomeWizardPowermeter(
+                    "192.168.1.1", "ABCD1234", "aabbccddee", **kwargs
+                )
         return pm
 
     def test_on_message_authorization_requested(self):
@@ -168,9 +170,7 @@ class TestHomeWizardPowermeter(unittest.TestCase):
         sslopt = pm._build_sslopt()
         self.assertEqual(sslopt["context"].verify_mode, ssl.CERT_NONE)
         self.assertFalse(sslopt["context"].check_hostname)
-        self.assertEqual(
-            sslopt["server_hostname"], "appliance/p1dongle/aabbccddee"
-        )
+        self.assertEqual(sslopt["server_hostname"], "appliance/p1dongle/aabbccddee")
 
     def test_verify_ssl_default_validates_certificate(self):
         pm = self._create_powermeter()


### PR DESCRIPTION
## Summary
Adds optional `VERIFY_SSL` (default `True`) under `[HOMEWIZARD]` so users who hit TLS certificate errors on a trusted LAN can disable certificate verification while still using `wss://`.

## Changes
- `HomeWizardPowermeter` accepts `verify_ssl`; when `False`, uses `CERT_NONE` and skips hostname check; logs a security warning
- `config_loader` reads `VERIFY_SSL` with `getboolean(..., fallback=True)`
- Documented in `config.ini.example`, `CHANGELOG.md`
- Unit tests for both SSL modes

## Context
Some setups may fail verification (CA/firmware/Python differences) while others work; this matches common escape hatches for local devices.