### PR TITLE
Add Modbus UDP transport support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- **Added** Modbus UDP support via a `TRANSPORT = TCP|UDP` option in the `[MODBUS]` section (defaults to `TCP`).
 - **Fixed** Home Assistant powermeter timing out on startup with "Timeout waiting for Home Assistant state" when the `subscribe_entities` initial snapshot never arrives (e.g. entity not yet loaded when AstraMeter starts). The Home Assistant powermeter now also issues an explicit `get_states` fetch right after subscribing to seed the cache.
 - **Fixed** multi-Venus setups where a battery passing PV through to the grid (full SoC with "feed excess to grid" enabled) caused other batteries on different phases to stop charging. AstraMeter now populates the CT002 cross-talk `*_chrg_power` / `*_dchrg_power` fields from the per-battery instruction it sent rather than from the battery's reported AC output, so involuntary PV-passthrough no longer looks like a battery discharge to the rest of the fleet ([#376](https://github.com/tomquist/astrameter/issues/376)).
 

--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ ID = your_id
 IP = 192.168.1.108
 ```
 
-### Modbus TCP
+### Modbus TCP/UDP
 
 ```ini
 [MODBUS]
@@ -653,6 +653,7 @@ DATA_TYPE = UINT16
 BYTE_ORDER = BIG
 WORD_ORDER = BIG
 REGISTER_TYPE = HOLDING  # or INPUT
+TRANSPORT = TCP  # or UDP
 ```
 
 ### MQTT
@@ -801,7 +802,10 @@ DATA_TYPE = UINT16
 BYTE_ORDER = BIG
 WORD_ORDER = BIG
 REGISTER_TYPE = HOLDING
+TRANSPORT = TCP
 ```
+
+`TRANSPORT` selects the Modbus transport: `TCP` (default) or `UDP`.
 
 ### Script
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -247,6 +247,8 @@ THROTTLE_INTERVAL = 0
 #BYTE_ORDER = BIG
 #WORD_ORDER = BIG
 #REGISTER_TYPE = HOLDING
+## Transport: TCP (default) or UDP
+#TRANSPORT = TCP
 ## Per-powermeter throttling override (optional)
 #THROTTLE_INTERVAL = 1
 

--- a/src/astrameter/config/config_loader.py
+++ b/src/astrameter/config/config_loader.py
@@ -530,6 +530,7 @@ def create_modbus_powermeter(
         config.get(section, "BYTE_ORDER", fallback="BIG"),
         config.get(section, "WORD_ORDER", fallback="BIG"),
         config.get(section, "REGISTER_TYPE", fallback="HOLDING"),
+        config.get(section, "TRANSPORT", fallback="TCP"),
     )
 
 

--- a/src/astrameter/powermeter/modbus.py
+++ b/src/astrameter/powermeter/modbus.py
@@ -1,8 +1,13 @@
-from pymodbus.client import AsyncModbusTcpClient
+from pymodbus.client import AsyncModbusTcpClient, AsyncModbusUdpClient
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
 
 from .base import Powermeter
+
+TRANSPORTS = {
+    "TCP": AsyncModbusTcpClient,
+    "UDP": AsyncModbusUdpClient,
+}
 
 DATA_TYPE_DECODERS = {
     "FLOAT32": "decode_32bit_float",
@@ -36,6 +41,7 @@ class ModbusPowermeter(Powermeter):
         byte_order="BIG",
         word_order="BIG",
         register_type="HOLDING",
+        transport="TCP",
     ):
         self.host = host
         self.port = port
@@ -57,12 +63,19 @@ class ModbusPowermeter(Powermeter):
         if not self._read_method:
             raise ValueError(f"Unsupported register type: {register_type}")
 
-        self.client: AsyncModbusTcpClient | None = None
+        self.transport = transport.upper()
+        if self.transport not in TRANSPORTS:
+            raise ValueError(f"Unsupported transport: {transport}")
+
+        self.client: AsyncModbusTcpClient | AsyncModbusUdpClient | None = None
 
     async def start(self) -> None:
         if self.client:
             return
-        self.client = AsyncModbusTcpClient(self.host, port=self.port)
+        client_cls = (
+            AsyncModbusUdpClient if self.transport == "UDP" else AsyncModbusTcpClient
+        )
+        self.client = client_cls(self.host, port=self.port)
         if not await self.client.connect():
             self.client = None
             raise ConnectionError(f"Failed to connect to {self.host}:{self.port}")

