### PR TITLE
fix(ct002): use instructed targets for *_dchrg_power cross-talk (#376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - **Fixed** Home Assistant powermeter timing out on startup with "Timeout waiting for Home Assistant state" when the `subscribe_entities` initial snapshot never arrives (e.g. entity not yet loaded when AstraMeter starts). The Home Assistant powermeter now also issues an explicit `get_states` fetch right after subscribing to seed the cache.
+- **Fixed** multi-Venus setups where a battery passing PV through to the grid (full SoC with "feed excess to grid" enabled) caused other batteries on different phases to stop charging. AstraMeter now populates the CT002 cross-talk `*_chrg_power` / `*_dchrg_power` fields from the per-battery instruction it sent rather than from the battery's reported AC output, so involuntary PV-passthrough no longer looks like a battery discharge to the rest of the fleet ([#376](https://github.com/tomquist/astrameter/issues/376)).
 
 ## 2.0.2
 

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -70,10 +70,11 @@ class Consumer:
     # Report data (updated each UDP request)
     phase: str = "A"
     power: int = 0
-    # The last per-phase target we returned to this consumer (i.e. what we
-    # *told* it to do on its own phase: negative = charge, positive =
-    # discharge).  Used to populate cross-talk *_dchrg / *_chrg fields in
-    # responses to other batteries — see _collect_reports_by_phase.
+    # Net AC power we expect this consumer to be at after applying the
+    # last instruction (its reported output plus the per-phase delta we
+    # delivered).  Negative = charging, positive = discharging.  Used to
+    # populate cross-talk *_dchrg / *_chrg fields in responses to other
+    # batteries — see _collect_reports_by_phase.
     last_instructed_power: float = 0.0
     timestamp: float = 0.0
     device_type: str = ""
@@ -395,11 +396,13 @@ class CT002:
             phase = consumer.phase.upper()
             if phase not in by_phase:
                 phase = "A"
-            # Use what AstraMeter *instructed* this consumer to do, not
-            # what it reported doing.  A battery passing PV through to AC
-            # at 100% SoC reports positive power even though we told it to
-            # charge; reporting the instruction here keeps the cross-talk
-            # dchrg signal free of those involuntary outputs (issue #376).
+            # Use the net AC power we *instructed* this consumer to be at
+            # (its reported output plus the delta in the last response),
+            # not what it physically reported.  A battery passing PV
+            # through to AC at 100% SoC reports positive power even
+            # though we told it to charge; reporting the instructed net
+            # power keeps the cross-talk dchrg signal free of those
+            # involuntary outputs (issue #376).
             power = round(consumer.last_instructed_power)
             if power == 0:
                 continue
@@ -663,12 +666,19 @@ class CT002:
             values = self._compute_smooth_target(values, consumer_id)
         values = ([*list(values), 0, 0, 0])[:3]
 
-        # Record the instruction we're about to send so cross-talk in
-        # *_chrg_power / *_dchrg_power fields reflects what AstraMeter
-        # *told* each battery to do, not what they reported (issue #376).
-        consumer = self._get_consumer(consumer_id)
-        phase_idx = {"A": 0, "B": 1, "C": 2}.get(consumer.phase.upper(), 0)
-        consumer.last_instructed_power = float(values[phase_idx])
+        # Record the *net* power we expect this battery to be at after
+        # applying the instruction (its reported output plus the delta we
+        # deliver — the battery's firmware computes
+        # ``new_target = current_power + grid_reading_field``).  The
+        # cross-talk *_chrg_power / *_dchrg_power fields convey net power
+        # per phase so other batteries can see who is actively
+        # charging/discharging cells; storing only the delta would lose
+        # the steady-state signal and flip signs on small corrections.
+        # See issue #376.
+        if not in_inspection_mode:
+            consumer = self._get_consumer(consumer_id)
+            phase_idx = {"A": 0, "B": 1, "C": 2}.get(consumer.phase.upper(), 0)
+            consumer.last_instructed_power = float(reported_power + values[phase_idx])
 
         try:
             response_fields = self._build_response_fields(fields, values)

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -70,6 +70,11 @@ class Consumer:
     # Report data (updated each UDP request)
     phase: str = "A"
     power: int = 0
+    # The last per-phase target we returned to this consumer (i.e. what we
+    # *told* it to do on its own phase: negative = charge, positive =
+    # discharge).  Used to populate cross-talk *_dchrg / *_chrg fields in
+    # responses to other batteries — see _collect_reports_by_phase.
+    last_instructed_power: float = 0.0
     timestamp: float = 0.0
     device_type: str = ""
     poll_interval: float | None = None
@@ -390,7 +395,12 @@ class CT002:
             phase = consumer.phase.upper()
             if phase not in by_phase:
                 phase = "A"
-            power = consumer.power
+            # Use what AstraMeter *instructed* this consumer to do, not
+            # what it reported doing.  A battery passing PV through to AC
+            # at 100% SoC reports positive power even though we told it to
+            # charge; reporting the instruction here keeps the cross-talk
+            # dchrg signal free of those involuntary outputs (issue #376).
+            power = round(consumer.last_instructed_power)
             if power == 0:
                 continue
             by_phase[phase]["active"] = True
@@ -652,6 +662,13 @@ class CT002:
         if self.active_control and not in_inspection_mode:
             values = self._compute_smooth_target(values, consumer_id)
         values = ([*list(values), 0, 0, 0])[:3]
+
+        # Record the instruction we're about to send so cross-talk in
+        # *_chrg_power / *_dchrg_power fields reflects what AstraMeter
+        # *told* each battery to do, not what they reported (issue #376).
+        consumer = self._get_consumer(consumer_id)
+        phase_idx = {"A": 0, "B": 1, "C": 2}.get(consumer.phase.upper(), 0)
+        consumer.last_instructed_power = float(values[phase_idx])
 
         try:
             response_fields = self._build_response_fields(fields, values)

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -674,11 +674,14 @@ class CT002:
         # per phase so other batteries can see who is actively
         # charging/discharging cells; storing only the delta would lose
         # the steady-state signal and flip signs on small corrections.
+        # Inspection-mode requests are recorded the same way — the only
+        # difference there is that ``values`` carries raw meter readings
+        # rather than balancer-computed deltas, so the battery can
+        # observe per-phase grid response and identify its phase.
         # See issue #376.
-        if not in_inspection_mode:
-            consumer = self._get_consumer(consumer_id)
-            phase_idx = {"A": 0, "B": 1, "C": 2}.get(consumer.phase.upper(), 0)
-            consumer.last_instructed_power = float(reported_power + values[phase_idx])
+        consumer = self._get_consumer(consumer_id)
+        phase_idx = {"A": 0, "B": 1, "C": 2}.get(consumer.phase.upper(), 0)
+        consumer.last_instructed_power = float(reported_power + values[phase_idx])
 
         try:
             response_fields = self._build_response_fields(fields, values)

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -674,14 +674,16 @@ class CT002:
         # per phase so other batteries can see who is actively
         # charging/discharging cells; storing only the delta would lose
         # the steady-state signal and flip signs on small corrections.
-        # Inspection-mode requests are recorded the same way — the only
-        # difference there is that ``values`` carries raw meter readings
-        # rather than balancer-computed deltas, so the battery can
-        # observe per-phase grid response and identify its phase.
-        # See issue #376.
-        consumer = self._get_consumer(consumer_id)
-        phase_idx = {"A": 0, "B": 1, "C": 2}.get(consumer.phase.upper(), 0)
-        consumer.last_instructed_power = float(reported_power + values[phase_idx])
+        # Skip during inspection mode: there is no instruction to record
+        # (we send raw meter readings as information, not a target; the
+        # battery is running its phase-discovery routine, not our
+        # integral controller), and we don't even know which phase to
+        # credit since ``consumer.phase`` defaults to "A" until the
+        # battery declares its real phase.  See issue #376.
+        if not in_inspection_mode:
+            consumer = self._get_consumer(consumer_id)
+            phase_idx = {"A": 0, "B": 1, "C": 2}.get(consumer.phase.upper(), 0)
+            consumer.last_instructed_power = float(reported_power + values[phase_idx])
 
         try:
             response_fields = self._build_response_fields(fields, values)

--- a/src/astrameter/simulator/battery.py
+++ b/src/astrameter/simulator/battery.py
@@ -38,6 +38,9 @@ class BatterySimulator:
         inspection_count: int = 1,
         time_scale: float = 1.0,
         power_update_delay_ticks: int = 0,
+        max_dc_input: int = 0,
+        dc_input_power: float = 0.0,
+        idle_on_cross_phase_discharge: bool = False,
     ) -> None:
         if phase not in protocol.PHASE_FIELD_INDEX:
             raise ValueError(
@@ -62,6 +65,8 @@ class BatterySimulator:
         self.inspection_count = inspection_count
         self.time_scale = max(0.1, time_scale)
         self.power_update_delay_ticks = max(0, int(power_update_delay_ticks))
+        self.max_dc_input = max(0, int(max_dc_input))
+        self.idle_on_cross_phase_discharge = idle_on_cross_phase_discharge
 
         self._current_power: float = 0.0
         self._soc: float = max(0.0, min(1.0, initial_soc))
@@ -72,6 +77,10 @@ class BatterySimulator:
         self._startup_elapsed: float = 0.0
         self._step_index: int = 0
         self._pending_power_targets: list[tuple[int, float]] = []
+        self._dc_input_power: float = max(
+            0.0, min(float(self.max_dc_input), dc_input_power)
+        )
+        self._last_response_dchrg: tuple[float, float, float] = (0.0, 0.0, 0.0)
 
     # -- public read-only properties ---------------------------------------
 
@@ -94,6 +103,18 @@ class BatterySimulator:
     @property
     def target_power(self) -> float:
         return self._target_power
+
+    @property
+    def dc_input_power(self) -> float:
+        return self._dc_input_power
+
+    @dc_input_power.setter
+    def dc_input_power(self, value: float) -> None:
+        self._dc_input_power = max(0.0, min(float(self.max_dc_input), float(value)))
+
+    @property
+    def last_response_dchrg(self) -> tuple[float, float, float]:
+        return self._last_response_dchrg
 
     def _apply_ct_derived_target(self, new_target: float) -> None:
         """Record CT request immediately; apply to physics after *power_update_delay_ticks*."""
@@ -139,6 +160,7 @@ class BatterySimulator:
             if idle and want_power:
                 self._startup_elapsed += dt
                 if self._startup_elapsed < self.startup_delay:
+                    self._apply_dc_passthrough()
                     return  # stay at current (near-zero) power
             else:
                 self._startup_elapsed = 0.0
@@ -156,11 +178,27 @@ class BatterySimulator:
             min(self.max_discharge_power, self._current_power),
         )
 
