### PR TITLE
Drop Home Assistant per-entity staleness check (delegate to integration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** Home Assistant sensors falsely reported as stale when their value doesn't change for a while (e.g. solar production on an unloaded phase, or at night) ([#363](https://github.com/tomquist/astrameter/issues/363)).
+- **Fixed** false "Home Assistant sensor is stale" errors for sensors that update infrequently or push only on value changes — including constant readings (e.g. solar production at night) and push-based integrations. The Home Assistant powermeter now treats a sensor as stale only when Home Assistant itself marks it `unavailable`/`unknown` or the websocket connection is lost ([#363](https://github.com/tomquist/astrameter/issues/363)).
 
 ## 2.0.0
 

--- a/src/astrameter/powermeter/homeassistant.py
+++ b/src/astrameter/powermeter/homeassistant.py
@@ -56,6 +56,13 @@ class HomeAssistant(Powermeter):
         )
         self.path_prefix = path_prefix
 
+        if self.power_calculate and len(self.power_input_alias) != len(
+            self.power_output_alias
+        ):
+            raise ValueError(
+                "Home Assistant power_input_alias and power_output_alias lengths differ"
+            )
+
         # ``None`` = no usable value (never received, or the integration
         # reported ``unavailable`` / ``unknown``). Freshness is owned by
         # the integration: it sets sensors to ``unavailable`` when its
@@ -255,10 +262,6 @@ class HomeAssistant(Powermeter):
             return [
                 self._get_entity_value(entity) for entity in self.current_power_entity
             ]
-        if len(self.power_input_alias) != len(self.power_output_alias):
-            raise ValueError(
-                "Home Assistant power_input_alias and power_output_alias lengths differ"
-            )
         results = []
         for in_entity, out_entity in zip(
             self.power_input_alias, self.power_output_alias, strict=False

--- a/src/astrameter/powermeter/homeassistant.py
+++ b/src/astrameter/powermeter/homeassistant.py
@@ -2,9 +2,6 @@ import asyncio
 import contextlib
 import json
 import logging
-import time
-from collections.abc import Callable
-from datetime import datetime, timezone
 from typing import Any
 
 import aiohttp
@@ -23,22 +20,6 @@ _HA_DIFF_ADD = "+"
 # WebSocket heartbeat (seconds) — same rationale as HomeWizard.
 WS_HEARTBEAT_SECONDS = 30.0
 
-# An entity older than this is considered stale by the local push timer.
-# Crossing this threshold triggers the REST fallback (see below), not an
-# immediate error: HA's ``subscribe_entities`` only forwards
-# ``state_changed`` events, so a sensor with a constant value (e.g. solar
-# production on an unloaded phase) produces no pushes even when HA itself
-# is up to date.
-DEFAULT_MAX_STATE_AGE_SECONDS = 60.0
-
-# Total wall-clock budget for the REST staleness fallback. When local push
-# silence exceeds ``max_state_age_seconds`` for any tracked entity, we
-# fan out parallel ``GET /api/states/{entity}`` requests bounded by this
-# deadline; HA returns ``last_reported`` (mutated on every state write,
-# including same-value reports), which we use as the authoritative
-# freshness signal. Bounded so a battery's UDP request never stalls.
-REST_REFRESH_TIMEOUT_SECONDS = 1.0
-
 
 class HomeAssistant(Powermeter):
     def __init__(
@@ -52,9 +33,6 @@ class HomeAssistant(Powermeter):
         power_input_alias: str | list[str],
         power_output_alias: str | list[str],
         path_prefix: str | None,
-        *,
-        max_state_age_seconds: float = DEFAULT_MAX_STATE_AGE_SECONDS,
-        clock: Callable[[], float] | None = None,
     ):
         self.ip = ip
         self.port = port
@@ -77,13 +55,14 @@ class HomeAssistant(Powermeter):
             else power_output_alias
         )
         self.path_prefix = path_prefix
-        self._max_state_age_seconds = max(0.0, max_state_age_seconds)
-        self._clock = clock or time.monotonic
 
+        # ``None`` = no usable value (never received, or the integration
+        # reported ``unavailable`` / ``unknown``). Freshness is owned by
+        # the integration: it sets sensors to ``unavailable`` when its
+        # upstream source dies, and aiohttp's websocket heartbeat catches
+        # a dead TCP connection on our side. A constant numeric value is
+        # therefore legitimate and must not be treated as stale.
         self._entity_values: dict[str, float | None] = {}
-        # Per-entity timestamp of the most recent state update, used
-        # for staleness detection (None = never received).
-        self._entity_update_time: dict[str, float | None] = {}
         self._tracked_entities = self._collect_entities()
         self._msg_id = 0
         self._subscribe_entities_id: int | None = None
@@ -103,11 +82,6 @@ class HomeAssistant(Powermeter):
         scheme = "wss" if self.use_https else "ws"
         prefix = self.path_prefix or ""
         return f"{scheme}://{self.ip}:{self.port}{prefix}/api/websocket"
-
-    def _build_rest_state_url(self, entity_id: str) -> str:
-        scheme = "https" if self.use_https else "http"
-        prefix = self.path_prefix or ""
-        return f"{scheme}://{self.ip}:{self.port}{prefix}/api/states/{entity_id}"
 
     def _next_id(self) -> int:
         self._msg_id += 1
@@ -153,19 +127,14 @@ class HomeAssistant(Powermeter):
                 raise
             except Exception as e:
                 logger.error("Home Assistant WebSocket error: %s", e, exc_info=True)
-            # Reset protocol state for reconnection; keep _entity_values
-            # as a courtesy, but mark them all stale so the staleness
-            # check in _get_entity_value falls back to REST (or raises)
-            # until fresh state pushes arrive from the reconnect.
-            # ``_entities_ready`` must also clear, otherwise
-            # ``wait_for_message()`` would return immediately for any
-            # caller relying on it as a readiness signal even though
-            # every entity is effectively stale until the next
-            # ``subscribe_entities`` snapshot.
+            # Reset protocol state and invalidate cached values so
+            # ``get_powermeter_watts`` raises (and ``wait_for_message``
+            # blocks) until the reconnected ``subscribe_entities``
+            # snapshot repopulates them.
             self._msg_id = 0
             self._subscribe_entities_id = None
-            for eid in list(self._entity_update_time):
-                self._entity_update_time[eid] = None
+            for eid in list(self._entity_values):
+                self._entity_values[eid] = None
             self._entities_ready.clear()
             await asyncio.sleep(5)
 
@@ -190,13 +159,13 @@ class HomeAssistant(Powermeter):
                     continue
                 if _HA_S in plus:
                     self._update_entity_value(eid, plus.get(_HA_S))
-                elif _HA_LU in plus or _HA_LC in plus:
-                    # state_reported (value unchanged): HA omits ``s`` and
-                    # sends only ``lu``. Treat as a keepalive so the
-                    # staleness check does not fire on sensors whose value
-                    # is legitimately constant (e.g. solar production at
-                    # night, an unloaded phase).
-                    self._mark_entity_alive(eid)
+                elif (_HA_LU in plus or _HA_LC in plus) and self._entity_values.get(
+                    eid
+                ) is not None:
+                    # state_reported (value unchanged) — wake
+                    # ``wait_for_next_message`` so callers don't time
+                    # out waiting for a push on a constant sensor.
+                    self._message_event.set()
         removals = ev.get("r")
         if isinstance(removals, list):
             for eid in removals:
@@ -248,177 +217,52 @@ class HomeAssistant(Powermeter):
         logger.debug(f"Home Assistant: update_entity_value: {entity_id}, {state_val}")
         if state_val is None:
             self._entity_values[entity_id] = None
-            self._entity_update_time[entity_id] = None
             self._check_entities_ready()
             return
         try:
-            value = float(state_val)  # type: ignore[arg-type]
-            self._entity_values[entity_id] = value
-            self._entity_update_time[entity_id] = self._clock()
+            self._entity_values[entity_id] = float(state_val)  # type: ignore[arg-type]
         except (ValueError, TypeError):
+            # ``unavailable`` / ``unknown`` (or any non-numeric state) —
+            # the integration is telling us the value isn't usable.
             logger.warning(
                 f"Home Assistant sensor {entity_id} state '{state_val}' is not numeric"
             )
             self._entity_values[entity_id] = None
-            self._entity_update_time[entity_id] = None
         self._check_entities_ready()
-        self._message_event.set()
-
-    def _mark_entity_alive(self, entity_id: str) -> None:
-        if self._entity_values.get(entity_id) is None:
-            return
-        self._entity_update_time[entity_id] = self._clock()
         self._message_event.set()
 
     def _check_entities_ready(self) -> None:
         ready = all(
-            self._entity_values.get(e) is not None
-            and self._entity_update_time.get(e) is not None
-            for e in self._tracked_entities
+            self._entity_values.get(e) is not None for e in self._tracked_entities
         )
         if ready:
             self._entities_ready.set()
         else:
             self._entities_ready.clear()
 
-    def _locally_stale_entities(self) -> list[str]:
-        if self._max_state_age_seconds <= 0:
-            return []
-        now = self._clock()
-        stale: list[str] = []
-        for eid in self._tracked_entities:
-            if self._entity_values.get(eid) is None:
-                stale.append(eid)
-                continue
-            last = self._entity_update_time.get(eid)
-            if last is None or (now - last) > self._max_state_age_seconds:
-                stale.append(eid)
-        return stale
-
-    async def _refresh_stale_via_rest(
-        self, timeout: float = REST_REFRESH_TIMEOUT_SECONDS
-    ) -> None:
-        """REST-poll any entity whose local push timer has crossed the
-        staleness threshold, bounded by ``timeout`` total wall-clock.
-
-        ``subscribe_entities`` only forwards ``state_changed``; sensors with
-        a constant value (e.g. solar production on an unloaded phase) never
-        push, so the per-entity timer is not a reliable freshness signal.
-        ``GET /api/states/{eid}`` returns HA's ``last_reported``, which is
-        mutated on every state write — including same-value reports — and
-        is the authoritative source of truth.
-        """
-        if self._session is None:
-            return
-        stale = self._locally_stale_entities()
-        if not stale:
-            return
-        # Whatever finishes in-budget is already applied; anything still
-        # stale after the timeout will be caught by ``_get_entity_value``.
-        with contextlib.suppress(asyncio.TimeoutError):
-            await asyncio.wait_for(
-                asyncio.gather(
-                    *(self._fetch_rest_state(eid) for eid in stale),
-                    return_exceptions=True,
-                ),
-                timeout=timeout,
-            )
-
-    async def _fetch_rest_state(self, entity_id: str) -> None:
-        assert self._session is not None
-        # Snapshot the local update time so we can detect a concurrent
-        # websocket push (or another in-flight REST refresh) and avoid
-        # clobbering newer data with a potentially-older REST response.
-        pre_update = self._entity_update_time.get(entity_id)
-        url = self._build_rest_state_url(entity_id)
-        headers = {"Authorization": f"Bearer {self.access_token}"}
-        try:
-            async with self._session.get(url, headers=headers) as resp:
-                if resp.status != 200:
-                    logger.debug(
-                        "Home Assistant REST refresh for %s: HTTP %s",
-                        entity_id,
-                        resp.status,
-                    )
-                    return
-                data = await resp.json()
-        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
-            logger.debug(
-                "Home Assistant REST refresh for %s failed: %s", entity_id, exc
-            )
-            return
-        if self._entity_update_time.get(entity_id) != pre_update:
-            return
-        if isinstance(data, dict):
-            self._apply_rest_state(entity_id, data)
-
-    def _apply_rest_state(self, entity_id: str, data: dict[str, Any]) -> None:
-        state_val = data.get("state")
-        if state_val in (None, "unknown", "unavailable"):
-            return
-        try:
-            value = float(state_val)  # type: ignore[arg-type]
-        except (ValueError, TypeError):
-            return
-        # Trust HA's ``last_reported`` (mutated on every state write).
-        # If HA itself hasn't seen an update within the staleness window,
-        # don't refresh local cache — let the staleness check raise.
-        if self._max_state_age_seconds > 0:
-            reported_iso = data.get("last_reported") or data.get("last_updated")
-            if not isinstance(reported_iso, str):
-                return
-            try:
-                reported_dt = datetime.fromisoformat(reported_iso)
-            except ValueError:
-                return
-            if reported_dt.tzinfo is None:
-                reported_dt = reported_dt.replace(tzinfo=timezone.utc)
-            ha_age = (datetime.now(timezone.utc) - reported_dt).total_seconds()
-            if ha_age > self._max_state_age_seconds:
-                return
-        self._entity_values[entity_id] = value
-        self._entity_update_time[entity_id] = self._clock()
-        self._check_entities_ready()
-        self._message_event.set()
-
     def _get_entity_value(self, entity_id: str) -> float:
         val = self._entity_values.get(entity_id)
         if val is None:
             raise ValueError(f"Home Assistant sensor {entity_id} has no state")
-        if self._max_state_age_seconds > 0:
-            last = self._entity_update_time.get(entity_id)
-            if last is None:
-                raise ValueError(
-                    f"Home Assistant sensor {entity_id} has no update timestamp"
-                )
-            age = self._clock() - last
-            if age > self._max_state_age_seconds:
-                raise ValueError(
-                    f"Home Assistant sensor {entity_id} is stale "
-                    f"({age:.1f}s old, max {self._max_state_age_seconds:.1f}s)"
-                )
         return val
 
     async def get_powermeter_watts(self) -> list[float]:
-        await self._refresh_stale_via_rest()
         if not self.power_calculate:
             return [
                 self._get_entity_value(entity) for entity in self.current_power_entity
             ]
-        else:
-            if len(self.power_input_alias) != len(self.power_output_alias):
-                raise ValueError(
-                    "Home Assistant power_input_alias and"
-                    " power_output_alias lengths differ"
-                )
-            results = []
-            for in_entity, out_entity in zip(
-                self.power_input_alias, self.power_output_alias, strict=False
-            ):
-                power_in = self._get_entity_value(in_entity)
-                power_out = self._get_entity_value(out_entity)
-                results.append(power_in - power_out)
-            return results
+        if len(self.power_input_alias) != len(self.power_output_alias):
+            raise ValueError(
+                "Home Assistant power_input_alias and power_output_alias lengths differ"
+            )
+        results = []
+        for in_entity, out_entity in zip(
+            self.power_input_alias, self.power_output_alias, strict=False
+        ):
+            power_in = self._get_entity_value(in_entity)
+            power_out = self._get_entity_value(out_entity)
+            results.append(power_in - power_out)
+        return results
 
     async def wait_for_message(self, timeout: float = 5) -> None:
         try:

--- a/src/astrameter/powermeter/homeassistant.py
+++ b/src/astrameter/powermeter/homeassistant.py
@@ -127,16 +127,20 @@ class HomeAssistant(Powermeter):
                 raise
             except Exception as e:
                 logger.error("Home Assistant WebSocket error: %s", e, exc_info=True)
-            # Reset protocol state and invalidate cached values so
-            # ``get_powermeter_watts`` raises (and ``wait_for_message``
-            # blocks) until the reconnected ``subscribe_entities``
-            # snapshot repopulates them.
-            self._msg_id = 0
-            self._subscribe_entities_id = None
-            for eid in list(self._entity_values):
-                self._entity_values[eid] = None
-            self._entities_ready.clear()
+            self._reset_for_reconnect()
             await asyncio.sleep(5)
+
+    def _reset_for_reconnect(self) -> None:
+        """Reset protocol state and invalidate cached values so
+        ``get_powermeter_watts`` raises (and ``wait_for_message`` blocks)
+        until the reconnected ``subscribe_entities`` snapshot repopulates
+        them.
+        """
+        self._msg_id = 0
+        self._subscribe_entities_id = None
+        for eid in list(self._entity_values):
+            self._entity_values[eid] = None
+        self._entities_ready.clear()
 
     def _handle_compressed_entity_event(self, ev: dict[str, Any]) -> None:
         """Apply subscribe_entities payloads (initial + diffs)."""

--- a/src/astrameter/powermeter/homeassistant_test.py
+++ b/src/astrameter/powermeter/homeassistant_test.py
@@ -300,24 +300,16 @@ async def test_three_phase_calculated():
 
 
 async def test_power_alias_length_mismatch():
-    pm = _create_powermeter(
-        current_power_entity="",
-        power_calculate=True,
-        power_input_alias=["sensor.power_in_1", "sensor.power_in_2"],
-        power_output_alias=["sensor.power_out_1"],
-    )
-    await _simulate_auth_and_states(
-        pm,
-        [
-            {"entity_id": "sensor.power_in_1", "state": "100"},
-            {"entity_id": "sensor.power_in_2", "state": "200"},
-            {"entity_id": "sensor.power_out_1", "state": "50"},
-        ],
-    )
-
+    """A static config invariant — fail fast at construction rather than
+    on every ``get_powermeter_watts`` call.
+    """
     with pytest.raises(ValueError) as exc_info:
-        await pm.get_powermeter_watts()
-
+        _create_powermeter(
+            current_power_entity="",
+            power_calculate=True,
+            power_input_alias=["sensor.power_in_1", "sensor.power_in_2"],
+            power_output_alias=["sensor.power_out_1"],
+        )
     assert (
         str(exc_info.value)
         == "Home Assistant power_input_alias and power_output_alias lengths differ"

--- a/src/astrameter/powermeter/homeassistant_test.py
+++ b/src/astrameter/powermeter/homeassistant_test.py
@@ -1,7 +1,5 @@
 import asyncio
 import json
-from datetime import datetime, timedelta, timezone
-from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -489,116 +487,15 @@ async def test_entities_ready_cleared_when_value_becomes_none():
     assert not pm._entities_ready.is_set()
 
 
-# --- Staleness detection ---------------------------------------------------
+# --- state_reported and reconnect behavior --------------------------------
 
 
-class _FakeClock:
-    def __init__(self, start: float = 0.0) -> None:
-        self.now = start
-
-    def __call__(self) -> float:
-        return self.now
-
-    def advance(self, seconds: float) -> None:
-        self.now += seconds
-
-
-async def test_stale_state_raises_in_get_powermeter_watts():
-    """Regression: if the websocket feed goes silent (half-open TCP or
-    stuck template sensor) the cached state age crosses
-    ``max_state_age_seconds`` and :meth:`get_powermeter_watts` must
-    raise instead of silently serving the frozen value.
-    """
-    clock = _FakeClock()
-    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
-    await _simulate_auth_and_states(
-        pm, [{"entity_id": "sensor.current_power", "state": "100"}]
-    )
-    assert await pm.get_powermeter_watts() == [100.0]
-
-    clock.advance(29.0)
-    assert await pm.get_powermeter_watts() == [100.0]
-
-    clock.advance(2.0)
-    with pytest.raises(ValueError, match="stale"):
-        await pm.get_powermeter_watts()
-
-
-async def test_fresh_state_clears_staleness():
-    clock = _FakeClock()
-    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
-    await _simulate_auth_and_states(
-        pm, [{"entity_id": "sensor.current_power", "state": "100"}]
-    )
-    clock.advance(50.0)
-    with pytest.raises(ValueError, match="stale"):
-        await pm.get_powermeter_watts()
-
-    ws = AsyncMock()
-    await pm._handle_message(
-        ws,
-        json.dumps(
-            {
-                "type": "event",
-                "event": {
-                    "c": {
-                        "sensor.current_power": {
-                            "+": {"s": "250"},
-                        }
-                    }
-                },
-            }
-        ),
-    )
-    assert await pm.get_powermeter_watts() == [250.0]
-
-
-async def test_state_reported_event_refreshes_staleness():
-    """Regression for issue #363: HA's ``subscribe_entities`` only includes
-    ``s`` in the diff when the state value actually changes. For sensors
-    whose value stays constant (e.g. solar production on an unused phase)
-    HA still pushes state_reported events, but their compressed diff only
-    carries an updated ``lu`` (last_updated timestamp). Treat those as
-    keepalives so the staleness check does not falsely fire on legitimately
-    constant sensors.
-    """
-    clock = _FakeClock()
-    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
-    await _simulate_auth_and_states(
-        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
-    )
-    assert await pm.get_powermeter_watts() == [0.0]
-
-    # 29 s in, an integration push reports the same value. HA emits a
-    # state_reported diff with only ``lu`` populated.
-    clock.advance(29.0)
-    ws = AsyncMock()
-    await pm._handle_message(
-        ws,
-        json.dumps(
-            {
-                "type": "event",
-                "event": {
-                    "c": {"sensor.current_power": {"+": {"lu": 1000.0}}},
-                },
-            }
-        ),
-    )
-
-    # The keepalive refreshed liveness; another 29 s should still be fresh.
-    clock.advance(29.0)
-    assert await pm.get_powermeter_watts() == [0.0]
-
-    # But continued silence past the threshold still trips staleness.
-    clock.advance(2.0)
-    with pytest.raises(ValueError, match="stale"):
-        await pm.get_powermeter_watts()
-
-
-async def test_state_reported_event_sets_message_event():
-    """``wait_for_next_message`` must wake on state_reported keepalives —
-    otherwise the Shelly / CT002 emulator's per-request fresh-push wait
-    times out for sensors whose value doesn't change between polls.
+async def test_state_reported_event_wakes_wait_for_next_message():
+    """HA's ``subscribe_entities`` omits ``s`` from the diff when a sensor
+    is reported with an unchanged value (only ``lu``/``lc`` updates).
+    ``wait_for_next_message`` must still wake on those so callers like the
+    Shelly emulator don't time out on constant sensors that the
+    integration is still actively reporting.
     """
     pm = _create_powermeter()
     await _simulate_auth_and_states(
@@ -623,16 +520,16 @@ async def test_state_reported_event_sets_message_event():
     await waiter  # would raise TimeoutError if state_reported didn't wake it
 
 
-async def test_state_reported_before_initial_state_is_ignored():
-    """If a state_reported keepalive arrives before any state value, the
-    entity must remain ``None`` — we cannot claim liveness for an entity
-    we have never received a value for.
+async def test_state_reported_before_initial_value_is_ignored():
+    """A bare ``lu``/``lc`` keepalive that arrives before any state value
+    must not wake ``wait_for_next_message`` — there is no usable value
+    yet, so claiming the sensor is alive would be misleading.
     """
-    clock = _FakeClock()
-    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
+    pm = _create_powermeter()
     ws = AsyncMock()
     await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
     await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    pm._message_event.clear()
     await pm._handle_message(
         ws,
         json.dumps(
@@ -646,384 +543,36 @@ async def test_state_reported_before_initial_state_is_ignored():
         ),
     )
     assert pm._entity_values.get("sensor.current_power") is None
-    assert pm._entity_update_time.get("sensor.current_power") is None
+    assert not pm._message_event.is_set()
 
 
-async def test_max_state_age_zero_disables_check():
-    clock = _FakeClock()
-    pm = _create_powermeter(max_state_age_seconds=0.0, clock=clock)
-    await _simulate_auth_and_states(
-        pm, [{"entity_id": "sensor.current_power", "state": "100"}]
-    )
-    clock.advance(100000.0)
-    assert await pm.get_powermeter_watts() == [100.0]
-
-
-async def test_reconnect_clears_entity_update_times_and_ready_flag():
-    """A websocket disconnect must clear the entity update times and
-    the ``_entities_ready`` event, so ``get_powermeter_watts`` raises
-    and ``wait_for_message`` blocks again until fresh state arrives
-    from the reconnect's ``subscribe_entities`` snapshot.
+async def test_reconnect_invalidates_cached_values():
+    """A websocket disconnect must invalidate cached values and clear the
+    ready flag, so ``get_powermeter_watts`` raises and
+    ``wait_for_message`` blocks again until the reconnected
+    ``subscribe_entities`` snapshot arrives. Without this, callers would
+    serve potentially-old values for the duration of the reconnect.
     """
-    clock = _FakeClock()
-    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
+    pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "100"}]
     )
     assert pm._entities_ready.is_set()
     assert await pm.get_powermeter_watts() == [100.0]
 
-    # Simulate exactly what ``_ws_loop`` does in its reconnect block.
+    # Simulate the reset block in ``_ws_loop`` after a disconnect.
     pm._msg_id = 0
     pm._subscribe_entities_id = None
-    for eid in list(pm._entity_update_time):
-        pm._entity_update_time[eid] = None
+    for eid in list(pm._entity_values):
+        pm._entity_values[eid] = None
     pm._entities_ready.clear()
 
     assert not pm._entities_ready.is_set()
     with pytest.raises(ValueError):
         await pm.get_powermeter_watts()
 
-    # Fresh state arrives from the reconnected subscribe_entities
-    # snapshot — both signals recover.
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "250"}]
     )
     assert pm._entities_ready.is_set()
     assert await pm.get_powermeter_watts() == [250.0]
-
-
-# --- REST fallback for state_reported -------------------------------------
-
-
-class _FakeResponse:
-    def __init__(self, status: int, data: Any) -> None:
-        self.status = status
-        self._data = data
-
-    async def __aenter__(self) -> "_FakeResponse":
-        return self
-
-    async def __aexit__(self, *_: object) -> None:
-        return None
-
-    async def json(self) -> Any:
-        return self._data
-
-
-class _FakeSession:
-    """Minimal stand-in for ``aiohttp.ClientSession`` covering ``get``."""
-
-    def __init__(self) -> None:
-        self.responses: dict[str, _FakeResponse | Exception] = {}
-        self.requested: list[str] = []
-        self.delay: float = 0.0
-
-    def set_state(
-        self,
-        url: str,
-        *,
-        state: str,
-        last_reported: datetime | None,
-        status: int = 200,
-    ) -> None:
-        payload: dict[str, Any] = {"state": state}
-        if last_reported is not None:
-            payload["last_reported"] = last_reported.isoformat()
-        self.responses[url] = _FakeResponse(status, payload)
-
-    def set_error(self, url: str, exc: Exception) -> None:
-        self.responses[url] = exc
-
-    def get(
-        self, url: str, headers: dict[str, str] | None = None
-    ) -> "_DelayedResponse":
-        return _DelayedResponse(self, url)
-
-
-class _DelayedResponse:
-    """Awaitable context manager that records the URL and may sleep."""
-
-    def __init__(self, session: _FakeSession, url: str) -> None:
-        self._session = session
-        self._url = url
-
-    async def __aenter__(self) -> _FakeResponse:
-        self._session.requested.append(self._url)
-        if self._session.delay:
-            await asyncio.sleep(self._session.delay)
-        entry = self._session.responses.get(self._url)
-        if isinstance(entry, Exception):
-            raise entry
-        if entry is None:
-            return _FakeResponse(404, {})
-        return entry
-
-    async def __aexit__(self, *_: object) -> None:
-        return None
-
-
-def _state_url(pm: HomeAssistant, entity_id: str) -> str:
-    return pm._build_rest_state_url(entity_id)
-
-
-async def test_rest_fallback_refreshes_stale_entity_via_last_reported():
-    """Regression for issue #363: a sensor whose value is constant (e.g.
-    solar production on an unloaded phase) produces no ``state_changed``
-    pushes, so the local push timer drifts past ``max_state_age_seconds``
-    even though HA itself is current. ``get_powermeter_watts`` must REST-
-    poll ``/api/states/{entity}`` and use HA's authoritative
-    ``last_reported`` to confirm freshness.
-    """
-    clock = _FakeClock(start=10_000.0)
-    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
-    session = _FakeSession()
-    pm._session = session  # type: ignore[assignment]
-
-    await _simulate_auth_and_states(
-        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
-    )
-    clock.advance(45.0)
-    session.set_state(
-        _state_url(pm, "sensor.current_power"),
-        state="0",
-        last_reported=datetime.now(timezone.utc),
-    )
-
-    assert await pm.get_powermeter_watts() == [0.0]
-    assert session.requested == [_state_url(pm, "sensor.current_power")]
-
-
-async def test_rest_fallback_raises_when_ha_last_reported_is_truly_stale():
-    """If HA's own ``last_reported`` is older than the staleness window
-    (the sensor's source has actually gone silent), don't refresh the
-    local cache — let the staleness check raise.
-    """
-    clock = _FakeClock(start=10_000.0)
-    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
-    session = _FakeSession()
-    pm._session = session  # type: ignore[assignment]
-
-    await _simulate_auth_and_states(
-        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
-    )
-    clock.advance(45.0)
-    session.set_state(
-        _state_url(pm, "sensor.current_power"),
-        state="0",
-        last_reported=datetime.now(timezone.utc) - timedelta(minutes=5),
-    )
-
-    with pytest.raises(ValueError, match="stale"):
-        await pm.get_powermeter_watts()
-
-
-async def test_rest_fallback_only_polls_stale_entities():
-    """Fresh entities must not be re-fetched — only those past the local
-    push threshold.
-    """
-    clock = _FakeClock(start=10_000.0)
-    pm = _create_powermeter(
-        power_calculate=True,
-        power_input_alias=["sensor.in_a", "sensor.in_b"],
-        power_output_alias=["sensor.out_a", "sensor.out_b"],
-        max_state_age_seconds=30.0,
-        clock=clock,
-    )
-    session = _FakeSession()
-    pm._session = session  # type: ignore[assignment]
-
-    await _simulate_auth_and_states(
-        pm,
-        [
-            {"entity_id": "sensor.in_a", "state": "100"},
-            {"entity_id": "sensor.in_b", "state": "200"},
-            {"entity_id": "sensor.out_a", "state": "0"},
-            {"entity_id": "sensor.out_b", "state": "50"},
-        ],
-    )
-
-    # Only sensor.out_a stays silent; the other three get fresh pushes.
-    clock.advance(20.0)
-    await pm._handle_message(
-        AsyncMock(),
-        json.dumps(
-            {
-                "type": "event",
-                "event": {
-                    "c": {
-                        "sensor.in_a": {"+": {"s": "110"}},
-                        "sensor.in_b": {"+": {"s": "210"}},
-                        "sensor.out_b": {"+": {"s": "60"}},
-                    }
-                },
-            }
-        ),
-    )
-    clock.advance(20.0)  # in_*/out_b: 20 s ago; out_a: 40 s ago
-
-    session.set_state(
-        _state_url(pm, "sensor.out_a"),
-        state="0",
-        last_reported=datetime.now(timezone.utc),
-    )
-
-    await pm.get_powermeter_watts()
-    assert session.requested == [_state_url(pm, "sensor.out_a")]
-
-
-async def test_rest_fallback_bounded_by_timeout():
-    """The REST fallback budget is total wall-clock across all stale
-    entities, not per-entity. If the network is slow enough that the
-    deadline expires before any response, the local cache is left
-    unrefreshed and the subsequent staleness check raises.
-    """
-    clock = _FakeClock(start=10_000.0)
-    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
-    session = _FakeSession()
-    session.delay = 5.0  # well past the budget
-    pm._session = session  # type: ignore[assignment]
-
-    await _simulate_auth_and_states(
-        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
-    )
-    clock.advance(45.0)
-    session.set_state(
-        _state_url(pm, "sensor.current_power"),
-        state="0",
-        last_reported=datetime.now(timezone.utc),
-    )
-
-    start = asyncio.get_event_loop().time()
-    await pm._refresh_stale_via_rest(timeout=0.05)
-    elapsed = asyncio.get_event_loop().time() - start
-    # Bounded by ~0.05 s — definitely well under the response's 5 s delay.
-    assert elapsed < 0.5
-    # Cache wasn't refreshed (response never returned), so the staleness
-    # check still raises with the original error.
-    with pytest.raises(ValueError, match="stale"):
-        await pm._refresh_stale_via_rest(timeout=0.05)
-        # Don't call get_powermeter_watts here — it would re-trigger
-        # the (slow) refresh with the default 1 s budget.
-        pm._get_entity_value("sensor.current_power")
-
-
-async def test_rest_fallback_ignores_unavailable_state():
-    """``state: "unavailable"`` (or "unknown") from REST is not a fresh
-    value — leave the local cache stale and raise.
-    """
-    clock = _FakeClock(start=10_000.0)
-    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
-    session = _FakeSession()
-    pm._session = session  # type: ignore[assignment]
-
-    await _simulate_auth_and_states(
-        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
-    )
-    clock.advance(45.0)
-    session.set_state(
-        _state_url(pm, "sensor.current_power"),
-        state="unavailable",
-        last_reported=datetime.now(timezone.utc),
-    )
-
-    with pytest.raises(ValueError, match="stale"):
-        await pm.get_powermeter_watts()
-
-
-async def test_rest_fallback_swallows_http_errors():
-    """Network/HTTP errors during the REST fallback must not propagate —
-    the staleness check raises with the original "stale" message instead,
-    so the caller's exception handling stays simple.
-    """
-    clock = _FakeClock(start=10_000.0)
-    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
-    session = _FakeSession()
-    pm._session = session  # type: ignore[assignment]
-    import aiohttp  # local import: only this test needs the type
-
-    await _simulate_auth_and_states(
-        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
-    )
-    clock.advance(45.0)
-    session.set_error(
-        _state_url(pm, "sensor.current_power"),
-        aiohttp.ClientConnectionError("boom"),
-    )
-
-    with pytest.raises(ValueError, match="stale"):
-        await pm.get_powermeter_watts()
-
-
-async def test_rest_fallback_does_not_clobber_concurrent_websocket_push():
-    """If a websocket push lands while a REST refresh for the same entity
-    is in flight, the WS value (which is at least as fresh as anything
-    REST can return) must win — REST must not overwrite it.
-    """
-    clock = _FakeClock(start=10_000.0)
-    pm = _create_powermeter(max_state_age_seconds=30.0, clock=clock)
-    session = _FakeSession()
-    pm._session = session  # type: ignore[assignment]
-
-    await _simulate_auth_and_states(
-        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
-    )
-    clock.advance(45.0)  # entity is now locally stale
-
-    # REST response advertises a fresh last_reported, but a websocket
-    # push will arrive while the REST round-trip is in flight.
-    session.delay = 0.05
-    session.set_state(
-        _state_url(pm, "sensor.current_power"),
-        state="0",
-        last_reported=datetime.now(timezone.utc),
-    )
-
-    refresh_task = asyncio.create_task(pm._refresh_stale_via_rest(timeout=1.0))
-    # Spin until _fetch_rest_state has snapshotted pre_update and is
-    # parked inside the FakeSession's delay (URL recorded).
-    for _ in range(50):
-        if session.requested:
-            break
-        await asyncio.sleep(0)
-    assert session.requested, "REST request did not start"
-    # Concurrent WS push with a different value.
-    await pm._handle_message(
-        AsyncMock(),
-        json.dumps(
-            {
-                "type": "event",
-                "event": {
-                    "c": {"sensor.current_power": {"+": {"s": "123"}}},
-                },
-            }
-        ),
-    )
-    await refresh_task
-
-    # REST returned "0" but the WS push of 123 happened during the
-    # round-trip; the guard must skip the REST apply.
-    assert pm._entity_values["sensor.current_power"] == 123.0
-
-
-async def test_rest_fallback_url_respects_path_prefix_and_scheme():
-    pm = _create_powermeter(
-        ip="example.test",
-        port="8123",
-        use_https=True,
-        path_prefix="/core",
-    )
-    assert (
-        pm._build_rest_state_url("sensor.foo")
-        == "https://example.test:8123/core/api/states/sensor.foo"
-    )
-
-
-async def test_rest_fallback_noop_when_no_session():
-    """Without a live session (no ``start()``), the REST refresh is a
-    silent no-op so unit tests that drive the WebSocket handlers directly
-    don't accidentally hit the network.
-    """
-    pm = _create_powermeter(max_state_age_seconds=30.0, clock=_FakeClock())
-    # _session is None by default.
-    await pm._refresh_stale_via_rest()  # must not raise

--- a/src/astrameter/powermeter/homeassistant_test.py
+++ b/src/astrameter/powermeter/homeassistant_test.py
@@ -490,16 +490,18 @@ async def test_entities_ready_cleared_when_value_becomes_none():
 # --- state_reported and reconnect behavior --------------------------------
 
 
-async def test_state_reported_event_wakes_wait_for_next_message():
+@pytest.mark.parametrize("ts_key", ["lu", "lc"])
+async def test_state_reported_event_wakes_wait_for_next_message(ts_key: str):
     """HA's ``subscribe_entities`` omits ``s`` from the diff when a sensor
     is reported with an unchanged value (only ``lu``/``lc`` updates).
     ``wait_for_next_message`` must still wake on those so callers like the
     Shelly emulator don't time out on constant sensors that the
-    integration is still actively reporting.
+    integration is still actively reporting — and the cached numeric value
+    must remain unchanged (the keepalive carries no new ``s``).
     """
     pm = _create_powermeter()
     await _simulate_auth_and_states(
-        pm, [{"entity_id": "sensor.current_power", "state": "0"}]
+        pm, [{"entity_id": "sensor.current_power", "state": "42"}]
     )
     pm._message_event.clear()
     waiter = asyncio.create_task(pm.wait_for_next_message(timeout=1))
@@ -512,12 +514,14 @@ async def test_state_reported_event_wakes_wait_for_next_message():
             {
                 "type": "event",
                 "event": {
-                    "c": {"sensor.current_power": {"+": {"lu": 1000.0}}},
+                    "c": {"sensor.current_power": {"+": {ts_key: 1000.0}}},
                 },
             }
         ),
     )
     await waiter  # would raise TimeoutError if state_reported didn't wake it
+    # Keepalive carries no ``s``; the cached value must be preserved.
+    assert pm._entity_values["sensor.current_power"] == 42.0
 
 
 async def test_state_reported_before_initial_value_is_ignored():
@@ -547,26 +551,26 @@ async def test_state_reported_before_initial_value_is_ignored():
 
 
 async def test_reconnect_invalidates_cached_values():
-    """A websocket disconnect must invalidate cached values and clear the
-    ready flag, so ``get_powermeter_watts`` raises and
-    ``wait_for_message`` blocks again until the reconnected
-    ``subscribe_entities`` snapshot arrives. Without this, callers would
-    serve potentially-old values for the duration of the reconnect.
+    """A websocket disconnect must invalidate cached values, clear the
+    ready flag, and reset the protocol counter so the reconnected
+    ``subscribe_entities`` snapshot is what callers see — not stale
+    cache. Drives the real ``_reset_for_reconnect`` method that
+    ``_ws_loop`` invokes after a disconnect, so a regression in any of
+    its four resets is caught here.
     """
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "100"}]
     )
