### PR TITLE
Support publishing Docker images under legacy name for backward compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
       registry: ghcr.io
       image-suffix: ""
       digest-prefix: "digests-base-"
+      legacy-image-name: tomquist/b2500-meter
 
   build-addon:
     needs: [ validate ]
@@ -163,3 +164,4 @@ jobs:
       registry: ghcr.io
       image-suffix: "-addon"
       digest-prefix: "digests-addon-"
+      legacy-image-name: tomquist/b2500-meter

--- a/.github/workflows/merge-manifests.yml
+++ b/.github/workflows/merge-manifests.yml
@@ -13,6 +13,11 @@ on:
       digest-prefix:
         required: true
         type: string
+      legacy-image-name:
+        required: false
+        type: string
+        default: ""
+        description: "Optional legacy image name (e.g. owner/repo) to publish the same manifest under for backward compatibility"
 
 jobs:
   merge:
@@ -32,11 +37,17 @@ jobs:
       - id: lower-repo
         run: |
           echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}${{ inputs.image-suffix }}" >> $GITHUB_OUTPUT
+          if [ -n "${{ inputs.legacy-image-name }}" ]; then
+            LEGACY_LOWER=$(echo "${{ inputs.legacy-image-name }}" | tr '[:upper:]' '[:lower:]')
+            echo "LEGACY_IMAGE_NAME=${LEGACY_LOWER}${{ inputs.image-suffix }}" >> $GITHUB_OUTPUT
+          fi
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ inputs.registry }}/${{ steps.lower-repo.outputs.IMAGE_NAME }}
+          images: |
+            ${{ inputs.registry }}/${{ steps.lower-repo.outputs.IMAGE_NAME }}
+            ${{ inputs.legacy-image-name != '' && format('{0}/{1}', inputs.registry, steps.lower-repo.outputs.LEGACY_IMAGE_NAME) || '' }}
           tags: |
             type=ref,event=branch
             type=ref,event=tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Next
-- **Breaking:** Rebrand project from "B2500 Meter" to "AstraMeter" (formerly b2500-meter). Package renamed to `astrameter`, CLI commands are now `astrameter` and `astra-sim`. Docker image moved from `ghcr.io/tomquist/b2500-meter` to `ghcr.io/tomquist/astrameter`. Home Assistant users must update their app repository URL to `https://github.com/tomquist/astrameter#main`.
+- **Breaking:** Rebrand project from "B2500 Meter" to "AstraMeter" (formerly b2500-meter). Package renamed to `astrameter`, CLI commands are now `astrameter` and `astra-sim`. Docker image moved from `ghcr.io/tomquist/b2500-meter` to `ghcr.io/tomquist/astrameter` (the legacy `ghcr.io/tomquist/b2500-meter` image is still published in parallel for backward compatibility). Home Assistant users must update their app repository URL to `https://github.com/tomquist/astrameter#main`.
 - Added CT002/CT003 emulation for steering multiple Marstek storage devices over the Marstek CT UDP protocol, with opt-in efficiency optimization that concentrates power on fewer batteries at low demand and rotates fairly over time (`MIN_EFFICIENT_POWER`, `EFFICIENCY_ROTATION_INTERVAL`, and related tuning options)
 - Added MQTT Insights: optional `[MQTT_INSIGHTS]` section publishes internal state (grid power, targets, saturation, consumer topology) to MQTT with Home Assistant Device Discovery, per-consumer active/pause control, manual target override, and Shelly battery offline availability; auto-configured in the HA app when Mosquitto is installed
 - Added HomeWizard P1 powermeter support via the device WebSocket API with optional `VERIFY_SSL` ([#231](https://github.com/tomquist/astrameter/pull/231), [#254](https://github.com/tomquist/astrameter/pull/254))


### PR DESCRIPTION
## Summary
This change adds support for publishing Docker images under a legacy image name in parallel with the new image name, enabling backward compatibility during project rebranding.

## Key Changes
- Added optional `legacy-image-name` input parameter to the `merge-manifests` workflow that accepts a legacy image name (e.g., `owner/repo`)
- Updated the manifest metadata extraction step to include both the primary and legacy image names when building and publishing Docker images
- Configured both base and addon image builds to publish under the legacy name `tomquist/b2500-meter` alongside the new `tomquist/astrameter` image
- Updated CHANGELOG to clarify that the legacy image is still published for backward compatibility during the AstraMeter rebranding

## Implementation Details
- The legacy image name is converted to lowercase (matching Docker registry naming conventions) and combined with the same image suffix as the primary image
- The legacy image name is only added to the metadata when explicitly provided (optional parameter with empty string default)
- Both images receive the same tags and manifest digests, ensuring they stay in sync

https://claude.ai/code/session_019rqSCHT7q5DGHZhntbLbpF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog confirming the legacy Docker image continues to be published alongside the primary image.

* **Chores**
  * Updated CI/CD workflow to support publishing container images under an additional legacy name for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->