+        # When SoC is saturated and DC input is present, the inverter
+        # passes the unabsorbed PV through to AC even if the AC target
+        # asks for charging.  Mirrors Marstek Venus D behaviour.
+        self._apply_dc_passthrough()
+
+    def _apply_dc_passthrough(self) -> None:
+        if self._soc < 1.0 or self._dc_input_power <= 0:
+            return
+        # Push at least the DC input through to AC as positive output.
+        self._current_power = max(self._current_power, self._dc_input_power)
+
     def _update_soc(self, dt: float) -> None:
         if self.capacity_wh <= 0:
             return
+        # AC energy first (positive current_power drains, negative charges)
         energy_wh = self._current_power * (dt / 3600.0)
         self._soc -= energy_wh / self.capacity_wh
+        # DC input charges the cells in parallel (when not already full).
+        if self._dc_input_power > 0:
+            dc_energy_wh = self._dc_input_power * (dt / 3600.0)
+            self._soc += dc_energy_wh / self.capacity_wh
         self._soc = max(0.0, min(1.0, self._soc))
 
     # -- protocol ----------------------------------------------------------
@@ -204,22 +242,63 @@ class BatterySimulator:
             logger.debug("Battery %s: bad response: %s", self.mac, err)
             return None
 
-        # Extract grid reading: sum of all three phase power fields (4, 5, 6).
-        # Real Marstek batteries treat this as the current grid consumption and
-        # adjust their output to compensate: if the grid is importing 70W, the
-        # battery increases its output by 70W.  This integral behavior drives
-        # the grid reading toward zero over successive cycles.
+        # Hand parsed response off to the deterministic helper so it can
+        # also be unit-tested without UDP I/O.
         if response_fields and phase_field != "0":
-            try:
-                phase_a = int(response_fields[4]) if len(response_fields) > 4 else 0
-                phase_b = int(response_fields[5]) if len(response_fields) > 5 else 0
-                phase_c = int(response_fields[6]) if len(response_fields) > 6 else 0
-                grid_reading = phase_a + phase_b + phase_c
-                self._apply_ct_derived_target(self._current_power + grid_reading)
-            except (ValueError, TypeError):
-                pass
+            self._handle_ct_response(response_fields)
 
         return response_fields
