### PR TITLE
Generalize CT002 inspection mode detection for future firmware variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## Next
-- Treat CT002/CT003 requests with phase `D` as inspection mode (in addition to `0`/empty), so newer Marstek battery firmwares no longer trigger "invalid phase" warnings and are responded to during phase detection ([#305](https://github.com/tomquist/astrameter/issues/305))
 - **Breaking:** Rebrand project from "B2500 Meter" to "AstraMeter" (formerly b2500-meter). Package renamed to `astrameter`, CLI commands are now `astrameter` and `astra-sim`. Docker image moved from `ghcr.io/tomquist/b2500-meter` to `ghcr.io/tomquist/astrameter` (the legacy `ghcr.io/tomquist/b2500-meter` image is still published in parallel for backward compatibility). Home Assistant users must update their app repository URL to `https://github.com/tomquist/astrameter#main`.
 - Added CT002/CT003 emulation for steering multiple Marstek storage devices over the Marstek CT UDP protocol, with opt-in efficiency optimization that concentrates power on fewer batteries at low demand and rotates fairly over time (`MIN_EFFICIENT_POWER`, `EFFICIENCY_ROTATION_INTERVAL`, and related tuning options)
 - Added MQTT Insights: optional `[MQTT_INSIGHTS]` section publishes internal state (grid power, targets, saturation, consumer topology) to MQTT with Home Assistant Device Discovery, per-consumer active/pause control, manual target override, and Shelly battery offline availability; auto-configured in the HA app when Mosquitto is installed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next
+- Treat CT002/CT003 requests with phase `D` as inspection mode (in addition to `0`/empty), so newer Marstek battery firmwares no longer trigger "invalid phase" warnings and are responded to during phase detection ([#305](https://github.com/tomquist/astrameter/issues/305))
 - **Breaking:** Rebrand project from "B2500 Meter" to "AstraMeter" (formerly b2500-meter). Package renamed to `astrameter`, CLI commands are now `astrameter` and `astra-sim`. Docker image moved from `ghcr.io/tomquist/b2500-meter` to `ghcr.io/tomquist/astrameter` (the legacy `ghcr.io/tomquist/b2500-meter` image is still published in parallel for backward compatibility). Home Assistant users must update their app repository URL to `https://github.com/tomquist/astrameter#main`.
 - Added CT002/CT003 emulation for steering multiple Marstek storage devices over the Marstek CT UDP protocol, with opt-in efficiency optimization that concentrates power on fewer batteries at low demand and rotates fairly over time (`MIN_EFFICIENT_POWER`, `EFFICIENCY_ROTATION_INTERVAL`, and related tuning options)
 - Added MQTT Insights: optional `[MQTT_INSIGHTS]` section publishes internal state (grid power, targets, saturation, consumer topology) to MQTT with Home Assistant Device Discovery, per-consumer active/pause control, manual target override, and Shelly battery offline availability; auto-configured in the HA app when Mosquitto is installed

--- a/docs/ct002-ct003-protocol.md
+++ b/docs/ct002-ct003-protocol.md
@@ -55,15 +55,15 @@ Request payload fields (consumer → CT):
 2. **meter_mac_code** — battery MAC (12 hex chars, from Marstek app device management)
 3. **hhm_dev_type** — CT type (`HME-4` or `HME-3`)
 4. **hhm_mac_code** — CT MAC (12 hex chars, from Marstek app device management)
-5. **phase** — phase identifier (`A`, `B`, `C`) observed in real traffic; `0` or empty means inspection mode
+5. **phase** — phase identifier (`A`, `B`, `C`) observed in real traffic; `D`, `0` or empty means inspection mode
 6. **phase_power** — signed integer watts for the phase in field 5
 
 This mapping is based on real packet captures. Older public scripts may show `0|0` placeholders,
 but observed live traffic carries `phase|power` in these two fields.
 
-### Inspection mode (phase `0` or empty)
+### Inspection mode (phase `D`, `0` or empty)
 
-When a device sends `phase=0` or an empty phase, it is in **inspection mode** — determining which
+When a device sends `phase=D`, `phase=0` or an empty phase, it is in **inspection mode** — determining which
 phase it is connected to. The emulator:
 
 - **Responds** to the request (so the device can continue its phase detection)
@@ -110,7 +110,7 @@ This list describes current emulator behavior as implemented.
 ## Multi‑consumer behavior
 
 The emulator tracks per‑consumer `phase` + `phase_power` from the request fields (only when phase is
-`A`, `B`, or `C`; inspection-mode requests with phase `0` or empty are responded to but not aggregated).
+`A`, `B`, or `C`; inspection-mode requests with phase `D`, `0` or empty are responded to but not aggregated).
 If a consumer stops sending updates for a while, its reported values are evicted after a configurable
 TTL (`CONSUMER_TTL`).
 

--- a/docs/ct002-ct003-protocol.md
+++ b/docs/ct002-ct003-protocol.md
@@ -55,15 +55,17 @@ Request payload fields (consumer → CT):
 2. **meter_mac_code** — battery MAC (12 hex chars, from Marstek app device management)
 3. **hhm_dev_type** — CT type (`HME-4` or `HME-3`)
 4. **hhm_mac_code** — CT MAC (12 hex chars, from Marstek app device management)
-5. **phase** — phase identifier (`A`, `B`, `C`) observed in real traffic; `D`, `0` or empty means inspection mode
+5. **phase** — phase identifier (`A`, `B`, `C`) observed in real traffic; any other value (observed: `0`, empty, `D`) means inspection mode
 6. **phase_power** — signed integer watts for the phase in field 5
 
 This mapping is based on real packet captures. Older public scripts may show `0|0` placeholders,
 but observed live traffic carries `phase|power` in these two fields.
 
-### Inspection mode (phase `D`, `0` or empty)
+### Inspection mode (any phase other than `A`/`B`/`C`)
 
-When a device sends `phase=D`, `phase=0` or an empty phase, it is in **inspection mode** — determining which
+When a device sends a phase that is not `A`, `B`, or `C` (observed markers
+include `0`, empty, and `D` from newer Marstek firmwares), it is in
+**inspection mode** — determining which
 phase it is connected to. The emulator:
 
 - **Responds** to the request (so the device can continue its phase detection)
@@ -110,7 +112,7 @@ This list describes current emulator behavior as implemented.
 ## Multi‑consumer behavior
 
 The emulator tracks per‑consumer `phase` + `phase_power` from the request fields (only when phase is
-`A`, `B`, or `C`; inspection-mode requests with phase `D`, `0` or empty are responded to but not aggregated).
+`A`, `B`, or `C`; inspection-mode requests carrying any other phase value — observed: `0`, empty, `D` — are responded to but not aggregated).
 If a consumer stops sending updates for a while, its reported values are evicted after a configurable
 TTL (`CONSUMER_TTL`).
 

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -504,7 +504,7 @@ class CT002:
         reported_phase = (fields[4] if len(fields) > 4 else "").strip().upper()
         reported_power = parse_int(fields[5] if len(fields) > 5 else 0)
 
-        if reported_phase not in ("A", "B", "C", "0", ""):
+        if reported_phase not in ("A", "B", "C", "D", "0", ""):
             logger.debug(
                 "CT002 request from %s has invalid phase '%s'",
                 addr,
@@ -512,7 +512,7 @@ class CT002:
             )
             return
 
-        in_inspection_mode = reported_phase in ("0", "")
+        in_inspection_mode = reported_phase in ("D", "0", "")
 
         logger.debug(
             "CT002 parsed fields from %s: meter_dev_type=%s meter_mac=%s ct_type=%s ct_mac=%s phase=%s power=%s consumer_id=%s%s",

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -509,15 +509,21 @@ class CT002:
         # (newer Marstek battery firmwares); accept any other value too so
         # future markers don't break phase detection.
         in_inspection_mode = reported_phase not in ("A", "B", "C")
+        if in_inspection_mode:
+            logger.debug(
+                "CT002 request from %s in inspection mode (phase=%r)",
+                addr,
+                reported_phase,
+            )
 
         logger.debug(
-            "CT002 parsed fields from %s: meter_dev_type=%s meter_mac=%s ct_type=%s ct_mac=%s phase=%s power=%s consumer_id=%s%s",
+            "CT002 parsed fields from %s: meter_dev_type=%s meter_mac=%s ct_type=%s ct_mac=%s phase=%r power=%s consumer_id=%s%s",
             addr,
             fields[0] if len(fields) > 0 else None,
             fields[1] if len(fields) > 1 else None,
             fields[2] if len(fields) > 2 else None,
             fields[3] if len(fields) > 3 else None,
-            reported_phase or "(inspection)",
+            reported_phase,
             reported_power,
             consumer_id,
             " in inspection mode" if in_inspection_mode else "",

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -504,15 +504,11 @@ class CT002:
         reported_phase = (fields[4] if len(fields) > 4 else "").strip().upper()
         reported_power = parse_int(fields[5] if len(fields) > 5 else 0)
 
-        if reported_phase not in ("A", "B", "C", "D", "0", ""):
-            logger.debug(
-                "CT002 request from %s has invalid phase '%s'",
-                addr,
-                reported_phase,
-            )
-            return
-
-        in_inspection_mode = reported_phase in ("D", "0", "")
+        # Anything other than A/B/C is treated as inspection mode. Observed
+        # inspection markers in real traffic include "0", empty, and "D"
+        # (newer Marstek battery firmwares); accept any other value too so
+        # future markers don't break phase detection.
+        in_inspection_mode = reported_phase not in ("A", "B", "C")
 
         logger.debug(
             "CT002 parsed fields from %s: meter_dev_type=%s meter_mac=%s ct_type=%s ct_mac=%s phase=%s power=%s consumer_id=%s%s",


### PR DESCRIPTION
## Summary
Updated the CT002 protocol handler to treat any phase value other than `A`, `B`, or `C` as inspection mode, rather than only recognizing `0` and empty values. This makes the implementation more robust to future firmware variants while maintaining backward compatibility.

## Key Changes
- **Inspection mode logic**: Changed from explicitly checking for `"0"` and `""` to a more general approach that accepts any phase value outside of `A`, `B`, `C`. This accommodates newer Marstek battery firmwares that use `D` and future markers.
- **Error handling**: Removed the early return on invalid phase values. Inspection mode requests are now processed and responded to (as per protocol spec) rather than being rejected.
- **Logging improvements**: 
  - Updated debug message to indicate "inspection mode" rather than "invalid phase"
  - Changed phase field formatting from string interpolation to `%r` for clearer representation of empty/special values
  - Simplified phase display in parsed fields log (now shows actual value instead of conditional "(inspection)" text)
- **Documentation**: Updated protocol documentation to clarify that inspection mode is triggered by any phase outside `A`/`B`/`C`, with examples of observed values (`0`, empty, `D`)

## Implementation Details
The change introduces a more forward-compatible design: instead of maintaining a hardcoded list of inspection mode markers, the code now uses an allowlist approach for valid phases. This means future firmware versions with new inspection markers will automatically be handled correctly without code changes.

https://claude.ai/code/session_018ZXk7b7AaPRfPErEqt3BRt