### PR TITLE
fix(homeassistant): seed cache via get_states after subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- **Fixed** Home Assistant powermeter timing out on startup with "Timeout waiting for Home Assistant state" when the `subscribe_entities` initial snapshot never arrives (e.g. entity not yet loaded when AstraMeter starts). The Home Assistant powermeter now also issues an explicit `get_states` fetch right after subscribing to seed the cache.
 
 ## 2.0.2
 

--- a/src/astrameter/powermeter/homeassistant.py
+++ b/src/astrameter/powermeter/homeassistant.py
@@ -73,6 +73,7 @@ class HomeAssistant(Powermeter):
         self._tracked_entities = self._collect_entities()
         self._msg_id = 0
         self._subscribe_entities_id: int | None = None
+        self._get_states_id: int | None = None
         self._session: aiohttp.ClientSession | None = None
         self._ws_task: asyncio.Task[None] | None = None
         self._entities_ready = asyncio.Event()
@@ -145,6 +146,7 @@ class HomeAssistant(Powermeter):
         """
         self._msg_id = 0
         self._subscribe_entities_id = None
+        self._get_states_id = None
         for eid in list(self._entity_values):
             self._entity_values[eid] = None
         self._entities_ready.clear()
@@ -212,17 +214,41 @@ class HomeAssistant(Powermeter):
                     "entity_ids": sorted(self._tracked_entities),
                 }
             )
+            # subscribe_entities is supposed to push an initial snapshot,
+            # but in setups where the entity isn't loaded yet at
+            # subscribe time, no initial event arrives and we'd block
+            # forever waiting for a state change. Seed the cache once.
+            self._get_states_id = self._next_id()
+            await ws.send_json({"id": self._get_states_id, "type": "get_states"})
         elif msg_type == "auth_invalid":
             logger.error(f"Home Assistant auth failed: {msg.get('message', '')}")
         elif msg_type == "result":
-            if msg.get("id") == self._subscribe_entities_id and not msg.get("success"):
+            msg_id = msg.get("id")
+            if msg_id == self._subscribe_entities_id and not msg.get("success"):
                 logger.error(
                     f"Home Assistant subscribe_entities failed: {msg.get('error')}"
                 )
+            elif msg_id == self._get_states_id:
+                if msg.get("success"):
+                    self._apply_get_states_result(msg.get("result"))
+                else:
+                    logger.error(
+                        f"Home Assistant get_states failed: {msg.get('error')}"
+                    )
         elif msg_type == "event":
             ev = msg.get("event")
             if isinstance(ev, dict):
                 self._handle_compressed_entity_event(ev)
+
+    def _apply_get_states_result(self, result: object) -> None:
+        if not isinstance(result, list):
+            return
+        for state_obj in result:
+            if not isinstance(state_obj, dict):
+                continue
+            eid = state_obj.get("entity_id")
+            if isinstance(eid, str) and eid in self._tracked_entities:
+                self._update_entity_value(eid, state_obj.get("state"))
 
     def _update_entity_value(self, entity_id: str, state_val: object) -> None:
         logger.debug(f"Home Assistant: update_entity_value: {entity_id}, {state_val}")

--- a/src/astrameter/powermeter/homeassistant_test.py
+++ b/src/astrameter/powermeter/homeassistant_test.py
@@ -71,11 +71,15 @@ async def test_auth_ok_subscribes_entities():
     await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
 
     calls = ws.send_json.call_args_list
-    assert len(calls) == 1
+    assert len(calls) == 2
 
     subscribe_msg = calls[0][0][0]
     assert subscribe_msg["type"] == "subscribe_entities"
     assert "sensor.current_power" in subscribe_msg["entity_ids"]
+
+    get_states_msg = calls[1][0][0]
+    assert get_states_msg["type"] == "get_states"
+    assert get_states_msg["id"] != subscribe_msg["id"]
 
 
 async def test_auth_invalid_does_not_crash():
@@ -399,6 +403,93 @@ async def test_subscribe_entities_contains_all_entities_calculate_mode():
     entity_ids = subscribe_msg["entity_ids"]
     assert "sensor.power_input" in entity_ids
     assert "sensor.power_output" in entity_ids
+
+
+# get_states bootstrap tests
+
+
+async def test_get_states_result_seeds_value_when_initial_event_missing():
+    """If ``subscribe_entities`` never pushes an initial snapshot (entity
+    not yet loaded, integration warming up), the explicit ``get_states``
+    fetch must still populate the cache so ``wait_for_message`` can
+    return.
+    """
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
+    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    gid = pm._get_states_id
+    await pm._handle_message(
+        ws,
+        json.dumps(
+            {
+                "id": gid,
+                "type": "result",
+                "success": True,
+                "result": [
+                    {"entity_id": "sensor.current_power", "state": "123"},
+                ],
+            }
+        ),
+    )
+    assert pm._entities_ready.is_set()
+    assert await pm.get_powermeter_watts() == [123.0]
+
+
+async def test_get_states_result_ignores_untracked_entities():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
+    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    gid = pm._get_states_id
+    await pm._handle_message(
+        ws,
+        json.dumps(
+            {
+                "id": gid,
+                "type": "result",
+                "success": True,
+                "result": [
+                    {"entity_id": "sensor.other", "state": "999"},
+                    {"entity_id": "sensor.current_power", "state": "50"},
+                ],
+            }
+        ),
+    )
+    assert await pm.get_powermeter_watts() == [50.0]
+
+
+async def test_get_states_failure_is_logged_not_raised():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
+    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    gid = pm._get_states_id
+    # Should not raise even if HA returns an error result for get_states.
+    await pm._handle_message(
+        ws,
+        json.dumps(
+            {
+                "id": gid,
+                "type": "result",
+                "success": False,
+                "error": {"code": "unknown_error", "message": "boom"},
+            }
+        ),
+    )
+    with pytest.raises(ValueError):
+        await pm.get_powermeter_watts()
+
+
+async def test_reconnect_clears_get_states_id():
+    pm = _create_powermeter()
+    ws = AsyncMock()
+    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
+    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    assert pm._get_states_id is not None
+
+    pm._reset_for_reconnect()
+    assert pm._get_states_id is None
 
 
 # Lifecycle tests


### PR DESCRIPTION
subscribe_entities is supposed to push an initial snapshot, but in setups where the entity isn't loaded yet at subscribe time, no initial event arrives and wait_for_message blocks until timeout. Issue an explicit get_states request right after subscribing so the cache gets seeded even when no state change happens.

Refs: discussion #379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Home Assistant powermeter startup timeout issue that occurred when initial entity snapshots failed to arrive. The integration now proactively fetches and caches entity states upon connection to ensure data availability.

* **Tests**
  * Added comprehensive test coverage for Home Assistant entity state bootstrap scenarios, validating success/failure handling and proper cache management during reconnection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/AstraMeter/pull/382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->