### PR TITLE
Clarify all-DC-surplus log message

### DIFF
--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -907,7 +907,8 @@ class LoadBalancer:
         if all_dc_under_surplus and not self._all_dc_surplus_warned:
             logger.info(
                 "CT002: %.0f W surplus but no AC-chargeable battery "
-                "reporting — holding all at 0 W. Reporting device_types: %s",
+                "reporting — nothing here can absorb it. Reporting "
+                "device_types: %s",
                 -grid_total,
                 sorted({reports[cid].get("device_type", "") or "?" for cid in reports}),
             )


### PR DESCRIPTION
Since #360 the balancer no longer holds DC-only consumers at 0 W under brief surplus, but the diagnostic log still said "holding all at 0 W". Update the text to match actual behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jj1NKjNHbhctbM5Sy3etsy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined system logging messages for improved clarity during battery management operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/AstraMeter/pull/369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->