### PR TITLE
Treat Home Assistant state_reported keepalives as liveness signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- **Fixed** spurious "Home Assistant sensor … is stale" errors on `subscribe_entities` feeds for sensors whose value doesn't change (e.g. solar production on an unloaded phase, an empty production sensor at night). HA omits the state field from compressed diffs when the value is unchanged and sends only an updated timestamp; AstraMeter now treats those state_reported keepalives as liveness signals so the 60 s staleness check no longer fires falsely ([#363](https://github.com/tomquist/astrameter/issues/363)).
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** spurious "Home Assistant sensor … is stale" errors on sensors whose value doesn't change (e.g. solar production on an unloaded phase, an empty production sensor at night). HA's `subscribe_entities` only forwards `state_changed` events, so a constant-value sensor produces no pushes even when HA itself is current; the previous 60 s per-entity timer therefore fired falsely. AstraMeter now falls back to `GET /api/states/{entity}` (parallel, bounded to 1 s total) and uses HA's authoritative `last_reported` timestamp — which is mutated on every state write including same-value reports — to confirm freshness. State_reported keepalives over the websocket (attribute-only diffs) also refresh liveness ([#363](https://github.com/tomquist/astrameter/issues/363)).
+- **Fixed** Home Assistant sensors falsely reported as stale when their value doesn't change for a while (e.g. solar production on an unloaded phase, or at night) ([#363](https://github.com/tomquist/astrameter/issues/363)).
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** spurious "Home Assistant sensor … is stale" errors on `subscribe_entities` feeds for sensors whose value doesn't change (e.g. solar production on an unloaded phase, an empty production sensor at night). HA omits the state field from compressed diffs when the value is unchanged and sends only an updated timestamp; AstraMeter now treats those state_reported keepalives as liveness signals so the 60 s staleness check no longer fires falsely ([#363](https://github.com/tomquist/astrameter/issues/363)).
+- **Fixed** spurious "Home Assistant sensor … is stale" errors on sensors whose value doesn't change (e.g. solar production on an unloaded phase, an empty production sensor at night). HA's `subscribe_entities` only forwards `state_changed` events, so a constant-value sensor produces no pushes even when HA itself is current; the previous 60 s per-entity timer therefore fired falsely. AstraMeter now falls back to `GET /api/states/{entity}` (parallel, bounded to 1 s total) and uses HA's authoritative `last_reported` timestamp — which is mutated on every state write including same-value reports — to confirm freshness. State_reported keepalives over the websocket (attribute-only diffs) also refresh liveness ([#363](https://github.com/tomquist/astrameter/issues/363)).
 
 ## 2.0.0
 

--- a/src/astrameter/powermeter/homeassistant.py
+++ b/src/astrameter/powermeter/homeassistant.py
@@ -326,6 +326,10 @@ class HomeAssistant(Powermeter):
 
     async def _fetch_rest_state(self, entity_id: str) -> None:
         assert self._session is not None
+        # Snapshot the local update time so we can detect a concurrent
+        # websocket push (or another in-flight REST refresh) and avoid
+        # clobbering newer data with a potentially-older REST response.
+        pre_update = self._entity_update_time.get(entity_id)
         url = self._build_rest_state_url(entity_id)
         headers = {"Authorization": f"Bearer {self.access_token}"}
         try:
@@ -342,6 +346,8 @@ class HomeAssistant(Powermeter):
             logger.debug(
                 "Home Assistant REST refresh for %s failed: %s", entity_id, exc
             )
+            return
+        if self._entity_update_time.get(entity_id) != pre_update:
             return
         if isinstance(data, dict):
             self._apply_rest_state(entity_id, data)

--- a/src/astrameter/powermeter/homeassistant.py
+++ b/src/astrameter/powermeter/homeassistant.py
@@ -15,6 +15,8 @@ logger = logging.getLogger("astrameter")
 
 # Home Assistant websocket subscribe_entities compressed state (homeassistant.const)
 _HA_S = "s"