+    pm._subscribe_entities_id = 42  # non-default; the reset must clear it
     assert pm._entities_ready.is_set()
     assert await pm.get_powermeter_watts() == [100.0]
 
-    # Simulate the reset block in ``_ws_loop`` after a disconnect.
-    pm._msg_id = 0
-    pm._subscribe_entities_id = None
-    for eid in list(pm._entity_values):
-        pm._entity_values[eid] = None
-    pm._entities_ready.clear()
+    pm._reset_for_reconnect()
 
+    assert pm._msg_id == 0
+    assert pm._subscribe_entities_id is None
+    assert pm._entity_values["sensor.current_power"] is None
     assert not pm._entities_ready.is_set()
     with pytest.raises(ValueError):
         await pm.get_powermeter_watts()
@@ -576,3 +580,33 @@ async def test_reconnect_invalidates_cached_values():
     )
     assert pm._entities_ready.is_set()
     assert await pm.get_powermeter_watts() == [250.0]
+
+
+async def test_unavailable_blocks_wait_for_message():
+    """When a sensor transitions to ``unavailable`` mid-stream, the ready
+    flag must clear so ``wait_for_message`` blocks again — callers
+    waiting for a usable reading shouldn't see the immediate return
+    they'd get from a fully-ready snapshot.
+    """
+    pm = _create_powermeter()
+    await _simulate_auth_and_states(
+        pm, [{"entity_id": "sensor.current_power", "state": "100"}]
+    )
+    await pm.wait_for_message(timeout=1)  # returns immediately when ready
+
+    ws = AsyncMock()
+    await pm._handle_message(
+        ws,
+        json.dumps(
+            {
+                "type": "event",
+                "event": {
+                    "c": {"sensor.current_power": {"+": {"s": "unavailable"}}},
+                },
+            }
+        ),
+    )
+
+    assert pm._entity_values["sensor.current_power"] is None
+    with pytest.raises(TimeoutError):
+        await pm.wait_for_message(timeout=0.05)