+
+    def _handle_ct_response(self, response_fields: list[str]) -> None:
+        """Apply integral-control target update and dchrg-driven idle rule.
+
+        Real Marstek batteries derive their new AC target by adding the
+        reported grid reading (sum of fields 4-6) to their current output.
+        If the opt-in firmware-mimic flag is on, a charging battery also
+        idles when it sees another phase being instructed to discharge.
+        """
+        try:
+            phase_a = int(response_fields[4]) if len(response_fields) > 4 else 0
+            phase_b = int(response_fields[5]) if len(response_fields) > 5 else 0
+            phase_c = int(response_fields[6]) if len(response_fields) > 6 else 0
+            grid_reading = phase_a + phase_b + phase_c
+            new_target: float = self._current_power + grid_reading
+
+            # *_dchrg_power live at fields 20/21/22 (A/B/C).
+            a_dchrg = int(response_fields[20]) if len(response_fields) > 20 else 0
+            b_dchrg = int(response_fields[21]) if len(response_fields) > 21 else 0
+            c_dchrg = int(response_fields[22]) if len(response_fields) > 22 else 0
+            self._last_response_dchrg = (
+                float(a_dchrg),
+                float(b_dchrg),
+                float(c_dchrg),
+            )
+
+            # Real Marstek firmware idles a charging battery when it sees
+            # another battery (on a different phase) being instructed to
+            # discharge — to avoid one battery feeding the other through
+            # the grid.  Opt-in; default off keeps existing simulator
+            # tests stable.
+            if (
+                self.idle_on_cross_phase_discharge
+                and new_target < 0
+                and self._other_phase_discharging((a_dchrg, b_dchrg, c_dchrg))
+            ):
+                new_target = 0.0
+
+            self._apply_ct_derived_target(new_target)
+        except (ValueError, TypeError):
+            pass
+
+    def _other_phase_discharging(self, dchrg_vec: tuple[int, int, int]) -> bool:
+        """True if a phase other than this battery's reports a positive dchrg."""
+        own_idx = {"A": 0, "B": 1, "C": 2}.get(self.phase, 0)
+        for i, value in enumerate(dchrg_vec):
+            if i == own_idx:
+                continue
+            if value > 0:
+                return True
+        return False
 
     # -- main loop ---------------------------------------------------------
 
@@ -272,6 +351,9 @@ class BatterySimulator:
             "soc": round(self._soc, 4),
             "max_charge": self.max_charge_power,
             "max_discharge": self.max_discharge_power,
+            "max_dc_input": self.max_dc_input,
+            "dc_input": round(self._dc_input_power),
+            "last_response_dchrg": [round(v) for v in self._last_response_dchrg],
         }
 
 

--- a/src/astrameter/simulator/battery.py
+++ b/src/astrameter/simulator/battery.py
@@ -77,10 +77,8 @@ class BatterySimulator:
         self._startup_elapsed: float = 0.0
         self._step_index: int = 0
         self._pending_power_targets: list[tuple[int, float]] = []
-        self._dc_input_power: float = max(
-            0.0, min(float(self.max_dc_input), dc_input_power)
-        )
-        self._last_response_dchrg: tuple[float, float, float] = (0.0, 0.0, 0.0)
+        self._dc_input_power: float = 0.0
+        self.dc_input_power = dc_input_power  # reuse setter clamp
 
     # -- public read-only properties ---------------------------------------
 
@@ -111,10 +109,6 @@ class BatterySimulator:
     @dc_input_power.setter
     def dc_input_power(self, value: float) -> None:
         self._dc_input_power = max(0.0, min(float(self.max_dc_input), float(value)))
-
-    @property
-    def last_response_dchrg(self) -> tuple[float, float, float]:
-        return self._last_response_dchrg
 
     def _apply_ct_derived_target(self, new_target: float) -> None:
         """Record CT request immediately; apply to physics after *power_update_delay_ticks*."""
@@ -257,48 +251,35 @@ class BatterySimulator:
         If the opt-in firmware-mimic flag is on, a charging battery also
         idles when it sees another phase being instructed to discharge.
         """
-        try:
-            phase_a = int(response_fields[4]) if len(response_fields) > 4 else 0
-            phase_b = int(response_fields[5]) if len(response_fields) > 5 else 0
-            phase_c = int(response_fields[6]) if len(response_fields) > 6 else 0
-            grid_reading = phase_a + phase_b + phase_c
-            new_target: float = self._current_power + grid_reading
 
-            # *_dchrg_power live at fields 20/21/22 (A/B/C).
-            a_dchrg = int(response_fields[20]) if len(response_fields) > 20 else 0
-            b_dchrg = int(response_fields[21]) if len(response_fields) > 21 else 0
-            c_dchrg = int(response_fields[22]) if len(response_fields) > 22 else 0
-            self._last_response_dchrg = (
-                float(a_dchrg),
-                float(b_dchrg),
-                float(c_dchrg),
-            )
+        def field(idx: int) -> int:
+            try:
+                return int(response_fields[idx])
+            except (IndexError, ValueError, TypeError):
+                return 0
 
-            # Real Marstek firmware idles a charging battery when it sees
-            # another battery (on a different phase) being instructed to
-            # discharge — to avoid one battery feeding the other through
-            # the grid.  Opt-in; default off keeps existing simulator
-            # tests stable.
-            if (
-                self.idle_on_cross_phase_discharge
-                and new_target < 0
-                and self._other_phase_discharging((a_dchrg, b_dchrg, c_dchrg))
-            ):
-                new_target = 0.0
+        grid_reading = field(4) + field(5) + field(6)
+        dchrg = (field(20), field(21), field(22))  # A/B/C_dchrg_power
+        new_target: float = self._current_power + grid_reading
 
-            self._apply_ct_derived_target(new_target)
-        except (ValueError, TypeError):
-            pass
+        # Real Marstek firmware idles a charging battery when it sees
+        # another battery (on a different phase) being instructed to
+        # discharge — to avoid one battery feeding the other through
+        # the grid.  Opt-in; default off keeps existing simulator
+        # tests stable.
+        if (
+            self.idle_on_cross_phase_discharge
+            and new_target < 0
+            and self._other_phase_discharging(dchrg)
+        ):
+            new_target = 0.0
 
-    def _other_phase_discharging(self, dchrg_vec: tuple[int, int, int]) -> bool:
+        self._apply_ct_derived_target(new_target)
+
+    def _other_phase_discharging(self, dchrg: tuple[int, int, int]) -> bool:
         """True if a phase other than this battery's reports a positive dchrg."""
-        own_idx = {"A": 0, "B": 1, "C": 2}.get(self.phase, 0)
-        for i, value in enumerate(dchrg_vec):
-            if i == own_idx:
-                continue
-            if value > 0:
-                return True
-        return False
+        own_idx = "ABC".index(self.phase)
+        return any(v > 0 for i, v in enumerate(dchrg) if i != own_idx)
 
     # -- main loop ---------------------------------------------------------
 
@@ -353,7 +334,6 @@ class BatterySimulator:
             "max_discharge": self.max_discharge_power,
             "max_dc_input": self.max_dc_input,
             "dc_input": round(self._dc_input_power),
-            "last_response_dchrg": [round(v) for v in self._last_response_dchrg],
         }
 
 

--- a/src/astrameter/simulator/battery_test.py
+++ b/src/astrameter/simulator/battery_test.py
@@ -10,20 +10,22 @@ from astrameter.simulator.battery import BatterySimulator
 from astrameter.simulator.runner import parse_config, validate_config
 
 