+_HA_LU = "lu"
+_HA_LC = "lc"
 _HA_DIFF_ADD = "+"
 
 # WebSocket heartbeat (seconds) — same rationale as HomeWizard.
@@ -167,8 +169,17 @@ class HomeAssistant(Powermeter):
                 if eid not in self._tracked_entities or not isinstance(diff, dict):
                     continue
                 plus = diff.get(_HA_DIFF_ADD)
-                if isinstance(plus, dict) and _HA_S in plus:
+                if not isinstance(plus, dict):
+                    continue
+                if _HA_S in plus:
                     self._update_entity_value(eid, plus.get(_HA_S))
+                elif _HA_LU in plus or _HA_LC in plus:
+                    # state_reported (value unchanged): HA omits ``s`` and
+                    # sends only ``lu``. Treat as a keepalive so the
+                    # staleness check does not fire on sensors whose value
+                    # is legitimately constant (e.g. solar production at
+                    # night, an unloaded phase).
+                    self._mark_entity_alive(eid)
         removals = ev.get("r")
         if isinstance(removals, list):
             for eid in removals:
@@ -234,6 +245,12 @@ class HomeAssistant(Powermeter):
             self._entity_values[entity_id] = None
             self._entity_update_time[entity_id] = None
         self._check_entities_ready()
+        self._message_event.set()
+
+    def _mark_entity_alive(self, entity_id: str) -> None:
+        if self._entity_values.get(entity_id) is None:
+            return
+        self._entity_update_time[entity_id] = self._clock()
         self._message_event.set()
 
     def _check_entities_ready(self) -> None:

--- a/src/astrameter/powermeter/homeassistant.py
+++ b/src/astrameter/powermeter/homeassistant.py
@@ -4,6 +4,7 @@ import json
 import logging
 import time
 from collections.abc import Callable
+from datetime import datetime, timezone
 from typing import Any
 
 import aiohttp
@@ -22,11 +23,21 @@ _HA_DIFF_ADD = "+"
 # WebSocket heartbeat (seconds) — same rationale as HomeWizard.
 WS_HEARTBEAT_SECONDS = 30.0
 
-# An entity older than this is considered stale.  HA typically pushes
-# state changes on every update plus periodic keepalives; anything
-# past 60 s without a push from a power sensor is strongly suspicious
-# and consistent with a stalled websocket stream.
+# An entity older than this is considered stale by the local push timer.
+# Crossing this threshold triggers the REST fallback (see below), not an
+# immediate error: HA's ``subscribe_entities`` only forwards
+# ``state_changed`` events, so a sensor with a constant value (e.g. solar
+# production on an unloaded phase) produces no pushes even when HA itself
+# is up to date.
 DEFAULT_MAX_STATE_AGE_SECONDS = 60.0
+
+# Total wall-clock budget for the REST staleness fallback. When local push
+# silence exceeds ``max_state_age_seconds`` for any tracked entity, we
+# fan out parallel ``GET /api/states/{entity}`` requests bounded by this
+# deadline; HA returns ``last_reported`` (mutated on every state write,
+# including same-value reports), which we use as the authoritative
+# freshness signal. Bounded so a battery's UDP request never stalls.
+REST_REFRESH_TIMEOUT_SECONDS = 1.0
 
 
 class HomeAssistant(Powermeter):
@@ -93,6 +104,11 @@ class HomeAssistant(Powermeter):
         prefix = self.path_prefix or ""
         return f"{scheme}://{self.ip}:{self.port}{prefix}/api/websocket"
 
+    def _build_rest_state_url(self, entity_id: str) -> str:
+        scheme = "https" if self.use_https else "http"
+        prefix = self.path_prefix or ""
+        return f"{scheme}://{self.ip}:{self.port}{prefix}/api/states/{entity_id}"
+
     def _next_id(self) -> int:
         self._msg_id += 1
         return self._msg_id
@@ -139,12 +155,13 @@ class HomeAssistant(Powermeter):
                 logger.error("Home Assistant WebSocket error: %s", e, exc_info=True)
             # Reset protocol state for reconnection; keep _entity_values
             # as a courtesy, but mark them all stale so the staleness
