### PR TITLE
ci: run ct002 codegen unit tests in the host-e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,20 @@ jobs:
       - name: Run host-platform E2E (cross-backend esphome suites)
         run: uv run pytest -m esphome_e2e -v
 
+      # The codegen unit tests (test_codegen.py) `importorskip("esphome")` —
+      # they import the esphome Python module to exercise the ct002 schema
+      # validators directly, so they need esphome importable in the venv that
+      # runs pytest (the `uv tool install` above only puts the CLI on PATH).
+      # They're not `esphome_e2e`-marked, so without this they skip in every
+      # job and never actually run. Install esphome into the project venv
+      # last (so it can't perturb the e2e run above) and run them with
+      # --no-sync so `uv run` doesn't drop esphome (it isn't in uv.lock).
+      - name: Install esphome into venv for codegen tests
+        run: uv pip install esphome
+
+      - name: Run ct002 codegen unit tests (esphome schema validators)
+        run: uv run --no-sync pytest tests/components/ct002/test_codegen.py -v
+
   validate:
     needs: [ lint ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The codegen schema-validator tests in `tests/components/ct002/test_codegen.py` `importorskip("esphome")` — they import the esphome **Python module** to exercise the `ct002` schema validators (MAC normalization, three-phase sensor validation) directly. That means they need the esphome module importable in the venv that runs `pytest`.

They ran **nowhere** in CI:

- **`validate`** job — esphome isn't installed → `importorskip` skips them (this is the `ESPHome not installed; skipping codegen unit tests / SKIPPED` line seen in CI logs).
- **`ct002-host-e2e`** job — only puts the esphome **CLI** on PATH (via `uv tool install`, which is an isolated env, not importable), and selects `-m esphome_e2e`, which these tests aren't marked with.
- No other job touches them.

So 8 unit tests were silently dead. (The ESPHome **E2E** tests — the `esphome_e2e`-marked suites — do run correctly in `ct002-host-e2e`; they detect esphome via `shutil.which("esphome")`, so they were unaffected.)

## Fix

Run the codegen tests in the `ct002-host-e2e` job, which already has the esphome toolchain:

```yaml
- name: Install esphome into venv for codegen tests
  run: uv pip install esphome
- name: Run ct002 codegen unit tests (esphome schema validators)
  run: uv run --no-sync pytest tests/components/ct002/test_codegen.py -v
```

- **`--no-sync`** — esphome isn't in `uv.lock`, so a normal `uv run` would re-sync and drop it; `--no-sync` preserves the pip-installed module.
- **Ordered last** — the venv mutation happens after the E2E run, so it can't perturb it.

## Verification

Locally: `uv pip install esphome` + `uv run --no-sync pytest test_codegen.py` → **8 passed**.

CI/tooling-only change; no `CHANGELOG.md` entry (no user-visible behavior change).

https://claude.ai/code/session_01EmFCdUKkFS5gp87kkjr5t1

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmFCdUKkFS5gp87kkjr5t1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * ESPHome external component for running CT002/CT003 emulator on ESP32
  * Modbus UDP transport support (TCP remains default)
  * MQTT Insights integration for Home Assistant discovery and monitoring
  * Marstek cloud device registration
  * DC battery input support with passthrough control

* **Bug Fixes**
  * Home Assistant powermeter startup timeout handling
  * Fixed invalid device ID generation for Shelly Pro 3EM variants
  * Multi-Venus setup PV passthrough no longer misinterpreted as discharge

* **Documentation**
  * Added comprehensive ESPHome and Python powermeter configuration guides
  * Updated troubleshooting with oscillation handling and battery behavior guidance
  * New efficiency warnings for DC batteries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/AstraMeter/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->