### PR TITLE
fix: don't slow EMA smoother across zero-crossings for high alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- **Fixed** EMA smoother slowing down across zero-crossings when `SMOOTH_TARGET_ALPHA` was configured above 0.5: the sign-flip "catchup" branch capped the effective alpha at 0.5, which actually reduced responsiveness for users who picked a larger alpha (e.g. 1.0 for near-instant tracking). The catchup boost now never drops below the configured alpha ([#371](https://github.com/tomquist/astrameter/issues/371)).
 
 ## 2.0.1
 

--- a/src/astrameter/powermeter/wrappers/smoothing.py
+++ b/src/astrameter/powermeter/wrappers/smoothing.py
@@ -74,7 +74,7 @@ class SmoothedPowermeter(PowermeterWrapper):
 
         catchup_alpha = self._alpha
         if (raw_total > 0) != (self._value > 0):
-            catchup_alpha = min(0.5, self._alpha * 4)
+            catchup_alpha = max(self._alpha, min(0.5, self._alpha * 4))
         delta = catchup_alpha * (raw_total - self._value)
 
         if self._max_step > 0:

--- a/src/astrameter/powermeter/wrappers/smoothing_test.py
+++ b/src/astrameter/powermeter/wrappers/smoothing_test.py
@@ -82,9 +82,26 @@ class TestSmoothedPowermeter:
         # Sign flip: raw goes negative
         fake.set([-100.0])
         await sm.get_powermeter_watts()
-        # catchup_alpha = min(0.5, 0.1 * 4) = 0.4
+        # catchup_alpha = max(0.1, min(0.5, 0.1 * 4)) = 0.4
         # delta = 0.4 * (-100 - 100) = -80 → new = 20
         assert sm.smoothed_value == pytest.approx(20.0)
+
+    @pytest.mark.asyncio
+    async def test_sign_change_does_not_slow_high_alpha(self):
+        fake = FakePowermeter([1.0])
+        sm = SmoothedPowermeter(fake, alpha=1.0)
+
+        await sm.get_powermeter_watts()
+        assert sm.smoothed_value == 1.0
+
+        # Sign flip: the catchup branch must not reduce alpha below the
+        # configured value, otherwise large user-chosen alphas (e.g. 1.0)
+        # respond slower across zero-crossings than they do anywhere else.
+        fake.set([-99.0])
+        await sm.get_powermeter_watts()
+        # catchup_alpha = max(1.0, min(0.5, 4.0)) = 1.0
+        # delta = 1.0 * (-99 - 1) = -100 → new = -99
+        assert sm.smoothed_value == pytest.approx(-99.0)
 
     @pytest.mark.asyncio
     async def test_max_step_limits_delta(self):


### PR DESCRIPTION
## Summary

Fixes #371.

The sign-flip "catchup" branch in `SmoothedPowermeter` (`src/astrameter/powermeter/wrappers/smoothing.py:75`) was intended to react faster when the raw total crosses zero by boosting the effective alpha to `alpha * 4`, capped at `0.5`:

```python
catchup_alpha = self._alpha
if (raw_total > 0) != (self._value > 0):
    catchup_alpha = min(0.5, self._alpha * 4)
```

But `min(0.5, alpha * 4)` is only a boost while `alpha < 0.125`. For any larger configured alpha the result simply pins to `0.5`, and once `alpha > 0.5` the branch actively **reduces** the step instead of accelerating it.

Reported symptom: running close to full self-consumption with `SMOOTH_TARGET_ALPHA = 1.0` (instant tracking) randomly halves the delta whenever the raw reading happens to straddle zero — so a `1 → 101` step moves the smoothed value by 100, while `-1 → 99` moves it by only 50, often dragging the smoothed value back inside `DEADBAND` and snapping it to 0.

## Fix

Raise the catchup alpha to at least the configured alpha, so the branch can only ever speed the smoother up, never slow it down:

```python
catchup_alpha = max(self._alpha, min(0.5, self._alpha * 4))
```

- For small alpha (e.g. `0.1 → 0.4`) the existing behaviour is preserved — that case still has a dedicated test (`test_sign_change_catchup`).
- For `alpha ≥ 0.5` the branch becomes a no-op instead of a slowdown.

## Test plan

- [x] Existing `test_sign_change_catchup` still passes (`alpha=0.1`, expected delta unchanged).
- [x] New `test_sign_change_does_not_slow_high_alpha` covers `alpha=1.0` and asserts the sign-flip step is no longer halved.
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/`
- [x] `uv run pytest` — 674 passed, 27 skipped (mosquitto-only tests).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NHs1UP46LvLw39x4eZLydG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed EMA smoothing responsiveness when `SMOOTH_TARGET_ALPHA` is configured above 0.5. The catchup coefficient logic now correctly applies the configured alpha value without artificial capping, restoring expected behavior for high smoothing settings (issue `#371`).

* **Tests**
  * Added and updated smoothing tests to verify correct behavior with various alpha configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/AstraMeter/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->