-            # check in _get_entity_value will raise until fresh state
-            # pushes arrive from the reconnect.  ``_entities_ready``
-            # must also clear, otherwise ``wait_for_message()`` would
-            # return immediately for any caller relying on it as a
-            # readiness signal even though every entity is effectively
-            # stale until the next ``subscribe_entities`` snapshot.
+            # check in _get_entity_value falls back to REST (or raises)
+            # until fresh state pushes arrive from the reconnect.
+            # ``_entities_ready`` must also clear, otherwise
+            # ``wait_for_message()`` would return immediately for any
+            # caller relying on it as a readiness signal even though
+            # every entity is effectively stale until the next
+            # ``subscribe_entities`` snapshot.
             self._msg_id = 0
             self._subscribe_entities_id = None
             for eid in list(self._entity_update_time):
@@ -264,6 +281,100 @@ class HomeAssistant(Powermeter):
         else:
             self._entities_ready.clear()
 
+    def _locally_stale_entities(self) -> list[str]:
+        if self._max_state_age_seconds <= 0:
+            return []
+        now = self._clock()
+        stale: list[str] = []
+        for eid in self._tracked_entities:
+            if self._entity_values.get(eid) is None:
+                stale.append(eid)
+                continue
+            last = self._entity_update_time.get(eid)
+            if last is None or (now - last) > self._max_state_age_seconds:
+                stale.append(eid)
+        return stale
+
+    async def _refresh_stale_via_rest(
+        self, timeout: float = REST_REFRESH_TIMEOUT_SECONDS
+    ) -> None:
+        """REST-poll any entity whose local push timer has crossed the
+        staleness threshold, bounded by ``timeout`` total wall-clock.
+
+        ``subscribe_entities`` only forwards ``state_changed``; sensors with
+        a constant value (e.g. solar production on an unloaded phase) never
+        push, so the per-entity timer is not a reliable freshness signal.
+        ``GET /api/states/{eid}`` returns HA's ``last_reported``, which is
+        mutated on every state write — including same-value reports — and
+        is the authoritative source of truth.
+        """
+        if self._session is None:
+            return
+        stale = self._locally_stale_entities()
+        if not stale:
+            return
+        # Whatever finishes in-budget is already applied; anything still
+        # stale after the timeout will be caught by ``_get_entity_value``.
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                asyncio.gather(
+                    *(self._fetch_rest_state(eid) for eid in stale),
+                    return_exceptions=True,
+                ),
+                timeout=timeout,
+            )
+
+    async def _fetch_rest_state(self, entity_id: str) -> None:
+        assert self._session is not None
+        url = self._build_rest_state_url(entity_id)
+        headers = {"Authorization": f"Bearer {self.access_token}"}
+        try:
+            async with self._session.get(url, headers=headers) as resp:
+                if resp.status != 200:
+                    logger.debug(
+                        "Home Assistant REST refresh for %s: HTTP %s",
+                        entity_id,
+                        resp.status,
+                    )
+                    return
+                data = await resp.json()
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            logger.debug(
+                "Home Assistant REST refresh for %s failed: %s", entity_id, exc
+            )
+            return
+        if isinstance(data, dict):
+            self._apply_rest_state(entity_id, data)
+
+    def _apply_rest_state(self, entity_id: str, data: dict[str, Any]) -> None:
+        state_val = data.get("state")
+        if state_val in (None, "unknown", "unavailable"):
+            return
+        try:
+            value = float(state_val)  # type: ignore[arg-type]
+        except (ValueError, TypeError):
+            return
+        # Trust HA's ``last_reported`` (mutated on every state write).
+        # If HA itself hasn't seen an update within the staleness window,
+        # don't refresh local cache — let the staleness check raise.
+        if self._max_state_age_seconds > 0:
+            reported_iso = data.get("last_reported") or data.get("last_updated")
+            if not isinstance(reported_iso, str):
+                return
+            try:
+                reported_dt = datetime.fromisoformat(reported_iso)
+            except ValueError:
+                return
+            if reported_dt.tzinfo is None:
+                reported_dt = reported_dt.replace(tzinfo=timezone.utc)
+            ha_age = (datetime.now(timezone.utc) - reported_dt).total_seconds()
+            if ha_age > self._max_state_age_seconds:
+                return
+        self._entity_values[entity_id] = value
+        self._entity_update_time[entity_id] = self._clock()
+        self._check_entities_ready()
+        self._message_event.set()
+
     def _get_entity_value(self, entity_id: str) -> float:
         val = self._entity_values.get(entity_id)
         if val is None:
