### PR TITLE
Remove TCP port 52500 mapping from addon configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added battery activity info logs for Shelly emulation to report detection, inactivity, and reconnection events ([#241](https://github.com/tomquist/astrameter/pull/241))
 - Reduced throttling output noise by replacing unconditional `print` calls in `ThrottledPowermeter` with structured logging (`logger.debug` for routine wait/fetch/cache messages; failures remain at error level) ([#251](https://github.com/tomquist/astrameter/pull/251))
 - Improved Shelly UDP server robustness by adding socket timeouts to avoid hangs during shutdown and testing ([#233](https://github.com/tomquist/astrameter/pull/233))
+- Fixed Home Assistant add-on health check failing to start with `address in use` on port 52500 by no longer publishing the port (the watchdog still reaches it via host networking).
 
 ### Breaking
 - The Home Assistant app no longer publishes images for 32-bit ARM (`armhf` / `armv7`). Installations must use a 64-bit Home Assistant OS or supervisor environment (`amd64` or `aarch64`), consistent with Home Assistant dropping 32-bit support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 - Added battery activity info logs for Shelly emulation to report detection, inactivity, and reconnection events ([#241](https://github.com/tomquist/astrameter/pull/241))
 - Reduced throttling output noise by replacing unconditional `print` calls in `ThrottledPowermeter` with structured logging (`logger.debug` for routine wait/fetch/cache messages; failures remain at error level) ([#251](https://github.com/tomquist/astrameter/pull/251))
 - Improved Shelly UDP server robustness by adding socket timeouts to avoid hangs during shutdown and testing ([#233](https://github.com/tomquist/astrameter/pull/233))
-- Fixed Home Assistant add-on health check failing to start with `address in use` on port 52500 by no longer publishing the port (the watchdog still reaches it via host networking).
 
 ### Breaking
 - The Home Assistant app no longer publishes images for 32-bit ARM (`armhf` / `armv7`). Installations must use a 64-bit Home Assistant OS or supervisor environment (`amd64` or `aarch64`), consistent with Home Assistant dropping 32-bit support.

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -13,7 +13,7 @@ init: false
 startup: application
 boot: auto
 auto_restart: true
-watchdog: "http://[HOST]:52500/health"
+watchdog: "http://[HOST]:[PORT:52500]/health"
 services:
   - "mqtt:want"
 homeassistant_api: true

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -13,7 +13,7 @@ init: false
 startup: application
 boot: auto
 auto_restart: true
-watchdog: "http://[HOST]:[PORT:52500]/health"
+watchdog: "http://[HOST]:52500/health"
 services:
   - "mqtt:want"
 homeassistant_api: true
@@ -26,7 +26,6 @@ ports:
   2220/udp: 2220
   2222/udp: 2222
   2223/udp: 2223
-  52500/tcp: 52500
 map:
   - type: addon_config
     read_only: false


### PR DESCRIPTION
## Summary
Removed the TCP port 52500 mapping from the Home Assistant addon configuration file.

## Changes
- Removed `52500/tcp: 52500` port mapping from the `ports` section in `ha_addon/config.yaml`

## Details
This change removes an unused TCP port mapping from the addon's port configuration. The UDP port mappings (2220, 2222, 2223) remain unchanged.

https://claude.ai/code/session_01KG91R96CZVPk1gk9tKnB5e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a TCP port mapping from add-on port configuration; UDP port mappings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->