-def _battery(delay: int = 0) -> BatterySimulator:
-    return BatterySimulator(
-        mac="02B250000001",
-        phase="A",
-        ct_mac="112233445566",
-        ct_host="127.0.0.1",
-        ct_port=12345,
-        inspection_count=0,
-        power_update_delay_ticks=delay,
-        startup_delay=0.0,
-        min_power_threshold=0.0,
-        ramp_rate=1e9,
-        poll_interval=1.0,
-    )
+def _battery(delay: int = 0, **kwargs) -> BatterySimulator:
+    defaults: dict = {
+        "mac": "02B250000001",
+        "phase": "A",
+        "ct_mac": "112233445566",
+        "ct_host": "127.0.0.1",
+        "ct_port": 12345,
+        "inspection_count": 0,
+        "power_update_delay_ticks": delay,
+        "startup_delay": 0.0,
+        "min_power_threshold": 0.0,
+        "ramp_rate": 1e9,
+        "poll_interval": 1.0,
+    }
+    defaults.update(kwargs)
+    return BatterySimulator(**defaults)
 
 
 def test_power_update_immediate_when_delay_zero() -> None:
@@ -71,6 +73,124 @@ async def test_power_update_delay_one_tick() -> None:
         assert b.to_dict()["applied_target"] == 80
 
 
+def test_dc_passthrough_at_full_soc() -> None:
+    """Venus D-like: full SoC + DC input → AC output forced to DC value."""
+    b = _battery(max_dc_input=500, initial_soc=1.0, dc_input_power=500.0)
+    # Even if the AC target is "charge", passthrough should override.
+    b._apply_ct_derived_target(-300.0)
+    b._update_power(1.0)
+    assert b.current_power >= 500.0, (
+        f"Expected DC passthrough to force +500W, got {b.current_power}"
+    )
+
+
+def test_dc_passthrough_inactive_when_soc_below_one() -> None:
+    """Below full SoC, DC input is absorbed by the cells, not passed through."""
+    b = _battery(max_dc_input=500, initial_soc=0.5, dc_input_power=500.0)
+    b._apply_ct_derived_target(0.0)
+    b._update_power(1.0)
+    # Without saturation, the inverter doesn't dump DC to AC.
+    assert b.current_power == 0.0
+
+
+def test_dc_input_charges_cells_below_full_soc() -> None:
+    """DC input raises SoC over time when not full."""
+    b = _battery(
+        max_dc_input=500,
+        initial_soc=0.5,
+        dc_input_power=500.0,
+        capacity_wh=1000.0,  # small capacity for visible change
+    )
+    initial_soc = b.soc
+    # Drive 60 seconds of DC input with no AC activity.
+    for _ in range(60):
+        b._update_soc(1.0)
+    assert b.soc > initial_soc, (
+        f"DC input should charge cells; SoC went {initial_soc} -> {b.soc}"
+    )
+
+
+def test_dc_input_setter_clamps_to_max() -> None:
+    b = _battery(max_dc_input=500)
+    b.dc_input_power = 2000.0  # over max
+    assert b.dc_input_power == 500.0
+    b.dc_input_power = -10.0  # below zero
+    assert b.dc_input_power == 0.0
+
+
+def _response_fields(
+    phase_targets: tuple[int, int, int] = (0, 0, 0),
+    dchrg: tuple[int, int, int] = (0, 0, 0),
+) -> list[str]:
+    """Build a CT002 response field list with the given phase targets + dchrg."""
+    return [
+        "HME-4",
+        "112233445566",
+        "HMG-50",
+        "02B250000001",
+        str(phase_targets[0]),
+        str(phase_targets[1]),
+        str(phase_targets[2]),
+        str(sum(phase_targets)),
+        "0",
+        "0",
+        "0",
+        "0",  # *_chrg_nb
+        "-50",
+        "1",  # wifi_rssi, info_idx
+        "0",
+        "0",
+        "0",
+        "0",
+        "0",  # x/A/B/C/ABC chrg_power
+        "0",
+        str(dchrg[0]),
+        str(dchrg[1]),
+        str(dchrg[2]),
+        "0",  # x/A/B/C/ABC dchrg_power
+    ]
+
+
+def test_idle_on_cross_phase_discharge_when_flag_on() -> None:
+    """A charging battery sees another phase's dchrg>0 → target snaps to 0."""
+    b = _battery(idle_on_cross_phase_discharge=True)  # phase A
+    b._current_power = -500.0  # currently charging
+
+    # phase_C grid = -500 (charge signal); B_dchrg = 400 (cross-phase
+    # discharge instruction from another battery on phase B).
+    fields = _response_fields(phase_targets=(0, 0, -500), dchrg=(0, 400, 0))
+    b._handle_ct_response(fields)
+
+    assert b.target_power == 0.0, (
+        f"Expected target forced to 0 by cross-phase dchrg signal, got {b.target_power}"
+    )
+
+
+def test_no_idle_when_flag_off() -> None:
+    """Flag off → cross-phase dchrg ignored, integral target rule applies."""
+    b = _battery(idle_on_cross_phase_discharge=False)  # phase A
+    b._current_power = -500.0
+
+    fields = _response_fields(phase_targets=(0, 0, -500), dchrg=(0, 400, 0))
+    b._handle_ct_response(fields)
+
+    # current_power=-500 + grid_reading=-500 → -1000
+    assert b.target_power == -1000.0
+
+
+def test_idle_ignores_own_phase_dchrg() -> None:
+    """A_dchrg on the battery's own phase doesn't trigger the idle rule."""
+    b = _battery(idle_on_cross_phase_discharge=True)  # phase A
+    b._current_power = -500.0
+
+    # Same-phase (A) dchrg should NOT trigger idle.  Use grid -500 so
+    # the integral rule wants new_target = -1000.
+    fields = _response_fields(phase_targets=(-500, 0, 0), dchrg=(400, 0, 0))
+    b._handle_ct_response(fields)
+
+    assert b.target_power == -1000.0
+
+
 def test_parse_config_power_update_delay_ticks() -> None:
     data = {
         "power_update_delay_ticks": 3,
@@ -84,3 +204,23 @@ def test_parse_config_power_update_delay_ticks() -> None:
     assert cfg.power_update_delay_ticks == 3
     assert cfg.batteries[0].power_update_delay_ticks == 3
     assert cfg.batteries[1].power_update_delay_ticks == 1
+
+
+def test_parse_config_venus_d_fields() -> None:
+    data = {
+        "batteries": [
+            {
+                "mac": "02B250000001",
+                "phase": "A",
+                "max_dc_input": 800,
+                "dc_input_power": 500,
+                "idle_on_cross_phase_discharge": True,
+            },
+        ],
+    }
+    cfg = parse_config(data)
+    validate_config(cfg)
+    bc = cfg.batteries[0]
+    assert bc.max_dc_input == 800
+    assert bc.dc_input_power == 500.0
+    assert bc.idle_on_cross_phase_discharge is True

--- a/src/astrameter/simulator/powermeter_sim.py
+++ b/src/astrameter/simulator/powermeter_sim.py
@@ -54,6 +54,7 @@ class PowermeterSimulator:
         self._app.router.add_post(
             "/batteries/{mac}/max_power", self._handle_set_battery_max_power
         )
+        self._app.router.add_post("/batteries/{mac}/dc", self._handle_set_battery_dc)
         self._app.router.add_post("/auto", self._handle_set_auto)
         self._app.router.add_post("/shutdown", self._handle_shutdown)
 
@@ -156,6 +157,37 @@ class PowermeterSimulator:
             battery.max_charge_power = charge
         if discharge is not None:
             battery.max_discharge_power = discharge
+        return web.json_response(self._build_status())
+
+    async def _handle_set_battery_dc(self, request: web.Request) -> web.Response:
+        mac = request.match_info["mac"].upper()
+        battery = self._find_battery(mac)
+        if battery is None:
+            return web.json_response({"error": "battery not found"}, status=404)
+        if battery.max_dc_input <= 0:
+            return web.json_response(
+                {"error": "battery has no DC input capability"}, status=400
+            )
+        body = await self._parse_json(request)
+        if isinstance(body, web.Response):
+            return body
+        raw = body.get("watts")
+        if raw is None:
+            return web.json_response({"error": "missing 'watts'"}, status=400)
+        try:
+            watts = float(raw)
+        except (ValueError, TypeError):
+            return web.json_response({"error": "invalid 'watts'"}, status=400)
+        if watts < 0 or watts > battery.max_dc_input:
+            return web.json_response(
+                {
+                    "error": (
+                        f"watts must be within [0, {battery.max_dc_input}], got {watts}"
+                    )
+                },
+                status=400,
+            )
+        battery.dc_input_power = watts
         return web.json_response(self._build_status())
 
     async def _handle_set_auto(self, request: web.Request) -> web.Response:

--- a/src/astrameter/simulator/powermeter_sim.py
+++ b/src/astrameter/simulator/powermeter_sim.py
@@ -11,6 +11,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import math
 from typing import TYPE_CHECKING
 
 from aiohttp import web
@@ -177,6 +178,8 @@ class PowermeterSimulator:
         try:
             watts = float(raw)
         except (ValueError, TypeError):
+            return web.json_response({"error": "invalid 'watts'"}, status=400)
+        if not math.isfinite(watts):
             return web.json_response({"error": "invalid 'watts'"}, status=400)
         if watts < 0 or watts > battery.max_dc_input:
             return web.json_response(

--- a/src/astrameter/simulator/runner.py
+++ b/src/astrameter/simulator/runner.py
@@ -27,6 +27,9 @@ class BatteryConfig:
     ramp_rate: float = 200.0
     poll_interval: float = 1.0
     power_update_delay_ticks: int = 0
+    max_dc_input: int = 0
+    dc_input_power: float = 0.0
+    idle_on_cross_phase_discharge: bool = False
 
 
 @dataclass
@@ -94,6 +97,9 @@ class SimulationRunner:
                 poll_interval=bc.poll_interval,
                 time_scale=cfg.time_scale,
                 power_update_delay_ticks=bc.power_update_delay_ticks,
+                max_dc_input=bc.max_dc_input,
+                dc_input_power=bc.dc_input_power,
+                idle_on_cross_phase_discharge=bc.idle_on_cross_phase_discharge,
             )
             for bc in cfg.batteries
         ]