@@ -283,6 +394,7 @@ class HomeAssistant(Powermeter):
         return val
 
     async def get_powermeter_watts(self) -> list[float]:
+        await self._refresh_stale_via_rest()
         if not self.power_calculate:
             return [
                 self._get_entity_value(entity) for entity in self.current_power_entity

--- a/src/astrameter/powermeter/homeassistant_test.py
+++ b/src/astrameter/powermeter/homeassistant_test.py
@@ -551,6 +551,102 @@ async def test_fresh_state_clears_staleness():
     assert await pm.get_powermeter_watts() == [250.0]
 
 
+async def test_state_reported_event_refreshes_staleness():
+    """Regression for issue #363: HA's ``subscribe_entities`` only includes
+    ``s`` in the diff when the state value actually changes. For sensors
+    whose value stays constant (e.g. solar production on an unused phase)
+    HA still pushes state_reported events, but their compressed diff only
+    carries an updated ``lu`` (last_updated timestamp). Treat those as
+    keepalives so the staleness check does not falsely fire on legitimately
+    constant sensors.
+    """
+    clock = _FakeClock()
+    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
+    )
+    assert await pm.get_powermeter_watts() == [0.0]
+
+    # 29 s in, an integration push reports the same value. HA emits a
+    # state_reported diff with only ``lu`` populated.
+    clock.advance(29.0)
+    ws = AsyncMock()
+    await pm._handle_message(
+        ws,
+        json.dumps(
+            {
+                "type": "event",
+                "event": {
+                    "c": {"sensor.current_power": {"+": {"lu": 1000.0}}},
+                },
+            }
+        ),
+    )
+
+    # The keepalive refreshed liveness; another 29 s should still be fresh.
+    clock.advance(29.0)
+    assert await pm.get_powermeter_watts() == [0.0]
+
+    # But continued silence past the threshold still trips staleness.
+    clock.advance(2.0)
+    with pytest.raises(ValueError, match="stale"):
+        await pm.get_powermeter_watts()
+
+
+async def test_state_reported_event_sets_message_event():
+    """``wait_for_next_message`` must wake on state_reported keepalives —
+    otherwise the Shelly / CT002 emulator's per-request fresh-push wait
+    times out for sensors whose value doesn't change between polls.
+    """
+    pm = _create_powermeter()
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
+    )
+    pm._message_event.clear()
+    waiter = asyncio.create_task(pm.wait_for_next_message(timeout=1))
+    await asyncio.sleep(0)
+
+    ws = AsyncMock()
+    await pm._handle_message(
+        ws,
+        json.dumps(
+            {
+                "type": "event",
+                "event": {
+                    "c": {"sensor.current_power": {"+": {"lu": 1000.0}}},
+                },
+            }
+        ),
+    )
+    await waiter  # would raise TimeoutError if state_reported didn't wake it
+
+
+async def test_state_reported_before_initial_state_is_ignored():
+    """If a state_reported keepalive arrives before any state value, the
+    entity must remain ``None`` — we cannot claim liveness for an entity
+    we have never received a value for.
+    """
+    clock = _FakeClock()
+    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
+    ws = AsyncMock()
+    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
+    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    await pm._handle_message(
+        ws,
+        json.dumps(
+            {
+                "id": pm._subscribe_entities_id,
+                "type": "event",
+                "event": {
+                    "c": {"sensor.current_power": {"+": {"lu": 1000.0}}},
+                },
+            }
+        ),
+    )
+    assert pm._entity_values.get("sensor.current_power") is None
+    assert pm._entity_update_time.get("sensor.current_power") is None
+
+
 async def test_max_state_age_zero_disables_check():
     clock = _FakeClock()
     pm = _create_powermeter(max_state_age_seconds=0.0, clock=clock)

