### PR TITLE
fix(shelly): shorten powermeter HTTP timeout to fail fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- **Fixed** intermittent CT stalls when the upstream Shelly EM/3EM was slow to respond: the HTTP read timeout is now 2s (was 10s) so an unresponsive Shelly fails fast and the next battery poll can recover, instead of pinning a request handler ([#404](https://github.com/tomquist/astrameter/issues/404)).
 - **Added** a project website (`web/`, deployable to GitHub Pages): a landing page introducing AstraMeter (features, supported devices and power meters, installation options, FAQ) plus a beginner-friendly config generator that walks you through a few questions and produces a ready-to-use Python `config.ini` or ESPHome YAML, with a live preview, save/load/share, and step-by-step ESPHome flashing guidance.
 - **Added** experimental ESPHome external component `ct002` to run the CT002/CT003 emulator directly on an ESP32. See `esphome.example.yaml` and the per-meter grid-power sensor reference in `docs/esphome-powermeters.md` (which also lists meters not yet supported on the ESP, e.g. Enphase Envoy and the SMA Energy Meter). Per-source `config.ini` documentation moved out of the README into `docs/powermeters.md`.
 - **Added** Modbus UDP support via a `TRANSPORT = TCP|UDP` option in the `[MODBUS]` section (defaults to `TCP`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** intermittent CT stalls when the upstream Shelly EM/3EM was slow to respond: the HTTP read timeout is now 2s (was 10s) so an unresponsive Shelly fails fast and the next battery poll can recover, instead of pinning a request handler ([#404](https://github.com/tomquist/astrameter/issues/404)).
+- **Fixed** intermittent CT stalls when an upstream HTTP power meter was slow to respond: the read timeout for the polling HTTP sources (Shelly, AMIS Reader, emlog, ESPHome, ioBroker, generic JSON-HTTP, SHRDZM, Tasmota, VZLogger) is now 2s with a 1s connect timeout (was 10s), so an unresponsive meter fails fast and the next battery poll can recover instead of pinning a request handler ([#404](https://github.com/tomquist/astrameter/issues/404)).
 - **Added** a project website (`web/`, deployable to GitHub Pages): a landing page introducing AstraMeter (features, supported devices and power meters, installation options, FAQ) plus a beginner-friendly config generator that walks you through a few questions and produces a ready-to-use Python `config.ini` or ESPHome YAML, with a live preview, save/load/share, and step-by-step ESPHome flashing guidance.
 - **Added** experimental ESPHome external component `ct002` to run the CT002/CT003 emulator directly on an ESP32. See `esphome.example.yaml` and the per-meter grid-power sensor reference in `docs/esphome-powermeters.md` (which also lists meters not yet supported on the ESP, e.g. Enphase Envoy and the SMA Energy Meter). Per-source `config.ini` documentation moved out of the README into `docs/powermeters.md`.
 - **Added** Modbus UDP support via a `TRANSPORT = TCP|UDP` option in the `[MODBUS]` section (defaults to `TCP`).

--- a/src/astrameter/powermeter/amisreader.py
+++ b/src/astrameter/powermeter/amisreader.py
@@ -11,7 +11,11 @@ class AmisReader(Powermeter):
     async def start(self) -> None:
         if self.session:
             return
-        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
+        # Fail fast: the battery polls ~1/s, so a slow source should error
+        # quickly and let the next poll retry rather than pin a handler.
+        self.session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=2, connect=1)
+        )
 
     async def stop(self) -> None:
         if self.session:

--- a/src/astrameter/powermeter/emlog.py
+++ b/src/astrameter/powermeter/emlog.py
@@ -13,7 +13,11 @@ class Emlog(Powermeter):
     async def start(self) -> None:
         if self.session:
             return
-        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
+        # Fail fast: the battery polls ~1/s, so a slow source should error
+        # quickly and let the next poll retry rather than pin a handler.
+        self.session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=2, connect=1)
+        )
 
     async def stop(self) -> None:
         if self.session:

--- a/src/astrameter/powermeter/esphome.py
+++ b/src/astrameter/powermeter/esphome.py
@@ -14,7 +14,11 @@ class ESPHome(Powermeter):
     async def start(self) -> None:
         if self.session:
             return
-        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
+        # Fail fast: the battery polls ~1/s, so a slow source should error
+        # quickly and let the next poll retry rather than pin a handler.
+        self.session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=2, connect=1)
+        )
 
     async def stop(self) -> None:
         if self.session:

--- a/src/astrameter/powermeter/iobroker.py
+++ b/src/astrameter/powermeter/iobroker.py
@@ -24,7 +24,11 @@ class IoBroker(Powermeter):
     async def start(self) -> None:
         if self.session:
             return
-        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
+        # Fail fast: the battery polls ~1/s, so a slow source should error
+        # quickly and let the next poll retry rather than pin a handler.
+        self.session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=2, connect=1)
+        )
 
     async def stop(self) -> None:
         if self.session:

--- a/src/astrameter/powermeter/json_http.py
+++ b/src/astrameter/powermeter/json_http.py
@@ -41,7 +41,9 @@ class JsonHttpPowermeter(Powermeter):
         self.session = aiohttp.ClientSession(
             auth=self.auth,
             headers=self.headers,
-            timeout=ClientTimeout(total=10),
+            # Fail fast: the battery polls ~1/s, so a slow source should error
+            # quickly and let the next poll retry rather than pin a handler.
+            timeout=ClientTimeout(total=2, connect=1),
         )
 
     async def stop(self) -> None:

--- a/src/astrameter/powermeter/json_http_test.py
+++ b/src/astrameter/powermeter/json_http_test.py
@@ -48,7 +48,7 @@ async def test_headers_and_auth(mock_aiohttp_session):
         mock_cls.assert_called_once_with(
             auth=BasicAuth("user", "pass"),
             headers={"X-Test": "1"},
-            timeout=ClientTimeout(total=10),
+            timeout=ClientTimeout(total=2, connect=1),
         )
         result = await meter.get_powermeter_watts()
         assert result == [50.0]

--- a/src/astrameter/powermeter/shelly.py
+++ b/src/astrameter/powermeter/shelly.py
@@ -14,7 +14,11 @@ class Shelly(Powermeter):
         self._rpc_session: aiohttp.ClientSession | None = None
 
     async def start(self) -> None:
-        timeout = ClientTimeout(total=10)
+        # The battery polls roughly once per second and gives up on the CT long
+        # before a 10s read would return, so fail fast: a slow/unresponsive
+        # Shelly should error quickly and let the next poll retry rather than
+        # pinning a request handler for seconds.
+        timeout = ClientTimeout(total=2, connect=1)
         auth = BasicAuth(self.user, self.password) if self.user else None
         self._session = aiohttp.ClientSession(auth=auth, timeout=timeout)
         self._rpc_session = aiohttp.ClientSession(

--- a/src/astrameter/powermeter/shrdzm.py
+++ b/src/astrameter/powermeter/shrdzm.py
@@ -13,7 +13,11 @@ class Shrdzm(Powermeter):
     async def start(self) -> None:
         if self.session:
             return
-        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
+        # Fail fast: the battery polls ~1/s, so a slow source should error
+        # quickly and let the next poll retry rather than pin a handler.
+        self.session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=2, connect=1)
+        )
 
     async def stop(self) -> None:
         if self.session:

--- a/src/astrameter/powermeter/tasmota.py
+++ b/src/astrameter/powermeter/tasmota.py
@@ -62,7 +62,9 @@ class Tasmota(Powermeter):
     async def start(self) -> None:
         if self.session:
             return
-        self.session = aiohttp.ClientSession(timeout=ClientTimeout(total=10))
+        # Fail fast: the battery polls ~1/s, so a slow source should error
+        # quickly and let the next poll retry rather than pin a handler.
+        self.session = aiohttp.ClientSession(timeout=ClientTimeout(total=2, connect=1))
 
     async def stop(self) -> None:
         if self.session:

--- a/src/astrameter/powermeter/vzlogger.py
+++ b/src/astrameter/powermeter/vzlogger.py
@@ -15,7 +15,11 @@ class VZLogger(Powermeter):
     async def start(self) -> None:
         if self.session:
             return
-        self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10))
+        # Fail fast: the battery polls ~1/s, so a slow source should error
+        # quickly and let the next poll retry rather than pin a handler.
+        self.session = aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=2, connect=1)
+        )
 
     async def stop(self) -> None:
         if self.session:


### PR DESCRIPTION
The B2500 polls the emulator roughly once per second and gives up on the CT long before a 10s HTTP read would return. When the upstream Shelly EM/3EM was slow, a request handler stayed pinned for up to 10s and the battery saw no reading, surfacing as a CT stall. Drop the timeout to 2s (connect 1s) so a slow Shelly errors quickly and the next poll recovers.

Refs #404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and responsiveness of various HTTP-based power meter integrations by making unresponsive devices fail fast. This prevents request handlers from getting stuck, lets frequent battery polling recover sooner, and reduces intermittent CT stalls users may have experienced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->