@@ -174,6 +180,11 @@ def parse_config(data: dict) -> SimulationConfig:
             ramp_rate=bd.get("ramp_rate", 200.0),
             poll_interval=bd.get("poll_interval", 1.0),
             power_update_delay_ticks=int(delay),
+            max_dc_input=int(bd.get("max_dc_input", 0)),
+            dc_input_power=float(bd.get("dc_input_power", 0.0)),
+            idle_on_cross_phase_discharge=bool(
+                bd.get("idle_on_cross_phase_discharge", False)
+            ),
         )
         batteries.append(bc)
 
@@ -215,6 +226,15 @@ def validate_config(cfg: SimulationConfig) -> None:
             raise ValueError(
                 f"Battery {bc.mac}: power_update_delay_ticks must be >= 0, "
                 f"got {bc.power_update_delay_ticks}"
+            )
+        if bc.max_dc_input < 0:
+            raise ValueError(
+                f"Battery {bc.mac}: max_dc_input must be >= 0, got {bc.max_dc_input}"
+            )
+        if not (0.0 <= bc.dc_input_power <= max(0.0, float(bc.max_dc_input))):
+            raise ValueError(
+                f"Battery {bc.mac}: dc_input_power must be within "
+                f"[0, max_dc_input={bc.max_dc_input}], got {bc.dc_input_power}"
             )
         mac = bc.mac.upper()
         if len(mac) != 12 or not all(c in "0123456789ABCDEF" for c in mac):

--- a/src/astrameter/simulator/runner.py
+++ b/src/astrameter/simulator/runner.py
@@ -231,7 +231,7 @@ def validate_config(cfg: SimulationConfig) -> None:
             raise ValueError(
                 f"Battery {bc.mac}: max_dc_input must be >= 0, got {bc.max_dc_input}"
             )
-        if not (0.0 <= bc.dc_input_power <= max(0.0, float(bc.max_dc_input))):
+        if not 0.0 <= bc.dc_input_power <= bc.max_dc_input:
             raise ValueError(
                 f"Battery {bc.mac}: dc_input_power must be within "
                 f"[0, max_dc_input={bc.max_dc_input}], got {bc.dc_input_power}"

--- a/tests/test_ct002_protocol.py
+++ b/tests/test_ct002_protocol.py
@@ -179,12 +179,14 @@ def test_ct002_splits_mixed_sign_instructions_per_storage_before_aggregation():
 
 
 def test_ct002_pv_passthrough_does_not_appear_as_dchrg():
-    """Regression for #376: positive *report* but negative *instruction* must
-    not populate *_dchrg_power (otherwise other batteries idle)."""
+    """Regression for #376: positive *report* but negative *net instruction*
+    must not populate *_dchrg_power (otherwise other batteries idle)."""
     device = CT002()
     request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "C", "-100"]
 
-    # Venus D reports +500 (PV passthrough) but we instructed -500 (charge).
+    # Venus D reports +500 (PV passthrough) but its net instructed target is
+    # -500 (we expect it to charge, even though firmware will keep
+    # passing PV through).
     device._update_consumer_report("venus-d", phase="A", power=500)
     device._consumers["venus-d"].last_instructed_power = -500.0
 
@@ -194,7 +196,28 @@ def test_ct002_pv_passthrough_does_not_appear_as_dchrg():
     )
 
     assert response[20] == "0"  # A_dchrg_power must be 0
-    assert response[15] == "-500"  # A_chrg_power reflects the instruction
+    assert response[15] == "-500"  # A_chrg_power reflects the net instruction
+
+
+def test_ct002_discharging_battery_with_small_correction_keeps_dchrg_signal():
+    """Net-power semantics: a battery discharging at +500 W that we just
+    corrected down by 100 must still register as discharging (+400 W),
+    not flip into the charge bucket on the strength of the delta alone."""
+    device = CT002()
+    request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "B", "0"]
+
+    # Venus on phase A is discharging at 500 W; we just sent it a -100 W
+    # correction (charge a little) → net target 400 W (still discharging).
+    device._update_consumer_report("venus-a", phase="A", power=500)
+    device._consumers["venus-a"].last_instructed_power = 400.0
+
+    response = device._build_response_fields(
+        request_fields=request_fields,
+        values=[0, 0, 0],
+    )
+
+    assert response[20] == "400"  # A_dchrg_power = net 400 W discharge
+    assert response[15] == "0"  # A_chrg_power stays 0
 
 
 def test_ct002_info_idx_increments_and_wraps():

