### PR TITLE
feat: optional DEVICE_IDS in config; extend addon config redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Configuration is managed via `config.ini`. Each powermeter type has specific set
 [GENERAL]
 # Comma-separated list of device types to emulate (ct001, shellypro3em, shellyemg3, shellyproem50, shellypro3em_old, shellypro3em_new)
 DEVICE_TYPE = ct001
+# Optional: comma-separated device IDs, same order as DEVICE_TYPE (auto-generated if omitted). Use for stable IDs across reinstalls or to match an existing device.
+#DEVICE_IDS = shellypro3em-c59b15461a21
 # Skip initial powermeter test on startup
 SKIP_POWERMETER_TEST = False
 # Sum power values of all phases and report on phase 1 (ct001 only and default is False)

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,6 +1,8 @@
 [GENERAL]
 # Comma-separated list of device types to emulate (ct001, shellypro3em, shellyemg3, shellyproem50)
 DEVICE_TYPE = ct001
+# Comma-separated list of device IDs (optional, auto-generated if not set)
+#DEVICE_IDS = shellypro3em-c59b15461a21
 # Skip initial powermeter test on startup
 SKIP_POWERMETER_TEST = False
 # Sum power values of all phases and report on phase 1 (ct001 only and default is False)

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -34,9 +34,7 @@ CONFIG="/app/config.ini"
 
 print_redacted_config() {
     sed -E \
-        -e 's/^(MAILBOX=).*/\1REDACTED/' \
-        -e 's/^(PASSWORD=).*/\1REDACTED/' \
-        -e 's/^(ACCESSTOKEN=).*/\1REDACTED/' \
+        -e 's/^((MAILBOX|PASSWORD|ACCESSTOKEN|TOKEN|SECRET))\s*=\s*.*/\1 = REDACTED/i' \
         "$1"
 }
 

--- a/main.py
+++ b/main.py
@@ -204,6 +204,13 @@ def main():
     )
 
     device_ids = args.device_ids if args.device_ids is not None else []
+    # Load device IDs from config if not provided via CLI
+    if not device_ids:
+        cfg_device_ids = cfg.get("GENERAL", "DEVICE_IDS", fallback="").strip()
+        if cfg_device_ids:
+            device_ids = [
+                did.strip() for did in cfg_device_ids.split(",") if did.strip()
+            ]
     # Fill missing device IDs with default format
     while len(device_ids) < len(device_types):
         device_type = device_types[len(device_ids)]


### PR DESCRIPTION
- Read GENERAL.DEVICE_IDS when --device-ids is not passed; document in config.ini.example and README.
- Redact TOKEN and SECRET in ha_addon print_redacted_config; use one pattern with optional spaces around '=' for INI-style keys.