--- a/src/astrameter/powermeter/modbus_test.py
+++ b/src/astrameter/powermeter/modbus_test.py
@@ -7,7 +7,7 @@ from pymodbus.datastore import (
     ModbusServerContext,
     ModbusSlaveContext,
 )
-from pymodbus.server import ModbusTcpServer
+from pymodbus.server import ModbusTcpServer, ModbusUdpServer
 
 from astrameter.powermeter import ModbusPowermeter
 
@@ -96,6 +96,21 @@ async def test_read_before_start_raises():
     pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
     with pytest.raises(RuntimeError, match="Client not started"):
         await pm.get_powermeter_watts()
+
+
+async def test_udp_transport_creates_udp_client():
+    pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1, transport="UDP")
+    with patch("astrameter.powermeter.modbus.AsyncModbusUdpClient") as MockClient:
+        mock_instance = MockClient.return_value
+        mock_instance.connect = AsyncMock(return_value=True)
+        await pm.start()
+        MockClient.assert_called_once_with("192.168.1.14", port=502)
+        assert pm.client is mock_instance
+
+
+async def test_invalid_transport_raises():
+    with pytest.raises(ValueError, match="Unsupported transport"):
+        ModbusPowermeter("192.168.1.14", 502, 1, 0, 1, transport="BOGUS")
 
 
 # ---------------------------------------------------------------------------
@@ -226,5 +241,34 @@ async def test_e2e_input_registers(modbus_server: int):
     try:
         result = await pm.get_powermeter_watts()
         assert result == [750.0]
+    finally:
+        await pm.stop()
+
+
+@pytest.fixture
+async def modbus_udp_server():
+    """Start a local Modbus UDP server on an ephemeral port."""
+    hr_values = [0] * 100
+    hr_values[0] = 500
+
+    store = ModbusSlaveContext(
+        hr=ModbusSequentialDataBlock(0, hr_values),
+        zero_mode=True,
+    )
+    context = ModbusServerContext(slaves=store, single=True)
+    server = ModbusUdpServer(context, address=("127.0.0.1", 0))
+    await server.listen()
+    # UDP uses a datagram transport (no listening socket list like TCP).
+    port = server.transport.get_extra_info("sockname")[1]  # type: ignore[union-attr]
+    yield port
+    await server.shutdown()
+
+
+async def test_e2e_udp_uint16_holding(modbus_udp_server: int):
+    pm = ModbusPowermeter("127.0.0.1", modbus_udp_server, 1, 0, 1, transport="UDP")
+    await pm.start()
+    try:
+        result = await pm.get_powermeter_watts()
+        assert result == [500.0]
     finally:
         await pm.stop()


### PR DESCRIPTION
## Summary
Extends the Modbus powermeter to support both TCP and UDP transports, with TCP remaining the default for backward compatibility.

## Changes
- **ModbusPowermeter** now accepts a `transport` parameter (defaults to `"TCP"`) to select between TCP and UDP
  - Added validation to reject unsupported transport types with a clear error message
  - Updated client instantiation logic to use `AsyncModbusUdpClient` when `transport="UDP"`
- **Config loader** reads the optional `TRANSPORT` setting from `[MODBUS]` sections (defaults to `"TCP"`)
- **Tests** added:
  - Unit test for UDP client creation and connection
  - Unit test for invalid transport rejection
  - End-to-end test with a real Modbus UDP server fixture
- **Documentation** updated:
  - README section title changed from "Modbus TCP" to "Modbus TCP/UDP"
  - Added `TRANSPORT = TCP` option documentation with UDP alternative
  - Example config file includes commented `TRANSPORT` option
  - CHANGELOG entry documenting the new feature

## Implementation Details
- Transport selection uses a `TRANSPORTS` dict mapping transport names to client classes for clean extensibility
- UDP server fixture uses ephemeral port (port 0) and extracts the assigned port from the transport's socket info
- Type hints updated to reflect that `client` can be either TCP or UDP client instance

https://claude.ai/code/session_01QV5esTqTbwnifgjXQ9rfhk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Modbus UDP transport support. Configure via `TRANSPORT = TCP|UDP` option in the `[MODBUS]` configuration section (defaults to TCP).

* **Documentation**
  * Updated documentation and configuration examples to clarify support for both Modbus TCP and UDP transports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/AstraMeter/pull/387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->