### PR TITLE
Move grace period calculation earlier in efficiency computation

### DIFF
--- a/src/b2500_meter/ct002/ct002.py
+++ b/src/b2500_meter/ct002/ct002.py
@@ -502,9 +502,13 @@ class CT002:
         self._efficiency_priority = [
             c for c in self._efficiency_priority if c in current
         ]
+        grace = now + min(SATURATION_GRACE_SECONDS, self.efficiency_rotation_interval)
         for cid in sorted(current):
             if cid not in self._efficiency_priority:
                 self._efficiency_priority.append(cid)
+                # New consumer: grant grace period so physical ramp-up time
+                # isn't misinterpreted as genuine saturation.
+                self._saturation_grace_until[cid] = grace
 
         # Saturation swap check BEFORE cache: when the grid is stable the
         # sample_id never changes, so the cache would prevent saturation
@@ -574,7 +578,6 @@ class CT002:
         # Grant a short grace period so the inverter can physically ramp
         # up before saturation is evaluated again.  The grace is also
         # cleared early once the battery proves it can produce output.
-        grace = now + min(SATURATION_GRACE_SECONDS, self.efficiency_rotation_interval)
         for cid in self._efficiency_deprioritized - deprioritized:
             self._saturation_by_consumer.pop(cid, None)
             self._saturation_grace_until[cid] = grace


### PR DESCRIPTION
## Summary
Refactored the grace period calculation in the efficiency deprioritization logic to be computed once at the beginning of the function rather than later in the execution flow. This ensures the grace period is consistently applied to all consumers that need it.

## Key Changes
- Moved the `grace` variable calculation from line 577 to line 505, immediately after filtering the efficiency priority list
- Applied the grace period to newly added consumers in the efficiency priority list, ensuring they receive a saturation grace period during their physical ramp-up phase
- Removed the duplicate grace period calculation that was previously applied only to deprioritized consumers

## Implementation Details
The grace period is now calculated once using `now + min(SATURATION_GRACE_SECONDS, self.efficiency_rotation_interval)` and reused for:
1. New consumers being added to the efficiency priority list (preventing false saturation detection during startup)
2. Consumers being deprioritized (allowing physical ramp-up time before re-evaluation)

This change ensures consistent timing and prevents the inverter's physical ramp-up time from being misinterpreted as genuine saturation across all consumer state transitions.

https://claude.ai/code/session_016ToTzSPmkbY9mwKZtgdhpQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced consumer prioritization to ensure consistent saturation suppression is applied immediately when consumers transition to active status, improving overall system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->