### PR TITLE
Lower minimum efficiency rotation interval from 10s to 1s

### DIFF
--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -190,7 +190,7 @@ class CT002:
         self.saturation_alpha = max(0.01, min(1.0, saturation_alpha))
         self.min_target_for_saturation = max(1, min_target_for_saturation)
         self.min_efficient_power = max(0, min_efficient_power)
-        self.efficiency_rotation_interval = max(10, efficiency_rotation_interval)
+        self.efficiency_rotation_interval = max(1, efficiency_rotation_interval)
         self.efficiency_fade_alpha = max(0.01, min(1.0, efficiency_fade_alpha))
         self.before_send: (
             Callable[[tuple, list, str], Awaitable[list[float] | None]] | None

--- a/tests/test_efficiency_e2e.py
+++ b/tests/test_efficiency_e2e.py
@@ -257,7 +257,7 @@ class TestEfficiencyE2E:
             num_batteries=2,
             base_load=[200.0, 0.0, 0.0],
             min_efficient_power=150,
-            efficiency_rotation_interval=5,  # Short interval for testing
+            efficiency_rotation_interval=7,  # Short interval for testing
             efficiency_fade_alpha=1.0,  # Instant fade so rotation isn't blocked
         )
         await h.start()
@@ -270,7 +270,7 @@ class TestEfficiencyE2E:
                 f"Expected 1 active before rotation. Powers: {powers_before}"
             )
 
-            # Wait for rotation + settling
+            # Wait for rotation (fires at ~7s) + settling
             await h.settle(8.0)
             powers_after = h.battery_powers()
             active_after = [i for i, p in enumerate(powers_after) if abs(p) > 15]

--- a/tests/test_efficiency_e2e.py
+++ b/tests/test_efficiency_e2e.py
@@ -270,15 +270,25 @@ class TestEfficiencyE2E:
                 f"Expected 1 active before rotation. Powers: {powers_before}"
             )
 
-            # Wait for rotation (fires at ~7s) + settling
-            await h.settle(8.0)
-            powers_after = h.battery_powers()
-            active_after = [i for i, p in enumerate(powers_after) if abs(p) > 15]
-            assert len(active_after) == 1, (
-                f"Expected 1 active after rotation. Powers: {powers_after}"
-            )
+            # Poll until the active battery set changes or timeout.
+            timeout = h.ct002.efficiency_rotation_interval + 15.0
+            poll_interval = 0.3
+            elapsed = 0.0
+            active_after: list[int] = list(active_before)
+            powers_after = powers_before
+            while elapsed < timeout:
+                await asyncio.sleep(poll_interval)
+                elapsed += poll_interval
+                powers_after = h.battery_powers()
+                active_after = [i for i, p in enumerate(powers_after) if abs(p) > 15]
+                if len(active_after) == 1 and active_after != active_before:
+                    break
+            else:
+                pytest.fail(
+                    f"Rotation did not switch active battery within {timeout}s. "
+                    f"active_before={active_before}, last powers={powers_after}"
+                )
 
-            # The active battery should have changed
             assert active_before != active_after, (
                 f"Expected rotation: active_before={active_before}, "
                 f"active_after={active_after}. "


### PR DESCRIPTION
## Summary
Reduced the minimum allowed `efficiency_rotation_interval` from 10 seconds to 1 second to enable more flexible testing and configuration of battery rotation behavior.

## Key Changes
- **src/b2500_meter/ct002/ct002.py**: Changed the minimum bound for `efficiency_rotation_interval` from `max(10, ...)` to `max(1, ...)`, allowing shorter rotation intervals for testing scenarios
- **tests/test_efficiency_e2e.py**: Updated test configuration to use a 7-second rotation interval (previously 5 seconds) and clarified the timing comment to indicate when rotation fires

## Implementation Details
The change allows the efficiency rotation mechanism to be tested with shorter intervals while maintaining a sensible lower bound of 1 second. This is particularly useful for end-to-end tests that need to verify battery switching behavior without requiring long wait times. The test update reflects the new capability by using a slightly longer interval (7s) that better demonstrates the rotation and settling behavior.

https://claude.ai/code/session_01MQgak8S2BWm7eNo2BuzqZY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Lowered the minimum efficiency rotation interval so rotations can occur more frequently when configured with smaller values.

* **Tests**
  * Updated end-to-end test to wait and poll for a priority-rotation change with a timeout and to provide a clearer failure message if the expected switch does not occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->