--- a/tests/test_ct002_protocol.py
+++ b/tests/test_ct002_protocol.py
@@ -283,24 +283,24 @@ async def test_handle_request_pv_passthrough_records_zero_net_target():
     assert by_phase["A"]["chrg_power"] == 0
 
 
-async def test_handle_request_records_net_target_in_inspection_mode():
-    """Inspection-mode requests record ``last_instructed_power`` the same
-    way normal requests do — only the values sent over differ (raw
-    meter readings rather than balancer-computed deltas).  The battery
-    in inspection mode is actively probing each phase to learn which
-    one reacts to its output, so it applies the response normally."""
+async def test_handle_request_skips_instruction_update_in_inspection_mode():
+    """No instruction is being given in inspection mode — we send raw
+    meter readings as information so the battery can identify its phase,
+    and the battery runs its phase-discovery routine rather than our
+    integral controller.  ``last_instructed_power`` would mix unrelated
+    quantities (the battery's probe + a meter reading we don't expect
+    it to apply) and would be attributed to phase A since the battery
+    hasn't declared its real phase, so it must stay untouched."""
     device = CT002(ct_mac="112233445566", active_control=False)
     await _drive_request(
         device,
         battery_mac="AABBCCDDEEFF",
-        phase="0",  # inspection
+        phase="0",
         reported_power=100,
-        delta_values=[50, 60, 70],
+        delta_values=[500, 0, 0],
     )
     consumer = device._consumers["aabbccddeeff"]
-    # Phase defaults to "A" during inspection, so phase_idx=0; net target
-    # = reported_power + values[0] = 100 + 50 = 150.
-    assert consumer.last_instructed_power == 150.0
+    assert consumer.last_instructed_power == 0.0
 
 
 def test_ct002_info_idx_increments_and_wraps():

--- a/tests/test_ct002_protocol.py
+++ b/tests/test_ct002_protocol.py
@@ -1,4 +1,5 @@
 import logging
+from unittest.mock import MagicMock
 
 from astrameter.ct002 import CT002, ReportingConsumerRow
 from astrameter.ct002.protocol import (
@@ -218,6 +219,83 @@ def test_ct002_discharging_battery_with_small_correction_keeps_dchrg_signal():
 
     assert response[20] == "400"  # A_dchrg_power = net 400 W discharge
     assert response[15] == "0"  # A_chrg_power stays 0
+
+
+async def _drive_request(
+    device: CT002,
+    battery_mac: str,
+    phase: str,
+    reported_power: int,
+    delta_values: list[float],
+) -> None:
+    """Send one UDP request through ``_handle_request`` with a pinned
+    ``before_send`` that injects *delta_values* as the per-phase deltas
+    AstraMeter will return.  Drives the production path that populates
+    ``last_instructed_power``."""
+    transport = MagicMock()
+
+    async def before_send(_addr, _fields, _consumer_id):
+        return list(delta_values)
+
+    device.before_send = before_send
+    request = build_payload(
+        ["HMG-50", battery_mac, "HME-4", "112233445566", phase, str(reported_power)]
+    )
+    await device._handle_request(request, ("1.1.1.1", 12345), transport)
+
+
+async def test_handle_request_records_net_instructed_power_not_delta():
+    """Regression for the delta-vs-net mistake.
+
+    Venus discharging at +500 W, we correct down by 100 W.  The simulator
+    interprets the response as ``new_target = current_power + grid_reading``,
+    so the *net* target is +400 W.  ``last_instructed_power`` must record
+    400, not the raw -100 delta."""
+    device = CT002(ct_mac="112233445566", active_control=False)
+    await _drive_request(
+        device,
+        battery_mac="AABBCCDDEEFF",
+        phase="A",
+        reported_power=500,
+        delta_values=[-100, 0, 0],
+    )
+    consumer = device._consumers["aabbccddeeff"]
+    assert consumer.last_instructed_power == 400.0, (
+        f"Expected net target 500 + (-100) = 400, got {consumer.last_instructed_power}"
+    )
+
+
+async def test_handle_request_pv_passthrough_records_zero_net_target():
+    """Venus D scenario from issue #376: reports +500 (passthrough), we
+    send a -500 charge delta → net target 0, A_dchrg_power must be 0."""
+    device = CT002(ct_mac="112233445566", active_control=False)
+    await _drive_request(
+        device,
+        battery_mac="AABBCCDDEEFF",
+        phase="A",
+        reported_power=500,
+        delta_values=[-500, 0, 0],
+    )
+    consumer = device._consumers["aabbccddeeff"]
+    assert consumer.last_instructed_power == 0.0
+    by_phase = device._collect_reports_by_phase()
+    assert by_phase["A"]["dchrg_power"] == 0
+    assert by_phase["A"]["chrg_power"] == 0
+
+
+async def test_handle_request_skips_instruction_update_in_inspection_mode():
+    """Inspection-mode requests (phase ``0``) must not pollute
+    ``last_instructed_power`` — the battery isn't applying the value yet."""
+    device = CT002(ct_mac="112233445566", active_control=False)
+    await _drive_request(
+        device,
+        battery_mac="AABBCCDDEEFF",
+        phase="0",
+        reported_power=0,
+        delta_values=[123, 456, 789],
+    )
+    consumer = device._consumers["aabbccddeeff"]
+    assert consumer.last_instructed_power == 0.0
 
 
 def test_ct002_info_idx_increments_and_wraps():

--- a/tests/test_ct002_protocol.py
+++ b/tests/test_ct002_protocol.py
@@ -95,20 +95,34 @@ def test_reporting_consumer_rows_order_and_shape() -> None:
     )
 
 
-def test_ct002_relays_sum_of_all_storage_reports_by_phase():
+def _set_instruction(
+    device: CT002, consumer_id: str, phase: str, instructed: float
+) -> None:
+    """Record an instruction value for *consumer_id* on *phase*.
+
+    The cross-talk *_chrg_power / *_dchrg_power fields aggregate the
+    *instructions* AstraMeter sends to each battery, not the powers they
+    report.  Tests that want to assert on the aggregate must populate the
+    instruction state, not just the report.
+    """
+    device._update_consumer_report(consumer_id, phase=phase, power=0)
+    device._consumers[consumer_id].last_instructed_power = float(instructed)
+
+
+def test_ct002_relays_sum_of_charge_instructions_by_phase():
     device = CT002()
     request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "B", "-100"]
 
-    # consumer-a reports charge-like value on phase A, consumer-b on phase B
-    device._update_consumer_report("consumer-a", phase="A", power=-180)
-    device._update_consumer_report("consumer-b", phase="B", power=-240)
+    # We *instructed* consumer-a to charge on A and consumer-b to charge on B.
+    _set_instruction(device, "consumer-a", phase="A", instructed=-180)
+    _set_instruction(device, "consumer-b", phase="B", instructed=-240)
 
     response_for_a = device._build_response_fields(
         request_fields=request_fields,
         values=[10, 20, 30],
     )
 