### PR DESCRIPTION
## Summary

Follow-up to #364 for [#363](https://github.com/tomquist/AstraMeter/issues/363). The 60 s per-entity timer and the REST `last_reported` fallback merged in #364 close the ESPHome/Slimmelezer case but not the push-based case [@DerDaehne flagged](https://github.com/tomquist/AstraMeter/issues/363#issuecomment-4466421572): when a smart meter (e.g. `ha-tibber-pulse-local`) only pushes on value changes, HA's `last_reported` stays old too, so the REST fallback bails and re-raises the same false stale error.

HA integrations already own this signal. They set sensors to `unavailable`/`unknown` when their upstream source dies (ESPHome device offline, tibber-pulse websocket dead, etc.), and `_update_entity_value` already converts those to `None`, on which `_get_entity_value` already raises. A constant numeric value is legitimate steady-state behaviour — there's nothing for us to check on top.

This PR removes the timer, the REST fallback, the wall-clock parsing of `last_reported`, the injectable `clock`, and `max_state_age_seconds`. Net ~600 lines deleted.

aiohttp's WebSocket heartbeat (30 s) still catches dead TCP and triggers reconnect; the reconnect block now invalidates cached values to `None` so callers can't serve them across an extended outage.

## Test plan

- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run pytest` — 671 passed, 27 skipped
- [ ] Manual confirmation from #363 reporters (olafz, ebogaard, DerDaehne) that constant-value sensors no longer raise

https://claude.ai/code/session_01LwA9fBRZcLjRi7fEU4fHyw

---
_Generated by [Claude Code](https://claude.ai/code/session_01LwA9fBRZcLjRi7fEU4fHyw)_