### PR TITLE
Document DC battery incompatibility with efficiency rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,15 @@ efficiency optimization detects this situation and concentrates the load on
 fewer batteries so each one stays above its efficient minimum, idling the
 rest. Batteries rotate periodically so wear is shared evenly.
 
+> **Not recommended for DC batteries.** Efficiency rotation relies on being
+> able to steer a deprioritized battery's output down to 0 W. DC-coupled
+> batteries such as the Marstek B2500 cannot be commanded to 0 W via the
+> CT002 protocol — they keep running at their minimum output power (e.g.
+> ~80 W) — so idling them does not work and the feature provides no benefit.
+> It is intended for AC batteries (e.g. the Marstek Venus) that can be
+> steered all the way to 0 W. For DC batteries, leave the efficiency settings
+> below disabled.
+
 When a timed rotation or forced swap promotes a new battery, the handoff now
 uses a **probe phase** instead of dropping the previous active battery to zero
 immediately. During probe, the promoted battery gets the real CT002


### PR DESCRIPTION
Adds a warning to the README clarifying that the efficiency rotation feature is not recommended for DC-coupled batteries, as they cannot be commanded to 0 W via the CT002 protocol and therefore cannot be properly idled.

## Summary

The efficiency rotation feature relies on being able to steer a deprioritized battery's output down to 0 W to idle it. DC-coupled batteries (such as the Marstek B2500) maintain a minimum output power (~80 W) and cannot be commanded to 0 W, making the feature ineffective for them.

## Changes

- Added a prominent warning block in the README under the efficiency rotation section explaining:
  - Why DC batteries are incompatible (cannot reach 0 W output)
  - Which battery types are affected (DC-coupled like Marstek B2500)
  - Which battery types work correctly (AC batteries like Marstek Venus)
  - Recommended action (disable efficiency settings for DC batteries)

https://claude.ai/code/session_01MEEHRSoz9fySQHsTBzQxp3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification regarding the efficiency rotation feature and DC batteries, noting that DC-coupled batteries cannot be steered to 0W. Users with DC batteries are advised to leave related efficiency settings disabled to ensure optimal performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/AstraMeter/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->