--- a/src/astrameter/powermeter/homeassistant_test.py
+++ b/src/astrameter/powermeter/homeassistant_test.py
@@ -1,5 +1,7 @@
 import asyncio
 import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -689,3 +691,288 @@ async def test_reconnect_clears_entity_update_times_and_ready_flag():
     )
     assert pm._entities_ready.is_set()
     assert await pm.get_powermeter_watts() == [250.0]
+
+
+# --- REST fallback for state_reported -------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status: int, data: Any) -> None:
+        self.status = status
+        self._data = data
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+    async def json(self) -> Any:
+        return self._data
+
+
+class _FakeSession:
+    """Minimal stand-in for ``aiohttp.ClientSession`` covering ``get``."""
+
+    def __init__(self) -> None:
+        self.responses: dict[str, _FakeResponse | Exception] = {}
+        self.requested: list[str] = []
+        self.delay: float = 0.0
+
+    def set_state(
+        self,
+        url: str,
+        *,
+        state: str,
+        last_reported: datetime | None,
+        status: int = 200,
+    ) -> None:
+        payload: dict[str, Any] = {"state": state}
+        if last_reported is not None:
+            payload["last_reported"] = last_reported.isoformat()
+        self.responses[url] = _FakeResponse(status, payload)
+
+    def set_error(self, url: str, exc: Exception) -> None:
+        self.responses[url] = exc
+
+    def get(
+        self, url: str, headers: dict[str, str] | None = None
+    ) -> "_DelayedResponse":
+        return _DelayedResponse(self, url)
+
+
+class _DelayedResponse:
+    """Awaitable context manager that records the URL and may sleep."""
+
+    def __init__(self, session: _FakeSession, url: str) -> None:
+        self._session = session
+        self._url = url
+
+    async def __aenter__(self) -> _FakeResponse:
+        self._session.requested.append(self._url)
+        if self._session.delay:
+            await asyncio.sleep(self._session.delay)
+        entry = self._session.responses.get(self._url)
+        if isinstance(entry, Exception):
+            raise entry
+        if entry is None:
+            return _FakeResponse(404, {})
+        return entry
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+def _state_url(pm: HomeAssistant, entity_id: str) -> str:
+    return pm._build_rest_state_url(entity_id)
+
+
+async def test_rest_fallback_refreshes_stale_entity_via_last_reported():
+    """Regression for issue #363: a sensor whose value is constant (e.g.
+    solar production on an unloaded phase) produces no ``state_changed``
+    pushes, so the local push timer drifts past ``max_state_age_seconds``
+    even though HA itself is current. ``get_powermeter_watts`` must REST-
+    poll ``/api/states/{entity}`` and use HA's authoritative
+    ``last_reported`` to confirm freshness.
+    """
+    clock = _FakeClock(start=10_000.0)
+    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
+    session = _FakeSession()
+    pm._session = session  # type: ignore[assignment]
+
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
+    )
+    clock.advance(45.0)
+    session.set_state(
+        _state_url(pm, "sensor.current_power"),
+        state="0",
+        last_reported=datetime.now(timezone.utc),
+    )
+
+    assert await pm.get_powermeter_watts() == [0.0]
+    assert session.requested == [_state_url(pm, "sensor.current_power")]
+
+
+async def test_rest_fallback_raises_when_ha_last_reported_is_truly_stale():
+    """If HA's own ``last_reported`` is older than the staleness window
+    (the sensor's source has actually gone silent), don't refresh the
+    local cache — let the staleness check raise.
+    """
+    clock = _FakeClock(start=10_000.0)
+    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
+    session = _FakeSession()
+    pm._session = session  # type: ignore[assignment]
+
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
+    )
+    clock.advance(45.0)
+    session.set_state(
+        _state_url(pm, "sensor.current_power"),
+        state="0",
+        last_reported=datetime.now(timezone.utc) - timedelta(minutes=5),
+    )
+
+    with pytest.raises(ValueError, match="stale"):
+        await pm.get_powermeter_watts()
+
+
+async def test_rest_fallback_only_polls_stale_entities():
+    """Fresh entities must not be re-fetched — only those past the local
+    push threshold.
+    """
+    clock = _FakeClock(start=10_000.0)
+    pm = _create_powermeter(
+        power_calculate=True,
+        power_input_alias=["sensor.in_a", "sensor.in_b"],
+        power_output_alias=["sensor.out_a", "sensor.out_b"],
+        max_state_age_seconds=30.0,
+        clock=clock,
+    )
+    session = _FakeSession()
+    pm._session = session  # type: ignore[assignment]
+
+    await _simulate_auth_and_states(
+        pm,
+        [
+            {"entity_id": "sensor.in_a", "state": "100"},
+            {"entity_id": "sensor.in_b", "state": "200"},
+            {"entity_id": "sensor.out_a", "state": "0"},
+            {"entity_id": "sensor.out_b", "state": "50"},
+        ],
+    )
+
+    # Only sensor.out_a stays silent; the other three get fresh pushes.
+    clock.advance(20.0)
+    await pm._handle_message(
+        AsyncMock(),
+        json.dumps(
+            {
+                "type": "event",
+                "event": {
+                    "c": {
+                        "sensor.in_a": {"+": {"s": "110"}},
+                        "sensor.in_b": {"+": {"s": "210"}},
+                        "sensor.out_b": {"+": {"s": "60"}},
+                    }
+                },
+            }
+        ),
+    )
+    clock.advance(20.0)  # in_*/out_b: 20 s ago; out_a: 40 s ago
+
+    session.set_state(
+        _state_url(pm, "sensor.out_a"),
+        state="0",
+        last_reported=datetime.now(timezone.utc),
+    )
+
+    await pm.get_powermeter_watts()
+    assert session.requested == [_state_url(pm, "sensor.out_a")]
+
+
+async def test_rest_fallback_bounded_by_timeout():
+    """The REST fallback budget is total wall-clock across all stale
+    entities, not per-entity. If the network is slow enough that the
+    deadline expires before any response, the local cache is left
+    unrefreshed and the subsequent staleness check raises.
+    """
+    clock = _FakeClock(start=10_000.0)
+    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
+    session = _FakeSession()
+    session.delay = 5.0  # well past the budget
+    pm._session = session  # type: ignore[assignment]
+
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
+    )
+    clock.advance(45.0)
+    session.set_state(
+        _state_url(pm, "sensor.current_power"),
+        state="0",
+        last_reported=datetime.now(timezone.utc),
+    )
+
+    start = asyncio.get_event_loop().time()
+    await pm._refresh_stale_via_rest(timeout=0.05)
+    elapsed = asyncio.get_event_loop().time() - start
+    # Bounded by ~0.05 s — definitely well under the response's 5 s delay.
+    assert elapsed < 0.5
+    # Cache wasn't refreshed (response never returned), so the staleness
+    # check still raises with the original error.
+    with pytest.raises(ValueError, match="stale"):
+        await pm._refresh_stale_via_rest(timeout=0.05)
+        # Don't call get_powermeter_watts here — it would re-trigger
+        # the (slow) refresh with the default 1 s budget.
+        pm._get_entity_value("sensor.current_power")
+
+
+async def test_rest_fallback_ignores_unavailable_state():
+    """``state: "unavailable"`` (or "unknown") from REST is not a fresh
+    value — leave the local cache stale and raise.
+    """
+    clock = _FakeClock(start=10_000.0)
+    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
+    session = _FakeSession()
+    pm._session = session  # type: ignore[assignment]
+
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
+    )
+    clock.advance(45.0)
+    session.set_state(
+        _state_url(pm, "sensor.current_power"),
+        state="unavailable",
+        last_reported=datetime.now(timezone.utc),
+    )
+
+    with pytest.raises(ValueError, match="stale"):
+        await pm.get_powermeter_watts()
+
+
+async def test_rest_fallback_swallows_http_errors():
+    """Network/HTTP errors during the REST fallback must not propagate —
+    the staleness check raises with the original "stale" message instead,
+    so the caller's exception handling stays simple.
+    """
+    clock = _FakeClock(start=10_000.0)
+    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
+    session = _FakeSession()
+    pm._session = session  # type: ignore[assignment]
+    import aiohttp  # local import: only this test needs the type
+
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
+    )
+    clock.advance(45.0)
+    session.set_error(
+        _state_url(pm, "sensor.current_power"),
+        aiohttp.ClientConnectionError("boom"),
+    )
+
+    with pytest.raises(ValueError, match="stale"):
+        await pm.get_powermeter_watts()
+
+
+async def test_rest_fallback_url_respects_path_prefix_and_scheme():
+    pm = _create_powermeter(
+        ip="example.test",
+        port="8123",
+        use_https=True,
+        path_prefix="/core",
+    )
+    assert (
+        pm._build_rest_state_url("sensor.foo")
+        == "https://example.test:8123/core/api/states/sensor.foo"
+    )
+
+
+async def test_rest_fallback_noop_when_no_session():
+    """Without a live session (no ``start()``), the REST refresh is a
+    silent no-op so unit tests that drive the WebSocket handlers directly
+    don't accidentally hit the network.
+    """
+    pm = _create_powermeter(max_state_age_seconds=30.0, clock=_FakeClock())
+    # _session is None by default.
+    await pm._refresh_stale_via_rest()  # must not raise

