### PR TITLE
docs: clarify port 1010 bind on Docker for shellypro3em_old

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,7 +1012,7 @@ A: Ports below 1024 require root privileges on Linux. Solutions:
 - Use `setcap` to grant permissions
 - Run as root (not recommended)
 
-Note: the Docker image runs as a non-root user, so binding port 1010 (`shellypro3em_old`) still fails with `PermissionError: [Errno 13]` under `network_mode: host`. Either lower the host's privileged-port range (`sudo sysctl -w net.ipv4.ip_unprivileged_port_start=1010`, persist via `/etc/sysctl.d/`) or run the container as root (`user: "0:0"` in compose). Publishing the port via bridge networking does **not** work, because the Marstek discovery packets are UDP broadcasts to the subnet address and aren't forwarded by Docker's port mapping.
+Note: the Docker image runs as a non-root user, so binding port 1010 (used by `shellypro3em_old` and the combined `shellypro3em`, which starts both listeners) still fails with `PermissionError: [Errno 13]` under `network_mode: host`. Port 2220 (`shellypro3em_new`) is unaffected. Either lower the host's privileged-port range (`sudo sysctl -w net.ipv4.ip_unprivileged_port_start=1010`, persist via `/etc/sysctl.d/`) or run the container as root (`user: "0:0"` in compose). Publishing the port via bridge networking does **not** work, because the Marstek discovery packets are UDP broadcasts to the subnet address and aren't forwarded by Docker's port mapping.
 
 ### I get parsing errors on startup or the app crashes.
 

--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,8 @@ A: Ports below 1024 require root privileges on Linux. Solutions:
 - Use `setcap` to grant permissions
 - Run as root (not recommended)
 
+Note: the Docker image runs as a non-root user, so binding port 1010 (`shellypro3em_old`) still fails with `PermissionError: [Errno 13]` under `network_mode: host`. Either lower the host's privileged-port range (`sudo sysctl -w net.ipv4.ip_unprivileged_port_start=1010`, persist via `/etc/sysctl.d/`) or run the container as root (`user: "0:0"` in compose). Publishing the port via bridge networking does **not** work, because the Marstek discovery packets are UDP broadcasts to the subnet address and aren't forwarded by Docker's port mapping.
+
 ### I get parsing errors on startup or the app crashes.
 
 A: Common causes:


### PR DESCRIPTION
## Summary

Adds a short note to the troubleshooting entry for `PermissionError` on ports 1010/2220, prompted by #367.

The current bullet recommends "Use Docker", but the published image runs as the non-root `astra` user, so `shellypro3em_old` still hits `EACCES` on port 1010 even with `network_mode: host`. The note documents the two workarounds that actually work — lowering `net.ipv4.ip_unprivileged_port_start` on the host or running the container as root — and warns that bridge port-publishing won't help because Marstek discovery uses UDP broadcasts to the subnet address.

## Test plan

- [ ] Render the Troubleshooting section and confirm the note reads cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFUDsHqx9SaeiXfopipk2R)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated FAQ troubleshooting section with clearer guidance on resolving binding permission errors on privileged ports when running the Docker container. Added explanations for the issue and provided two mitigation approaches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/AstraMeter/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->