### PR TITLE
fix(homeassistant): bootstrap state via REST instead of WS get_states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Added** experimental ESPHome external component `ct002` to run the CT002/CT003 emulator directly on an ESP32. See `esphome.example.yaml`.
 - **Added** Modbus UDP support via a `TRANSPORT = TCP|UDP` option in the `[MODBUS]` section (defaults to `TCP`).
-- **Fixed** Home Assistant powermeter timing out on startup with "Timeout waiting for Home Assistant state" when the `subscribe_entities` initial snapshot never arrives (e.g. entity not yet loaded when AstraMeter starts). The Home Assistant powermeter now also issues an explicit `get_states` fetch right after subscribing to seed the cache.
+- **Fixed** Home Assistant powermeter timing out on startup with "Timeout waiting for Home Assistant state" when the configured sensor hasn't changed value since AstraMeter started.
 - **Fixed** `DEVICE_TYPE = shellypro3em_new` (and `shellypro3em_old`) generating an invalid `device-N` source id that the B2500 rejected, so the CT was never detected. These variants now default to a proper `shellypro3em-*` id like the combined `shellypro3em` type ([#389](https://github.com/tomquist/astrameter/issues/389)).
 - **Fixed** multi-Venus setups where a battery passing PV through to the grid (full SoC with "feed excess to grid" enabled) caused other batteries on different phases to stop charging. AstraMeter now populates the CT002 cross-talk `*_chrg_power` / `*_dchrg_power` fields from the per-battery instruction it sent rather than from the battery's reported AC output, so involuntary PV-passthrough no longer looks like a battery discharge to the rest of the fleet ([#376](https://github.com/tomquist/astrameter/issues/376)).
 

--- a/src/astrameter/powermeter/homeassistant.py
+++ b/src/astrameter/powermeter/homeassistant.py
@@ -73,9 +73,9 @@ class HomeAssistant(Powermeter):
         self._tracked_entities = self._collect_entities()
         self._msg_id = 0
         self._subscribe_entities_id: int | None = None
-        self._get_states_id: int | None = None
         self._session: aiohttp.ClientSession | None = None
         self._ws_task: asyncio.Task[None] | None = None
+        self._fetch_states_task: asyncio.Task[None] | None = None
         self._entities_ready = asyncio.Event()
         self._message_event = asyncio.Event()
 
@@ -91,6 +91,11 @@ class HomeAssistant(Powermeter):
         prefix = self.path_prefix or ""
         return f"{scheme}://{self.ip}:{self.port}{prefix}/api/websocket"
 
+    def _build_state_url(self, entity_id: str) -> str:
+        scheme = "https" if self.use_https else "http"
+        prefix = self.path_prefix or ""
+        return f"{scheme}://{self.ip}:{self.port}{prefix}/api/states/{entity_id}"
+
     def _next_id(self) -> int:
         self._msg_id += 1
         return self._msg_id
@@ -102,6 +107,11 @@ class HomeAssistant(Powermeter):
         self._ws_task = asyncio.create_task(self._ws_loop())
 
     async def stop(self) -> None:
+        if self._fetch_states_task:
+            self._fetch_states_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._fetch_states_task
+            self._fetch_states_task = None
         if self._ws_task:
             self._ws_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -146,7 +156,11 @@ class HomeAssistant(Powermeter):
         """
         self._msg_id = 0
         self._subscribe_entities_id = None
-        self._get_states_id = None
+        if self._fetch_states_task and not self._fetch_states_task.done():
+            # An in-flight REST bootstrap from the previous connection
+            # could otherwise race in after the reset and resurrect a
+            # stale value.
+            self._fetch_states_task.cancel()
         for eid in list(self._entity_values):
             self._entity_values[eid] = None
         self._entities_ready.clear()
@@ -217,38 +231,51 @@ class HomeAssistant(Powermeter):
             # subscribe_entities is supposed to push an initial snapshot,
             # but in setups where the entity isn't loaded yet at
             # subscribe time, no initial event arrives and we'd block
-            # forever waiting for a state change. Seed the cache once.
-            self._get_states_id = self._next_id()
-            await ws.send_json({"id": self._get_states_id, "type": "get_states"})
+            # forever waiting for a state change. Seed the cache once
+            # via per-entity REST fetches (vs. WebSocket ``get_states``,
+            # which would ship every entity in HA).
+            if self._fetch_states_task and not self._fetch_states_task.done():
+                self._fetch_states_task.cancel()
+            self._fetch_states_task = asyncio.create_task(self._fetch_initial_states())
         elif msg_type == "auth_invalid":
             logger.error(f"Home Assistant auth failed: {msg.get('message', '')}")
         elif msg_type == "result":
-            msg_id = msg.get("id")
-            if msg_id == self._subscribe_entities_id and not msg.get("success"):
+            if msg.get("id") == self._subscribe_entities_id and not msg.get("success"):
                 logger.error(
                     f"Home Assistant subscribe_entities failed: {msg.get('error')}"
                 )
-            elif msg_id == self._get_states_id:
-                if msg.get("success"):
-                    self._apply_get_states_result(msg.get("result"))
-                else:
-                    logger.error(
-                        f"Home Assistant get_states failed: {msg.get('error')}"
-                    )
         elif msg_type == "event":
             ev = msg.get("event")
             if isinstance(ev, dict):
                 self._handle_compressed_entity_event(ev)
 
-    def _apply_get_states_result(self, result: object) -> None:
-        if not isinstance(result, list):
+    async def _fetch_initial_states(self) -> None:
+        if not self._session:
             return
-        for state_obj in result:
-            if not isinstance(state_obj, dict):
+        headers = {"Authorization": f"Bearer {self.access_token}"}
+        for eid in sorted(self._tracked_entities):
+            if self._entity_values.get(eid) is not None:
                 continue
-            eid = state_obj.get("entity_id")
-            if isinstance(eid, str) and eid in self._tracked_entities:
-                self._update_entity_value(eid, state_obj.get("state"))
+            url = self._build_state_url(eid)
+            try:
+                async with self._session.get(url, headers=headers) as resp:
+                    if resp.status != 200:
+                        logger.debug(
+                            "Home Assistant: REST state fetch for %s returned %s",
+                            eid,
+                            resp.status,
+                        )
+                        continue
+                    data = await resp.json()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.debug(
+                    "Home Assistant: REST state fetch for %s failed: %s", eid, e
+                )
+                continue
+            if isinstance(data, dict):
+                self._update_entity_value(eid, data.get("state"))
 
     def _update_entity_value(self, entity_id: str, state_val: object) -> None:
         logger.debug(f"Home Assistant: update_entity_value: {entity_id}, {state_val}")

--- a/src/astrameter/powermeter/homeassistant_test.py
+++ b/src/astrameter/powermeter/homeassistant_test.py
@@ -598,6 +598,45 @@ async def test_reconnect_cancels_in_flight_fetch():
         await pm._fetch_states_task
 
 
+async def test_reconnect_prevents_stale_bootstrap_reseed():
+    """End-to-end guard on the real ``_fetch_initial_states``: when the
+    REST response only resolves *after* ``_reset_for_reconnect`` has
+    cancelled the task, the post-await write must never land — the stale
+    value cannot reseed the cache that the reset just cleared.
+    """
+    pm = _create_powermeter()
+    gate = asyncio.Event()
+
+    def _get(url, headers=None):
+        resp = MagicMock()
+        resp.status = 200
+
+        async def _json():
+            await gate.wait()  # don't resolve until the test releases it
+            return {"entity_id": "sensor.current_power", "state": "123"}
+
+        resp.json = _json
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+        return resp
+
+    session = MagicMock()
+    session.get = MagicMock(side_effect=_get)
+    pm._session = session
+
+    pm._fetch_states_task = asyncio.create_task(pm._fetch_initial_states())
+    await asyncio.sleep(0)  # let the task reach `await resp.json()`
+
+    pm._reset_for_reconnect()  # cancels the in-flight task and clears cache
+    gate.set()  # the json await would resume here — but cancellation wins
+
+    with pytest.raises(asyncio.CancelledError):
+        await pm._fetch_states_task
+
+    # The stale "123" must never have been written.
+    assert "sensor.current_power" not in pm._entity_values
+
+
 # Lifecycle tests
 
 

--- a/src/astrameter/powermeter/homeassistant_test.py
+++ b/src/astrameter/powermeter/homeassistant_test.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -69,17 +69,15 @@ async def test_auth_ok_subscribes_entities():
     ws.send_json.reset_mock()
 
     await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    if pm._fetch_states_task:
+        pm._fetch_states_task.cancel()
 
     calls = ws.send_json.call_args_list
-    assert len(calls) == 2
+    assert len(calls) == 1
 
     subscribe_msg = calls[0][0][0]
     assert subscribe_msg["type"] == "subscribe_entities"
     assert "sensor.current_power" in subscribe_msg["entity_ids"]
-
-    get_states_msg = calls[1][0][0]
-    assert get_states_msg["type"] == "get_states"
-    assert get_states_msg["id"] != subscribe_msg["id"]
 
 
 async def test_auth_invalid_does_not_crash():
@@ -405,91 +403,199 @@ async def test_subscribe_entities_contains_all_entities_calculate_mode():
     assert "sensor.power_output" in entity_ids
 
 
-# get_states bootstrap tests
+# REST bootstrap tests
 
 
-async def test_get_states_result_seeds_value_when_initial_event_missing():
-    """If ``subscribe_entities`` never pushes an initial snapshot (entity
-    not yet loaded, integration warming up), the explicit ``get_states``
-    fetch must still populate the cache so ``wait_for_message`` can
-    return.
+def _make_rest_session(responses: dict[str, dict | None]):
+    """Build a ``ClientSession`` mock where ``session.get(url)`` returns
+    the configured JSON (or 404 when the mapped value is ``None``).
+    ``responses`` is keyed by full URL.
+    """
+    captured_headers: dict[str, str] = {}
+
+    def _get(url, headers=None):
+        captured_headers.clear()
+        if headers:
+            captured_headers.update(headers)
+        body = responses.get(url)
+        resp = MagicMock()
+        if body is None:
+            resp.status = 404
+            resp.json = AsyncMock(return_value={})
+        else:
+            resp.status = 200
+            resp.json = AsyncMock(return_value=body)
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+        return resp
+
+    session = MagicMock()
+    session.get = MagicMock(side_effect=_get)
+    session.close = AsyncMock()
+    session._captured_headers = captured_headers
+    return session
+
+
+async def test_fetch_initial_states_seeds_value():
+    """When ``subscribe_entities`` never pushes an initial snapshot
+    (entity not yet loaded, integration warming up), the REST bootstrap
+    must still populate the cache so ``wait_for_message`` can return.
     """
     pm = _create_powermeter()
-    ws = AsyncMock()
-    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
-    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
-    gid = pm._get_states_id
-    await pm._handle_message(
-        ws,
-        json.dumps(
-            {
-                "id": gid,
-                "type": "result",
-                "success": True,
-                "result": [
-                    {"entity_id": "sensor.current_power", "state": "123"},
-                ],
-            }
-        ),
+    pm._session = _make_rest_session(
+        {
+            "http://192.168.1.8:8123/api/states/sensor.current_power": {
+                "entity_id": "sensor.current_power",
+                "state": "123",
+            },
+        }
     )
+    await pm._fetch_initial_states()
     assert pm._entities_ready.is_set()
     assert await pm.get_powermeter_watts() == [123.0]
 
 
-async def test_get_states_result_ignores_untracked_entities():
+async def test_fetch_initial_states_sends_bearer_token():
     pm = _create_powermeter()
-    ws = AsyncMock()
-    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
-    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
-    gid = pm._get_states_id
-    await pm._handle_message(
-        ws,
-        json.dumps(
-            {
-                "id": gid,
-                "type": "result",
-                "success": True,
-                "result": [
-                    {"entity_id": "sensor.other", "state": "999"},
-                    {"entity_id": "sensor.current_power", "state": "50"},
-                ],
-            }
-        ),
+    session = _make_rest_session(
+        {
+            "http://192.168.1.8:8123/api/states/sensor.current_power": {
+                "entity_id": "sensor.current_power",
+                "state": "10",
+            },
+        }
     )
-    assert await pm.get_powermeter_watts() == [50.0]
+    pm._session = session
+    await pm._fetch_initial_states()
+    assert session._captured_headers.get("Authorization") == "Bearer token"
 
 
-async def test_get_states_failure_is_logged_not_raised():
-    pm = _create_powermeter()
-    ws = AsyncMock()
-    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
-    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
-    gid = pm._get_states_id
-    # Should not raise even if HA returns an error result for get_states.
-    await pm._handle_message(
-        ws,
-        json.dumps(
-            {
-                "id": gid,
-                "type": "result",
-                "success": False,
-                "error": {"code": "unknown_error", "message": "boom"},
-            }
-        ),
+async def test_fetch_initial_states_uses_https_and_path_prefix():
+    pm = _create_powermeter(use_https=True, path_prefix="/core")
+    session = _make_rest_session(
+        {
+            "https://192.168.1.8:8123/core/api/states/sensor.current_power": {
+                "entity_id": "sensor.current_power",
+                "state": "42",
+            },
+        }
     )
+    pm._session = session
+    await pm._fetch_initial_states()
+    assert await pm.get_powermeter_watts() == [42.0]
+
+
+async def test_fetch_initial_states_fetches_each_tracked_entity():
+    pm = _create_powermeter(
+        current_power_entity=[
+            "sensor.power_phase1",
+            "sensor.power_phase2",
+            "sensor.power_phase3",
+        ]
+    )
+    session = _make_rest_session(
+        {
+            "http://192.168.1.8:8123/api/states/sensor.power_phase1": {
+                "entity_id": "sensor.power_phase1",
+                "state": "100",
+            },
+            "http://192.168.1.8:8123/api/states/sensor.power_phase2": {
+                "entity_id": "sensor.power_phase2",
+                "state": "200",
+            },
+            "http://192.168.1.8:8123/api/states/sensor.power_phase3": {
+                "entity_id": "sensor.power_phase3",
+                "state": "300",
+            },
+        }
+    )
+    pm._session = session
+    await pm._fetch_initial_states()
+    assert await pm.get_powermeter_watts() == [100.0, 200.0, 300.0]
+    # Only the tracked entities — no full-state dump like WS ``get_states``.
+    assert session.get.call_count == 3
+
+
+async def test_fetch_initial_states_skips_already_populated_entity():
+    """If the ``subscribe_entities`` snapshot arrived first and already
+    seeded a value, the REST fetch shouldn't waste a request — and must
+    not clobber the (potentially newer) cached value.
+    """
+    pm = _create_powermeter()
+    pm._update_entity_value("sensor.current_power", "999")
+    session = _make_rest_session(
+        {
+            "http://192.168.1.8:8123/api/states/sensor.current_power": {
+                "entity_id": "sensor.current_power",
+                "state": "1",
+            },
+        }
+    )
+    pm._session = session
+    await pm._fetch_initial_states()
+    assert session.get.call_count == 0
+    assert await pm.get_powermeter_watts() == [999.0]
+
+
+async def test_fetch_initial_states_handles_404():
+    pm = _create_powermeter()
+    # 404: entity doesn't exist (or normalized differently); we mustn't
+    # raise — the WS stream may still deliver a value later.
+    pm._session = _make_rest_session(
+        {"http://192.168.1.8:8123/api/states/sensor.current_power": None}
+    )
+    await pm._fetch_initial_states()
+    assert not pm._entities_ready.is_set()
     with pytest.raises(ValueError):
         await pm.get_powermeter_watts()
 
 
-async def test_reconnect_clears_get_states_id():
+async def test_fetch_initial_states_swallows_request_exceptions():
     pm = _create_powermeter()
+    session = MagicMock()
+    session.get = MagicMock(side_effect=RuntimeError("boom"))
+    pm._session = session
+    # Must not raise — the WS connection may still deliver a value later.
+    await pm._fetch_initial_states()
+    assert not pm._entities_ready.is_set()
+
+
+async def test_auth_ok_schedules_rest_bootstrap():
+    pm = _create_powermeter()
+    pm._session = _make_rest_session(
+        {
+            "http://192.168.1.8:8123/api/states/sensor.current_power": {
+                "entity_id": "sensor.current_power",
+                "state": "7",
+            },
+        }
+    )
     ws = AsyncMock()
     await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
     await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
-    assert pm._get_states_id is not None
+    assert pm._fetch_states_task is not None
+    await pm._fetch_states_task
+    assert await pm.get_powermeter_watts() == [7.0]
 
+
+async def test_reconnect_cancels_in_flight_fetch():
+    """An in-flight REST bootstrap from the previous connection must be
+    cancelled by ``_reset_for_reconnect``; otherwise it could resurrect
+    a stale value after the reset.
+    """
+    pm = _create_powermeter()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _hang():
+        started.set()
+        await release.wait()
+
+    pm._fetch_states_task = asyncio.create_task(_hang())
+    await started.wait()
     pm._reset_for_reconnect()
-    assert pm._get_states_id is None
+    with pytest.raises(asyncio.CancelledError):
+        await pm._fetch_states_task
 
 
 # Lifecycle tests


### PR DESCRIPTION
The previous get_states bootstrap used the WebSocket get_states command, which returns every entity in the Home Assistant state machine — wasteful for setups with many entities when we only care about one or a handful.

Swap to per-entity REST GET /api/states/<entity_id> requests, scheduled as a background task right after subscribe_entities. Cancel any in-flight bootstrap on disconnect or stop so a late response can't resurrect a stale value after _reset_for_reconnect clears the cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved startup timeout when a configured Home Assistant sensor kept its initial value.
  * Initial sensor values are now reliably loaded at startup even if no state change occurs.
  * Background fetches are canceled on disconnect/reconnect to avoid applying stale values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/AstraMeter/pull/383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->