--- a/src/astrameter/powermeter/homeassistant_test.py
+++ b/src/astrameter/powermeter/homeassistant_test.py
@@ -955,6 +955,57 @@ async def test_rest_fallback_swallows_http_errors():
         await pm.get_powermeter_watts()
 
 
+async def test_rest_fallback_does_not_clobber_concurrent_websocket_push():
+    """If a websocket push lands while a REST refresh for the same entity
+    is in flight, the WS value (which is at least as fresh as anything
+    REST can return) must win — REST must not overwrite it.
+    """
+    clock = _FakeClock(start=10_000.0)
+    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
+    session = _FakeSession()
+    pm._session = session  # type: ignore[assignment]
+
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
+    )
+    clock.advance(45.0)  # entity is now locally stale
+
+    # REST response advertises a fresh last_reported, but a websocket
+    # push will arrive while the REST round-trip is in flight.
+    session.delay = 0.05
+    session.set_state(
+        _state_url(pm, "sensor.current_power"),
+        state="0",
+        last_reported=datetime.now(timezone.utc),
+    )
+
+    refresh_task = asyncio.create_task(pm._refresh_stale_via_rest(timeout=1.0))
+    # Spin until _fetch_rest_state has snapshotted pre_update and is
+    # parked inside the FakeSession's delay (URL recorded).
+    for _ in range(50):
+        if session.requested:
+            break
+        await asyncio.sleep(0)
+    assert session.requested, "REST request did not start"
+    # Concurrent WS push with a different value.
+    await pm._handle_message(
+        AsyncMock(),
+        json.dumps(
+            {
+                "type": "event",
+                "event": {
+                    "c": {"sensor.current_power": {"+": {"s": "123"}}},
+                },
+            }
+        ),
+    )
+    await refresh_task
+
+    # REST returned "0" but the WS push of 123 happened during the
+    # round-trip; the guard must skip the REST apply.
+    assert pm._entity_values["sensor.current_power"] == 123.0
+
+
 async def test_rest_fallback_url_respects_path_prefix_and_scheme():
     pm = _create_powermeter(
         ip="example.test",


### PR DESCRIPTION
https://claude.ai/code/session_01LwA9fBRZcLjRi7fEU4fHyw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Home Assistant sensors being falsely reported as stale when values remain unchanged (e.g., solar production at night). The system now better handles entity freshness tracking and includes a fallback mechanism to verify sensor status.

* **Tests**
  * Expanded test coverage for stale sensor detection and freshness validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/AstraMeter/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->