### PR TITLE
Support reading 3 phases with VZLogger Powermeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,12 +313,22 @@ POWER_OUTPUT_ALIAS = sensor.power_out_1,sensor.power_out_2,sensor.power_out_3
 
 ### VZLogger
 
+Example: Variant with total power
 ```ini
 [VZLOGGER]
 IP = 192.168.1.106
 PORT = 8080
-UUID = your-uuid
+UUID = your-uuid-total-power
 ```
+
+Example: Variant with 3 phases
+```ini
+[VZLOGGER]
+IP = 192.168.1.106
+PORT = 8080
+UUID = your-uuid-phase-1, your-uuid-phase-2, your-uuid-phase-3
+```
+
 
 ### ESPHome
 

--- a/README.md
+++ b/README.md
@@ -455,6 +455,24 @@ CURRENT_POWER_ENTITY = sensor.current_power
 # No NETMASK specified - will match all clients (0.0.0.0/0)
 ```
 
+### Wrappers / Filters
+
+You can configure wrappers/filters which are using other powermeters as source for reading power values. The wrapper can then modify the power values of the original powermeter.
+A wrapped powermeter is not available for providing data to a Shelly/CT. Each Wrapper has an config entry called "WRAPPING", which needs to refer to the section of the powermeter
+to be warpped. Chaining of multiple wrappers is possible.
+
+The ANTI_WINDUP wrapper can be used for Marstek Venus devices to prevent them from oscillating. The powermeter being wrapped should deliver values every second.
+
+```ini
+[ANTI_WINDUP]
+FAST = 1.5
+SLOW = 0.5
+DAMPING = 0.7
+THRESHOLD_LOW = 25
+THRESHOLD_HIGH = 200
+WRAPPING = VZLOGGER
+```
+
 ## Node-RED Implementation
 
 This project also provides a Node-RED implementation, allowing integration with various smart meters. The Node-RED flow is available in the `nodered.json` file. Note that the Node-RED implementation only supports emulating a CT001.

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -24,6 +24,8 @@ from powermeter import (
     JsonHttpPowermeter,
     TQEnergyManager,
     ThrottledPowermeter,
+    AntiWindup,
+    LowPassFilter,
 )
 
 SHELLY_SECTION = "SHELLY"
@@ -39,6 +41,8 @@ AMIS_READER_SECTION = "AMIS_READER"
 MODBUS_SECTION = "MODBUS"
 JSON_HTTP_SECTION = "JSON_HTTP"
 TQ_EM_SECTION = "TQ_EM"
+ANTI_WINDUP_SECTION = "ANTI_WINDUP"
+LOW_PASS_FILTER_SECTION = "LOW_PASS_FILTER"
 
 
 class ClientFilter:
@@ -59,12 +63,13 @@ class ClientFilter:
 def read_all_powermeter_configs(
     config: configparser.ConfigParser,
 ) -> List[Tuple[Powermeter, ClientFilter]]:
-    powermeters = []
+    powermeters = {}
     global_throttle_interval = config.getfloat(
         "GENERAL", "THROTTLE_INTERVAL", fallback=0.0
     )
 
     for section in config.sections():
+        if "WRAPPING" in config[section]: continue
         powermeter = create_powermeter(section, config)
         if powermeter is not None:
             section_throttle_interval = config.getfloat(
@@ -83,8 +88,20 @@ def read_all_powermeter_configs(
                 powermeter = ThrottledPowermeter(powermeter, section_throttle_interval)
 
             client_filter = create_client_filter(section, config)
-            powermeters.append((powermeter, client_filter))
-    return powermeters
+            powermeters[section] = (powermeter, client_filter)
+
+    for section in config.sections():
+        if "WRAPPING" not in config[section]: continue
+        powermeter = create_wrapping_powermeter(section, config, powermeters[config[section]["WRAPPING"]][0])
+        client_filter = create_client_filter(section, config)
+        powermeters[section] = (powermeter, client_filter)
+
+    for section in config.sections():
+        # remove all powermeters, that are wrapped by other PMs
+        if "WRAPPING" in config[section]: powermeters.pop(config[section]["WRAPPING"], None)
+
+    pms = list(powermeters.values())
+    return pms
 
 
 def create_client_filter(
@@ -94,6 +111,22 @@ def create_client_filter(
     netmasks = [IPv4Network(netmask) for netmask in netmasks.split(",")]
     return ClientFilter(netmasks)
 
+def create_wrapping_powermeter(section: str, config: configparser.ConfigParser, powermeter : Powermeter
+) -> Union[Powermeter, None]:
+    if section.startswith(ANTI_WINDUP_SECTION):
+        fast = float(config.get(section, "FAST"))
+        slow = float(config.get(section, "SLOW"))
+        threshold_low = int(config.get(section, "THRESHOLD_LOW"))
+        threshold_high = int(config.get(section, "THRESHOLD_HIGH"))
+        damping = float(config.get(section, "DAMPING"))
+        return AntiWindup(powermeter, fast, slow, threshold_low, threshold_high, damping)
+    if section.startswith(LOW_PASS_FILTER_SECTION):
+        slope_on = int(config.get(section, "SLOPE_ON"))
+        slope_off = int(config.get(section, "SLOPE_OFF"))
+        max_filter_time = float(config.get(section, "MAX_FILTER_TIME"))
+        return LowPassFilter(powermeter, slope_on, slope_off, max_filter_time)
+    else:
+        return None
 
 # Helper function to create a powermeter instance
 def create_powermeter(

--- a/powermeter/__init__.py
+++ b/powermeter/__init__.py
@@ -14,3 +14,4 @@ from .json_http import JsonHttpPowermeter
 from .script import Script
 from .throttling import ThrottledPowermeter
 from .tq_em import TQEnergyManager
+from .wrapper import AntiWindup, LowPassFilter

--- a/powermeter/vzlogger.py
+++ b/powermeter/vzlogger.py
@@ -6,12 +6,18 @@ class VZLogger(Powermeter):
     def __init__(self, ip: str, port: str, uuid: str):
         self.ip = ip
         self.port = port
-        self.uuid = uuid
+        self.uuids = dict(zip([u.strip() for u in uuid.split(",")], [0,1,2]))
         self.session = requests.Session()
 
     def get_json(self):
-        url = f"http://{self.ip}:{self.port}/{self.uuid}"
+        url = f"http://{self.ip}:{self.port}"
         return self.session.get(url, timeout=10).json()
 
     def get_powermeter_watts(self):
-        return [int(self.get_json()["data"][0]["tuples"][0][1])]
+        powers = [0, 0, 0]
+        for item in self.get_json()["data"]:
+            uuid = item['uuid']
+            pos = self.uuids.get(uuid, None)
+            if pos != None:
+                powers[pos] = item['tuples'][0][1]
+        return powers

--- a/powermeter/vzlogger_test.py
+++ b/powermeter/vzlogger_test.py
@@ -6,14 +6,32 @@ from powermeter import VZLogger
 class TestVZLogger(unittest.TestCase):
 
     @patch("requests.Session.get")
-    def test_vzlogger_get_powermeter_watts(self, mock_get):
+    def test_vzlogger_get_powermeter_watts_total(self, mock_get):
         mock_response = MagicMock()
-        mock_response.json.return_value = {"data": [{"tuples": [[None, 900]]}]}
+        mock_response.json.return_value = {
+            "version": "0.8.9",
+            "generator": "vzlogger",
+            "data": [
+                { "uuid": "0", "last": 1776549041735, "interval": -1, "protocol": "sml", "tuples": [ [ 1776549041735, 100] ] },
+                { "uuid": "1", "last": 1776549041735, "interval": -1, "protocol": "sml", "tuples": [ [ 1776549041735, 200] ] },
+                { "uuid": "2", "last": 1776549041735, "interval": -1, "protocol": "sml", "tuples": [ [ 1776549041735, 300] ] },
+                { "uuid": "3", "last": 1776549041735, "interval": -1, "protocol": "sml", "tuples": [ [ 1776549041735, 400] ] },
+                { "uuid": "4", "last": 1776549041735, "interval": -1, "protocol": "sml", "tuples": [ [ 1776549041735, 500] ] },
+                { "uuid": "5", "last": 1776549041735, "interval": -1, "protocol": "sml", "tuples": [ [ 1776549041735, 600] ] },
+                { "uuid": "6", "last": 1776549041735, "interval": -1, "protocol": "sml", "tuples": [ [ 1776549041735, 700] ] },
+                { "uuid": "7", "last": 1776549041735, "interval": -1, "protocol": "sml", "tuples": [ [ 1776549041735, 800] ] }
+            ]
+        }
         mock_get.return_value = mock_response
 
-        vzlogger = VZLogger("192.168.1.9", "8088", "uuid")
-        self.assertEqual(vzlogger.get_powermeter_watts(), [900])
+        vzlogger = VZLogger("192.168.1.9", "8088", "4")
+        self.assertEqual(vzlogger.get_powermeter_watts(), [500, 0, 0])
 
+        vzlogger = VZLogger("192.168.1.9", "8088", "5,6,7")
+        self.assertEqual(vzlogger.get_powermeter_watts(), [600, 700, 800])
+
+        vzlogger = VZLogger("192.168.1.9", "8088", "5, 6, 7")
+        self.assertEqual(vzlogger.get_powermeter_watts(), [600, 700, 800])
 
 if __name__ == "__main__":
     unittest.main()

--- a/powermeter/wrapper.py
+++ b/powermeter/wrapper.py
@@ -1,0 +1,73 @@
+from .base import Powermeter
+import time
+import threading
+from config.logger import logger
+import collections
+
+class LowPassFilter(Powermeter):
+    def __init__(self, powermeter, slope_on, slope_off, max_filter_time):
+        self._powermeter = powermeter
+        self._filtering = False
+        self._last_power = [0, 0, 0]
+        self._last_spike_time = 0
+        self._slope_on = slope_on
+        self._slope_off = slope_off
+        self._max_filter_time = max_filter_time
+        self._lock = threading.Lock()
+    
+    def get_powermeter_watts(self):
+        with self._lock:
+            powers = self._powermeter.get_powermeter_watts() 
+            total = sum(powers)
+            last_total = sum(self._last_power)
+            diff = abs(total - last_total)
+            if self._filtering:
+                if diff > self._slope_off: 
+                    if time.perf_counter() - self._last_spike_time <= self._max_filter_time:
+                        powers = self._last_power
+                        logger.info(f"Filtering")
+                    else:
+                        logger.info(f"Stop filtering")
+                        self._filtering = False
+                else:
+                    logger.info(f"Stop filtering")
+                    self._filtering = False
+            else:
+                if diff > self._slope_on:
+                    logger.info(f"Start filtering")
+                    self._filtering = True
+                    self._last_spike_time = time.perf_counter()
+                    powers = self._last_power
+            self._last_power = powers
+            return powers
+
+
+class AntiWindup(Powermeter):
+    def __init__(self, powermeter, fast, slow, threshold_low, threshold_high, damping):
+        self._powermeter = powermeter
+        self._deque = collections.deque([[0, 0, 0]], maxlen=10)
+        self._fast = fast
+        self._slow = slow
+        self._threshold_low = threshold_low
+        self._threshold_high = threshold_high
+        self._damping = damping
+        self._factor = slow
+        self._lock = threading.Lock()
+
+    def get_powermeter_watts(self):
+        with self._lock:
+            powers = self._powermeter.get_powermeter_watts() 
+            total = abs(sum(powers))
+            # stdev-based offset
+            if self._deque[-1] != powers:
+                self._deque.append(powers)
+                if total > self._threshold_low:
+                    diff = min(total, self._threshold_high) - self._threshold_low
+                    self._factor = ((diff/(self._threshold_high-self._threshold_low)) * (self._fast -self._slow)) + self._slow
+                else:
+                    self._factor = self._slow
+            else:
+                self._factor *= self._damping
+            powers = [float(p)*(self._factor) for p in powers]
+            logger.info(sum(powers))
+            return powers

--- a/powermeter/wrapper_test.py
+++ b/powermeter/wrapper_test.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from powermeter import VZLogger
+from powermeter import AntiWindup
+
+
+class TestAntiWindupWithVZLogger(unittest.TestCase):
+
+    @patch("requests.Session.get")
+    def test_anti_windup_get_powermeter_watts(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "version": "0.8.9",
+            "generator": "vzlogger",
+            "data": [
+                { "uuid": "5", "last": 1776549041735, "interval": -1, "protocol": "sml", "tuples": [ [ 1776549041735, 100] ] },
+                { "uuid": "6", "last": 1776549041735, "interval": -1, "protocol": "sml", "tuples": [ [ 1776549041735, 200] ] },
+                { "uuid": "7", "last": 1776549041735, "interval": -1, "protocol": "sml", "tuples": [ [ 1776549041735, 300] ] },
+
+                { "uuid": "1", "last": 1776549041735, "interval": -1, "protocol": "sml", "tuples": [ [ 1776549041735, 1] ] },
+                { "uuid": "2", "last": 1776549041735, "interval": -1, "protocol": "sml", "tuples": [ [ 1776549041735, 2] ] },
+                { "uuid": "3", "last": 1776549041735, "interval": -1, "protocol": "sml", "tuples": [ [ 1776549041735, 3] ] }
+
+            ]
+        }
+        mock_get.return_value = mock_response
+
+        vzlogger = VZLogger("192.168.1.9", "8088", "5,6,7")
+        aw = AntiWindup(vzlogger, 1.5, 0.5, 25, 150, 0.7)
+        self.assertEqual(aw.get_powermeter_watts(), [150, 300, 450])
+        self.assertEqual([round(ii) for ii in aw.get_powermeter_watts()], [105, 210, 315])
+
+        vzlogger = VZLogger("192.168.1.9", "8088", "1,2,3")
+        aw = AntiWindup(vzlogger, 1.5, 0.5, 25, 150, 0.7)
+        self.assertEqual(aw.get_powermeter_watts(), [0.5, 1, 1.5])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+requests
+jsonpath-ng
+paho-mqtt
+pymodbus<=3.9.0
+pytest
+


### PR DESCRIPTION
Minor enhancement for VZLogger Powermeter to support reading of power for 3 phases as alternative to reading total power.

For total power one can use:
UUID = your-uuid-total-power

To read each phase separately provide list of UUIDs separated by ","
UUID = your-uuid-phase-1, your-uuid-phase-2, your-uuid-phase-3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended power meter support to handle multiple sensors via comma-separated configuration, enabling three-phase meter deployments.

* **Documentation**
  * Updated configuration examples with guidance for both single and multi-phase power meter setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->