-    # negative sums are forwarded into *_chrg_power
+    # negative instructions are forwarded into *_chrg_power
     assert response_for_a[15] == "-180"  # A_chrg_power
     assert response_for_a[16] == "-240"  # B_chrg_power
     assert response_for_a[21] == "0"  # B_dchrg_power
@@ -124,19 +138,19 @@ def test_ct002_relays_sum_of_all_storage_reports_by_phase():
     assert response_for_b[16] == "-240"  # B_chrg_power
 
 
-def test_ct002_splits_positive_phase_sum_into_dchrg_fields():
+def test_ct002_splits_positive_instructions_into_dchrg_fields():
     device = CT002()
     request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "B", "100"]
 
-    device._update_consumer_report("consumer-a", phase="A", power=500)
-    device._update_consumer_report("consumer-b", phase="B", power=800)
+    _set_instruction(device, "consumer-a", phase="A", instructed=500)
+    _set_instruction(device, "consumer-b", phase="B", instructed=800)
 
     response = device._build_response_fields(
         request_fields=request_fields,
         values=[10, 20, 30],
     )
 
-    # positive sums are forwarded into *_dchrg_power
+    # positive instructions are forwarded into *_dchrg_power
     assert response[15] == "0"  # A_chrg_power
     assert response[16] == "0"  # B_chrg_power
     assert response[20] == "500"  # A_dchrg_power
@@ -145,23 +159,42 @@ def test_ct002_splits_positive_phase_sum_into_dchrg_fields():
     assert response[9] == "1"  # B_chrg_nb
 
 
-def test_ct002_splits_mixed_sign_reports_per_storage_before_aggregation():
+def test_ct002_splits_mixed_sign_instructions_per_storage_before_aggregation():
     device = CT002()
     request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "A", "0"]
 
-    # Same phase, opposite directions from different storages.
-    device._update_consumer_report("consumer-a", phase="A", power=-300)
-    device._update_consumer_report("consumer-b", phase="A", power=120)
+    # Same phase, opposite instructions to different storages.
+    _set_instruction(device, "consumer-a", phase="A", instructed=-300)
+    _set_instruction(device, "consumer-b", phase="A", instructed=120)
 
     response = device._build_response_fields(
         request_fields=request_fields,
         values=[10, 20, 30],
     )
 
-    # Split is done per storage report before phase aggregation.
+    # Split is done per storage instruction before phase aggregation.
     assert response[15] == "-300"  # A_chrg_power
     assert response[20] == "120"  # A_dchrg_power
     assert response[8] == "1"  # A_chrg_nb active flag
+
+
+def test_ct002_pv_passthrough_does_not_appear_as_dchrg():
+    """Regression for #376: positive *report* but negative *instruction* must
+    not populate *_dchrg_power (otherwise other batteries idle)."""
+    device = CT002()
+    request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "C", "-100"]
+
+    # Venus D reports +500 (PV passthrough) but we instructed -500 (charge).
+    device._update_consumer_report("venus-d", phase="A", power=500)
+    device._consumers["venus-d"].last_instructed_power = -500.0
+
+    response = device._build_response_fields(
+        request_fields=request_fields,
+        values=[0, 0, -500],
+    )
+
+    assert response[20] == "0"  # A_dchrg_power must be 0
+    assert response[15] == "-500"  # A_chrg_power reflects the instruction
 
 
 def test_ct002_info_idx_increments_and_wraps():

--- a/tests/test_ct002_protocol.py
+++ b/tests/test_ct002_protocol.py
@@ -283,19 +283,24 @@ async def test_handle_request_pv_passthrough_records_zero_net_target():
     assert by_phase["A"]["chrg_power"] == 0
 
 
-async def test_handle_request_skips_instruction_update_in_inspection_mode():
-    """Inspection-mode requests (phase ``0``) must not pollute
-    ``last_instructed_power`` — the battery isn't applying the value yet."""
+async def test_handle_request_records_net_target_in_inspection_mode():
+    """Inspection-mode requests record ``last_instructed_power`` the same
+    way normal requests do — only the values sent over differ (raw
+    meter readings rather than balancer-computed deltas).  The battery
+    in inspection mode is actively probing each phase to learn which
+    one reacts to its output, so it applies the response normally."""
     device = CT002(ct_mac="112233445566", active_control=False)
     await _drive_request(
         device,
         battery_mac="AABBCCDDEEFF",
-        phase="0",
-        reported_power=0,
-        delta_values=[123, 456, 789],
+        phase="0",  # inspection
+        reported_power=100,
+        delta_values=[50, 60, 70],
     )
     consumer = device._consumers["aabbccddeeff"]
-    assert consumer.last_instructed_power == 0.0
+    # Phase defaults to "A" during inspection, so phase_idx=0; net target
+    # = reported_power + values[0] = 100 + 50 = 150.
+    assert consumer.last_instructed_power == 150.0
 
 
 def test_ct002_info_idx_increments_and_wraps():

