### PR TITLE
Fix shellypro3em_old/new variants to use correct device ID prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Added** Modbus UDP support via a `TRANSPORT = TCP|UDP` option in the `[MODBUS]` section (defaults to `TCP`).
 - **Fixed** Home Assistant powermeter timing out on startup with "Timeout waiting for Home Assistant state" when the `subscribe_entities` initial snapshot never arrives (e.g. entity not yet loaded when AstraMeter starts). The Home Assistant powermeter now also issues an explicit `get_states` fetch right after subscribing to seed the cache.
+- **Fixed** `DEVICE_TYPE = shellypro3em_new` (and `shellypro3em_old`) generating an invalid `device-N` source id that the B2500 rejected, so the CT was never detected. These variants now default to a proper `shellypro3em-*` id like the combined `shellypro3em` type ([#389](https://github.com/tomquist/astrameter/issues/389)).
 - **Fixed** multi-Venus setups where a battery passing PV through to the grid (full SoC with "feed excess to grid" enabled) caused other batteries on different phases to stop charging. AstraMeter now populates the CT002 cross-talk `*_chrg_power` / `*_dchrg_power` fields from the per-battery instruction it sent rather than from the battery's reported AC output, so involuntary PV-passthrough no longer looks like a battery discharge to the rest of the fleet ([#376](https://github.com/tomquist/astrameter/issues/376)).
 
 ## 2.0.2

--- a/src/astrameter/main.py
+++ b/src/astrameter/main.py
@@ -620,10 +620,18 @@ def _resolve_device_config(
             device_ids = [
                 did.strip() for did in cfg_device_ids.split(",") if did.strip()
             ]
+    shelly_id_prefixes = {
+        "shellypro3em": "shellypro3em",
+        "shellypro3em_old": "shellypro3em",
+        "shellypro3em_new": "shellypro3em",
+        "shellyemg3": "shellyemg3",
+        "shellyproem50": "shellyproem50",
+    }
     while len(device_ids) < len(device_types):
         device_type = device_types[len(device_ids)]
-        if device_type in ["shellypro3em", "shellyemg3", "shellyproem50"]:
-            device_ids.append(f"{device_type}-ec4609c439c{len(device_ids) + 1}")
+        prefix = shelly_id_prefixes.get(device_type)
+        if prefix is not None:
+            device_ids.append(f"{prefix}-ec4609c439c{len(device_ids) + 1}")
         else:
             device_ids.append(f"device-{len(device_ids) + 1}")
 

--- a/src/astrameter/main_test.py
+++ b/src/astrameter/main_test.py
@@ -1,7 +1,9 @@
+import argparse
+import configparser
 from ipaddress import IPv4Network
 
 from astrameter.config.config_loader import ClientFilter
-from astrameter.main import read_ct_powermeter
+from astrameter.main import _resolve_device_config, read_ct_powermeter
 from astrameter.powermeter import Powermeter
 
 
@@ -82,3 +84,33 @@ async def test_read_ct_powermeter_swallows_timeout_and_serves_cached():
     powermeters = [(pm, _LOCAL, True)]
     result = await read_ct_powermeter(("127.0.0.1", 0), powermeters)
     assert result == [11.0, 22.0, 33.0]
+
+
+def _resolve(device_type: str) -> tuple[list[str], list[str]]:
+    cfg = configparser.ConfigParser()
+    cfg.add_section("GENERAL")
+    cfg.set("GENERAL", "DEVICE_TYPE", device_type)
+    args = argparse.Namespace(
+        device_types=None, skip_powermeter_test=None, device_ids=None
+    )
+    device_types, device_ids, _ = _resolve_device_config(cfg, args)
+    return device_types, device_ids
+
+
+def test_resolve_device_config_shellypro3em_new_gets_shelly_id():
+    """Issue #389: explicit shellypro3em_new must use a shellypro3em-* id."""
+    device_types, device_ids = _resolve("shellypro3em_new")
+    assert device_types == ["shellypro3em_new"]
+    assert device_ids == ["shellypro3em-ec4609c439c1"]
+
+
+def test_resolve_device_config_shellypro3em_old_gets_shelly_id():
+    device_types, device_ids = _resolve("shellypro3em_old")
+    assert device_types == ["shellypro3em_old"]
+    assert device_ids == ["shellypro3em-ec4609c439c1"]
+
+
+def test_resolve_device_config_shellypro3em_expands_to_old_and_new():
+    device_types, device_ids = _resolve("shellypro3em")
+    assert device_types == ["shellypro3em_old", "shellypro3em_new"]
+    assert device_ids == ["shellypro3em-ec4609c439c1", "shellypro3em-ec4609c439c1"]


### PR DESCRIPTION
## Summary
Fixes an issue where `DEVICE_TYPE = shellypro3em_new` and `shellypro3em_old` were generating invalid `device-N` source IDs instead of the proper `shellypro3em-*` format, causing the B2500 to reject them and preventing CT detection.

## Changes
- **Refactored device ID generation logic** in `_resolve_device_config()` to use a `shelly_id_prefixes` dictionary that maps all Shelly device type variants to their correct ID prefix
  - `shellypro3em`, `shellypro3em_old`, and `shellypro3em_new` now all map to the `shellypro3em` prefix
  - `shellyemg3` and `shellyproem50` continue to use their respective prefixes
  - Other device types fall back to the generic `device-N` format
- **Added comprehensive test coverage** with three new test cases:
  - `test_resolve_device_config_shellypro3em_new_gets_shelly_id()` — verifies the new variant generates a `shellypro3em-*` ID
  - `test_resolve_device_config_shellypro3em_old_gets_shelly_id()` — verifies the old variant generates a `shellypro3em-*` ID
  - `test_resolve_device_config_shellypro3em_expands_to_old_and_new()` — verifies the combined type expands correctly with proper IDs
- **Updated CHANGELOG.md** to document the fix for issue #389

## Implementation Details
The fix uses a lookup dictionary instead of hardcoded type checks, making it easier to maintain and extend device type mappings in the future. All Shelly variants now correctly generate IDs with their appropriate prefix, ensuring compatibility with the B2500 device detection.

https://claude.ai/code/session_018Z9twNmeGVSPFXMiRwumPd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed device ID generation for Shelly Pro 3EM device variants. Previous versions of certain variants generated invalid device IDs that were rejected by the system and prevented current transformer detection from functioning. These variants now automatically generate valid, compatible device IDs that are properly recognized and accepted by the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/AstraMeter/pull/392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->