### PR TITLE
chore(ha-addon): drop 32-bit ARM image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,6 @@ jobs:
         platform:
           - linux/amd64
           - linux/arm64
-          - linux/arm/v7
-          - linux/arm/v6
     uses: ./.github/workflows/build-image.yml
     with:
       registry: ghcr.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Improved Shelly UDP server robustness by adding socket timeouts to avoid hangs during shutdown and testing ([#233](https://github.com/tomquist/b2500-meter/pull/233))
 - Fixed Modbus `UNIT_ID` handling and clarified Home Assistant entity ID configuration in the docs ([#191](https://github.com/tomquist/b2500-meter/pull/191), [#195](https://github.com/tomquist/b2500-meter/pull/195))
 
+### Breaking
+- The Home Assistant add-on no longer publishes images for 32-bit ARM (`armhf` / `armv7`). Installations must use a 64-bit Home Assistant OS or supervisor environment (`amd64` or `aarch64`), consistent with Home Assistant dropping 32-bit support.
+
 ## 1.0.8
 - Added support for Modbus holding registers through new `REGISTER_TYPE` configuration option ([#173](https://github.com/tomquist/b2500-meter/pull/173))
 - Improved Shelly emulator with threaded UDP handling for better performance under concurrent requests when throttle interval is used ([#168](https://github.com/tomquist/b2500-meter/pull/168))

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -6,7 +6,6 @@ description: >-
 arch:
   - amd64
   - aarch64
-  - armv7
 url: "https://github.com/tomquist/b2500-meter"
 image: "ghcr.io/tomquist/b2500-meter-addon"
 panel_icon: "mdi:meter-electric"


### PR DESCRIPTION
Remove linux/arm/v6 and linux/arm/v7 from the add-on CI matrix and armv7 from ha_addon arch metadata. Document as a breaking change in CHANGELOG.