### PR TITLE
Bump urllib3 minimum version to 2.6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "GPL-3.0-or-later" }
 dependencies = [
     "aiohttp>=3.9.0",
     "requests",
-    "urllib3",
+    "urllib3>=2.6.3",
     "aiomqtt>=2.0.0,<3",
     "jsonpath-ng",
     "pymodbus==3.6.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "GPL-3.0-or-later" }
 dependencies = [
     "aiohttp>=3.9.0",
     "requests",
-    "urllib3>=2.6.3",
+    "urllib3>=2.6.3,<3",
     "aiomqtt>=2.0.0,<3",
     "jsonpath-ng",
     "pymodbus==3.6.5",

--- a/uv.lock
+++ b/uv.lock
@@ -225,7 +225,7 @@ requires-dist = [
     { name = "smllib" },
     { name = "textual", marker = "extra == 'sim'", specifier = ">=1.0.0" },
     { name = "textual-plot", marker = "extra == 'sim'", specifier = ">=0.10.1" },
-    { name = "urllib3", specifier = ">=2.6.3" },
+    { name = "urllib3", specifier = ">=2.6.3,<3" },
 ]
 provides-extras = ["dev", "sim"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -225,7 +225,7 @@ requires-dist = [
     { name = "smllib" },
     { name = "textual", marker = "extra == 'sim'", specifier = ">=1.0.0" },
     { name = "textual-plot", marker = "extra == 'sim'", specifier = ">=0.10.1" },
-    { name = "urllib3" },
+    { name = "urllib3", specifier = ">=2.6.3" },
 ]
 provides-extras = ["dev", "sim"]
 


### PR DESCRIPTION
## Summary
Updated the urllib3 dependency constraint to require version 2.6.3 or later, replacing the previous unconstrained dependency specification.

## Changes
- Updated `urllib3` dependency from unversioned to `urllib3>=2.6.3` in project dependencies

## Details
This change ensures the project uses a minimum version of urllib3 that likely includes important bug fixes, security patches, or feature improvements introduced in version 2.6.3. The constraint allows for patch and minor version updates while maintaining compatibility with the specified minimum version.

https://claude.ai/code/session_01DWtXjZkj1kbpkBcQpX5mqY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened the urllib3 dependency to require at least version 2.6.3 and restrict major-version upgrades (urllib3>=2.6.3,<3).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->