### PR TITLE
Use jsonpath-ng extended parser for JSON_PATHS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - **Added** `exc_info` to logger warnings for better debugging ([#307](https://github.com/tomquist/astrameter/pull/307)).
 
 ### Changed
+- **Upgraded** `JSON_PATHS` parsing in the JSON HTTP and MQTT powermeters to the `jsonpath-ng` extended syntax, so values that arrive with a unit suffix (e.g. openHAB `Number:Power` returning `"331.74 W"`) can be sanitized inside the path with `` `split(...)` `` or `` `sub(/regex/, replacement)` `` instead of failing the float conversion ([#348](https://github.com/tomquist/astrameter/issues/348)).
 - **Switched** the Home Assistant powermeter integration from REST polling to the WebSocket API ([#232](https://github.com/tomquist/astrameter/pull/232)).
 - **Expanded** Shelly emulation logs to report battery detection, inactivity, and reconnection events ([#241](https://github.com/tomquist/astrameter/pull/241)).
 - **Reduced** throttling output noise by replacing unconditional `print` calls in `ThrottledPowermeter` with structured logging (`logger.debug` for routine wait/fetch/cache messages; failures remain at error level) ([#251](https://github.com/tomquist/astrameter/pull/251)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,11 @@
 - **Added** `exc_info` to logger warnings for better debugging ([#307](https://github.com/tomquist/astrameter/pull/307)).
 
 ### Changed
-- **Upgraded** `JSON_PATHS` parsing in the JSON HTTP and MQTT powermeters to the `jsonpath-ng` extended syntax, so values that arrive with a unit suffix (e.g. openHAB `Number:Power` returning `"331.74 W"`) can be sanitized inside the path with `` `split(...)` `` or `` `sub(/regex/, replacement)` `` instead of failing the float conversion ([#348](https://github.com/tomquist/astrameter/issues/348)).
 - **Switched** the Home Assistant powermeter integration from REST polling to the WebSocket API ([#232](https://github.com/tomquist/astrameter/pull/232)).
 - **Expanded** Shelly emulation logs to report battery detection, inactivity, and reconnection events ([#241](https://github.com/tomquist/astrameter/pull/241)).
 - **Reduced** throttling output noise by replacing unconditional `print` calls in `ThrottledPowermeter` with structured logging (`logger.debug` for routine wait/fetch/cache messages; failures remain at error level) ([#251](https://github.com/tomquist/astrameter/pull/251)).
 - **Improved** Shelly UDP server robustness by adding socket timeouts to avoid hangs during shutdown and testing ([#233](https://github.com/tomquist/astrameter/pull/233)).
+- **Upgraded** `JSON_PATHS` parsing in the JSON HTTP and MQTT powermeters to the `jsonpath-ng` extended syntax, so values that arrive with a unit suffix (e.g. openHAB `Number:Power` returning `"331.74 W"`) can be sanitized inside the path with `` `split(...)` `` or `` `sub(/regex/, replacement)` `` instead of failing the float conversion ([#349](https://github.com/tomquist/astrameter/pull/349)).
 
 ### Fixed
 - **Fixed** Modbus `UNIT_ID` handling and clarified Home Assistant entity ID configuration in the docs ([#191](https://github.com/tomquist/astrameter/pull/191), [#195](https://github.com/tomquist/astrameter/pull/195)).

--- a/README.md
+++ b/README.md
@@ -717,6 +717,13 @@ PASSWORD = pass (Optional)
 HEADERS = Authorization: Bearer token
 ```
 
+`JSON_PATHS` is parsed with the [`jsonpath-ng` extended syntax](https://github.com/h2non/jsonpath-ng#extensions), so you can chain extensions like `` `split(...)` `` or `` `sub(/regex/, replacement)` `` to massage the value before it's converted to a float. For example, an openHAB `Number:Power` item returns `"331.74 W"` — strip the unit with either of:
+
+```ini
+JSON_PATHS = $.state.`split( , 0, -1)`
+JSON_PATHS = $.state.`sub(/[^0-9.\-]+$/, )`
+```
+
 ### TQ Energy Manager
 
 ```ini

--- a/README.md
+++ b/README.md
@@ -681,6 +681,8 @@ TOPIC = home/powermeter
 The `JSON_PATH` option is used to extract the power value from a JSON payload. The path must be a [valid JSONPath expression](https://goessner.net/articles/JsonPath/).
 If the payload is a simple integer value, you can omit this option.
 
+Both `JSON_PATH` and `JSON_PATHS` are parsed with the [`jsonpath-ng` extended syntax](https://github.com/h2non/jsonpath-ng#extensions), so you can chain extensions like `` `split(...)` `` or `` `sub(/regex/, replacement)` `` to massage a payload value before it's converted to a float — for instance `$.state.`split( , 0, -1)`` or `$.state.`sub(/[^0-9.\-]+$/, )`` to strip a unit suffix like `"331.74 W"`. See the [JSON HTTP](#json-http) section below for more examples.
+
 #### Multi-phase MQTT
 
 For three-phase setups, there are two options:

--- a/config.ini.example
+++ b/config.ini.example
@@ -279,6 +279,10 @@ THROTTLE_INTERVAL = 0
 # [JSON_HTTP]
 #URL = http://example.com/api
 #JSON_PATHS = $.power
+## JSON_PATHS supports jsonpath-ng extensions; strip a unit suffix like
+## "331.74 W" with `split` or `sub`:
+##JSON_PATHS = $.state.`split( , 0, -1)`
+##JSON_PATHS = $.state.`sub(/[^0-9.\-]+$/, )`
 #USERNAME = user
 #PASSWORD = pass
 #HEADERS = Authorization: Bearer token

--- a/src/astrameter/powermeter/json_http.py
+++ b/src/astrameter/powermeter/json_http.py
@@ -2,7 +2,7 @@ import json
 
 import aiohttp
 from aiohttp import BasicAuth, ClientTimeout
-from jsonpath_ng import parse
+from jsonpath_ng.ext import parse
 
 from astrameter.config.logger import logger
 

--- a/src/astrameter/powermeter/json_http_test.py
+++ b/src/astrameter/powermeter/json_http_test.py
@@ -23,6 +23,17 @@ async def test_three_phase(mock_aiohttp_session):
         await meter.stop()
 
 
+async def test_strips_unit_suffix_via_jsonpath_ext(mock_aiohttp_session):
+    mock_aiohttp_session.set_json({"state": "331.74 W"})
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
+        meter = JsonHttpPowermeter(
+            "http://localhost", "$.state.`sub(/[^0-9.\\-]+$/, )`"
+        )
+        await meter.start()
+        assert await meter.get_powermeter_watts() == [331.74]
+        await meter.stop()
+
+
 async def test_headers_and_auth(mock_aiohttp_session):
     mock_aiohttp_session.set_json({"power": 50})
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session) as mock_cls:

--- a/src/astrameter/powermeter/mqtt.py
+++ b/src/astrameter/powermeter/mqtt.py
@@ -4,7 +4,7 @@ import json
 import ssl
 
 import aiomqtt
-from jsonpath_ng import parse
+from jsonpath_ng.ext import parse
 
 from astrameter.config.logger import logger
 


### PR DESCRIPTION
Switches the JSON HTTP and MQTT powermeters from `jsonpath_ng.parse` to `jsonpath_ng.ext.parse` so users can sanitize values inside the path expression with `split` or `sub` extensions. This lets sources like openHAB's `Number:Power` items (which serialize as `"331.74 W"`) be consumed without the float conversion blowing up on the unit suffix.

Refs #348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JSON HTTP and MQTT powermeters now support extracting numeric values with unit suffixes (e.g., "331.74 W") using enhanced JSONPath expressions with built-in transformations.

* **Documentation**
  * Added examples and guidance for configuring JSONPath expressions to strip units and perform data transformations.

* **Tests**
  * Added test coverage for unit-suffix stripping functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->