--- a/tests/test_issue376_pv_passthrough.py
+++ b/tests/test_issue376_pv_passthrough.py
@@ -1,0 +1,202 @@
+"""Regression test for GitHub issue #376.
+
+A Venus D-like battery (full SoC, PV passthrough → AC) on phase A reports
+positive ``power`` to the CT002 emulator while a Venus E-like battery on
+phase C is charging.  Real Marstek firmware reads ``*_dchrg_power`` from
+the CT002 response and idles a charging battery when another phase shows
+discharge — that's the user-visible bug: Venus E stops charging the
+moment Venus D enables "feed excess to grid."
+
+This test wires a deterministic CT002 + two simulated batteries + a
+powermeter showing strong household export.  It verifies that AstraMeter
+keeps instructing Venus E to charge across many ticks (i.e. it does not
+broadcast Venus D's passthrough as a discharge signal).
+"""
+
+from __future__ import annotations
+
+import socket
+import time
+
+from astrameter.ct002.ct002 import CT002
+from astrameter.simulator.battery import BatterySimulator
+from astrameter.simulator.load_model import LoadModel
+from astrameter.simulator.powermeter_sim import PowermeterSimulator
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self._now = time.time()
+
+    def __call__(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+
+def _find_free_ports(n: int) -> list[int]:
+    types = [socket.SOCK_DGRAM] + [socket.SOCK_STREAM] * (n - 1)
+    ports: list[int] = []
+    socks: list[socket.socket] = []
+    for i in range(n):
+        s = socket.socket(socket.AF_INET, types[i])
+        s.bind(("127.0.0.1", 0))
+        ports.append(s.getsockname()[1])
+        socks.append(s)
+    for s in socks:
+        s.close()
+    return ports
+
+
+class _Issue376Harness:
+    """Two-battery harness: Venus D-like (PV passthrough) + Venus E-like.
+
+    - Venus D on phase A, SoC=1.0, ``max_dc_input=500``, dc_input_power=500.
+    - Venus E on phase C, SoC=0.5, charging.
+    - Powermeter shows strong household export on all phases.
+    - Both batteries enable ``idle_on_cross_phase_discharge`` so the
+      simulator mirrors the Marstek firmware reaction this issue is about.
+    """
+
+    def __init__(self) -> None:
+        ct_port, http_port = _find_free_ports(2)
+        self.ct_port = ct_port
+        self.http_port = http_port
+        self.clock = _FakeClock()
+
+        # Strong export on all phases (mirrors the Tasmota readings in the
+        # log attached to issue #376: l1=-7480, l2=-7820, l3=-3933).
+        # Use base_load < 0 since LoadModel adds base_load and battery output
+        # to derive grid contribution; negative base_load means the meter
+        # sees export even before batteries kick in.
+        self.load_model = LoadModel(
+            base_load=[-7000.0, -7800.0, -3900.0],
+            base_noise=0.0,
+            loads=[],
+        )
+
+        ct_mac = "112233445566"
+        self.venus_d = BatterySimulator(
+            mac="02B250000001",
+            phase="A",
+            ct_mac=ct_mac,
+            ct_host="127.0.0.1",
+            ct_port=ct_port,
+            max_charge_power=800,
+            max_discharge_power=800,
+            initial_soc=1.0,
+            ramp_rate=400.0,
+            poll_interval=0.3,
+            min_power_threshold=5.0,
+            startup_delay=0.0,
+            inspection_count=0,
+            max_dc_input=500,
+            dc_input_power=500.0,
+            idle_on_cross_phase_discharge=True,
+        )
+        self.venus_e = BatterySimulator(
+            mac="02B250000002",
+            phase="C",
+            ct_mac=ct_mac,
+            ct_host="127.0.0.1",
+            ct_port=ct_port,
+            max_charge_power=2500,
+            max_discharge_power=2500,
+            initial_soc=0.5,
+            ramp_rate=400.0,
+            poll_interval=0.3,
+            min_power_threshold=5.0,
+            startup_delay=0.0,
+            inspection_count=0,
+            idle_on_cross_phase_discharge=True,
+        )
+        self.batteries = [self.venus_d, self.venus_e]
+
+        self.powermeter = PowermeterSimulator(
+            batteries=self.batteries,
+            load_model=self.load_model,
+            host="127.0.0.1",
+            port=http_port,
+        )
+
+        self.ct002 = CT002(
+            udp_port=ct_port,
+            ct_mac=ct_mac,
+            active_control=True,
+            fair_distribution=True,
+            min_efficient_power=0,
+            clock=self.clock,
+            reset_fn=None,
+        )
+
+        async def update_readings(_addr, _fields=None, _consumer_id=None):
+            grid = self.powermeter.compute_grid()
+            return [grid["phase_a"], grid["phase_b"], grid["phase_c"]]
+
+        self.ct002.before_send = update_readings
+
+    async def start(self) -> None:
+        await self.powermeter.start()
+        await self.ct002.start()
+
+    async def stop(self) -> None:
+        await self.ct002.stop()
+        await self.powermeter.stop()
+
+    async def step(self, n: int = 1) -> None:
+        for _ in range(n):
+            max_dt = max(b.poll_interval for b in self.batteries)
+            for b in self.batteries:
+                await b.step(b.poll_interval)
+            self.clock.advance(max_dt)
+
+
+async def test_venus_e_keeps_charging_during_venus_d_pv_passthrough() -> None:
+    h = _Issue376Harness()
+    await h.start()
+    try:
+        # Warm-up: let inspection mode complete (n=0 so this is fast) and
+        # let the balancer settle.
+        await h.step(40)
+
+        # Track Venus E's power over the final 10 ticks.
+        venus_e_powers: list[float] = []
+        for _ in range(10):
+            await h.step(1)
+            venus_e_powers.append(h.venus_e.current_power)
+
+        avg_venus_e = sum(venus_e_powers) / len(venus_e_powers)
+
+        # 1. Primary assertion: Venus E is still charging hard, not idle.
+        #    Before the fix the firmware-mimic flag drives this to ~0
+        #    once Venus D's passthrough lands in A_dchrg_power.
+        assert avg_venus_e < -500.0, (
+            f"Venus E should be charging (current_power << 0) despite Venus D's "
+            f"PV passthrough; got avg={avg_venus_e:.0f}, samples={venus_e_powers}"
+        )
+
+        # 2. A_dchrg_power in CT002 state must be 0 — Venus D's positive
+        #    output must not be broadcast as a discharge signal.
+        by_phase = h.ct002._collect_reports_by_phase()
+        assert by_phase["A"]["dchrg_power"] == 0, (
+            f"A_dchrg_power should be 0 (Venus D was instructed to charge); "
+            f"got {by_phase}"
+        )
+
+        # 3. Sanity: Venus D *was* instructed to charge.
+        venus_d_consumer = h.ct002._consumers.get(h.venus_d.mac.lower())
+        assert venus_d_consumer is not None
+        assert venus_d_consumer.last_instructed_power < 0.0, (
+            f"Venus D should have been instructed to charge "
+            f"(negative target on phase A); got "
+            f"last_instructed_power={venus_d_consumer.last_instructed_power}"
+        )
+
+        # 4. Sanity: Venus D is in fact passing PV through to AC.
+        assert h.venus_d.current_power > 0, (
+            f"Venus D should be doing PV passthrough; got "
+            f"current_power={h.venus_d.current_power}"
+        )
+    finally:
+        await h.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -163,7 +163,7 @@ wheels = [
 
 [[package]]
 name = "astrameter"
-version = "1.1.0"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
When one Marstek battery is full and passing PV through to AC (positive power report) while another is charging on a different phase, the second battery's firmware reads the cross-talk `*_dchrg_power` field as "another battery is discharging" and goes idle to avoid battery-to-battery feed. This stopped Venus E from charging the moment Venus D enabled excess feed-in even with the household exporting many kW of PV.

The CT002 wire format can't distinguish PV passthrough from intentional battery discharge, but AstraMeter already knows what it told each battery to do via the balancer's per-phase target. Aggregate the *instruction* into `*_chrg_power` / `*_dchrg_power` instead of the reported power, so involuntary positive output from a saturated battery no longer looks like a discharge to the rest of the fleet.

Adds a Venus D-like option to the BatterySimulator (DC input that passes through to AC at 100% SoC) plus an opt-in firmware-mimicking `idle_on_cross_phase_discharge` flag that reproduces the bug at the simulator level, and a deterministic regression test that exercises the full CT002 + simulator + powermeter stack against the scenario from the issue's debug log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented startup timeout by ensuring powermeter state is seeded on subscription.
  * Fixed multi-battery PV passthrough so one battery’s passthrough won’t stop charging on other phases.

* **New Features**
  * Added DC (solar/charger) input support to battery simulators with configurable max and active input.
  * Added HTTP control endpoint to set battery DC input power and reflected DC status in simulator output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/AstraMeter/pull/384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->