### PR TITLE
release: pin ESPHome external_components ref in docs/esphome-powermet…

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -16,13 +16,17 @@ print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
 print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
-# Point the ESPHome external_components ref in README.md and esphome.example.yaml
-# at the given git ref (a tag at release time, "develop" between releases).
+# Files carrying a copy-paste `github://tomquist/astrameter@<ref>` external_components
+# snippet that must track the release (tag at release time, "develop" in between).
+COMPONENT_REF_FILES=(README.md esphome.example.yaml docs/esphome-powermeters.md)
+
+# Point the ESPHome external_components ref in the docs/examples above at the
+# given git ref (a tag at release time, "develop" between releases).
 set_component_ref() {
   local ref="$1"
   sed -i.bak -E "s#(github://tomquist/astrameter@)[^[:space:]]+#\1${ref}#g" \
-    README.md esphome.example.yaml
-  rm -f README.md.bak esphome.example.yaml.bak
+    "${COMPONENT_REF_FILES[@]}"
+  rm -f "${COMPONENT_REF_FILES[@]/%/.bak}"
 }
 
 if [ -z "${1:-}" ]; then
@@ -143,7 +147,7 @@ LINE=$(grep -n '^## Next$' CHANGELOG.md | head -1 | cut -d: -f1)
 sed -i.bak "${LINE}s/^## Next$/## $VERSION/" CHANGELOG.md
 rm -f CHANGELOG.md.bak
 
-git add pyproject.toml uv.lock ha_addon/config.yaml README.md esphome.example.yaml CHANGELOG.md
+git add pyproject.toml uv.lock ha_addon/config.yaml "${COMPONENT_REF_FILES[@]}" CHANGELOG.md
 git commit -m "Release v${VERSION}
 
 - Set version in pyproject.toml, uv.lock and ha_addon/config.yaml
@@ -194,8 +198,8 @@ print_info "Resetting ESPHome external_components ref to develop"
 set_component_ref "develop"
 
 needs_commit=false
-if ! git diff --quiet ha_addon/config.yaml README.md esphome.example.yaml; then
-  git add ha_addon/config.yaml README.md esphome.example.yaml
+if ! git diff --quiet ha_addon/config.yaml "${COMPONENT_REF_FILES[@]}"; then
+  git add ha_addon/config.yaml "${COMPONENT_REF_FILES[@]}"
   needs_commit=true
 fi
 

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -103,6 +103,25 @@ external_components:
     components: [ct002]
 """
 
+# Per-meter ESPHome reference doc: carries *several* copy-paste snippets, each
+# with its own @develop ref. All of them must be pinned/reset alongside README,
+# so the fixture deliberately has more than one.
+_DOCS_ESPHOME = """\
+# ESPHome power meters
+
+```yaml
+external_components:
+  - source: github://tomquist/astrameter@develop
+    components: [ct002]
+```
+
+```yaml
+external_components:
+  - source: github://tomquist/astrameter@develop
+    components: [ct002]
+```
+"""
+
 _CHANGELOG = """\
 # Changelog
 
@@ -151,6 +170,8 @@ def _init_sandbox(tmp_path: Path) -> Path:
 
     (work / "README.md").write_text(_README)
     (work / "esphome.example.yaml").write_text(_EXAMPLE)
+    (work / "docs").mkdir()
+    (work / "docs" / "esphome-powermeters.md").write_text(_DOCS_ESPHOME)
     (work / "CHANGELOG.md").write_text(_CHANGELOG)
     (work / "pyproject.toml").write_text(_PYPROJECT)
     (work / "uv.lock").write_text(_UVLOCK)
@@ -187,6 +208,10 @@ def test_release_happy_path(tmp_path: Path) -> None:
     assert "## Next" not in main_changelog
     assert "astrameter@9.9.9" in _show(work, "main", "README.md")
     assert "astrameter@9.9.9" in _show(work, "main", "esphome.example.yaml")
+    # Every snippet in the per-meter doc must be pinned — no stray @develop left.
+    main_docs = _show(work, "main", "docs/esphome-powermeters.md")
+    assert "astrameter@9.9.9" in main_docs
+    assert "astrameter@develop" not in main_docs
 
     # --- tag points at the released commit -----------------------------
     assert "9.9.9" in _git(work, "tag", "--list").split()
@@ -197,6 +222,9 @@ def test_release_happy_path(tmp_path: Path) -> None:
     assert "## Next" in _show(work, "develop", "CHANGELOG.md")
     assert "astrameter@develop" in _show(work, "develop", "README.md")
     assert "astrameter@develop" in _show(work, "develop", "esphome.example.yaml")
+    develop_docs = _show(work, "develop", "docs/esphome-powermeters.md")
+    assert "astrameter@develop" in develop_docs
+    assert "astrameter@9.9.9" not in develop_docs
     # The release version carried over via the merge (script doesn't reset it).
     assert 'version = "9.9.9"' in _show(work, "develop", "pyproject.toml")
 


### PR DESCRIPTION
…ers.md

The new per-meter ESPHome reference doc carries 17 copy-paste 'github://tomquist/astrameter@develop' snippets, but release.sh only rewrote README.md and esphome.example.yaml. After a release the doc would still point users at @develop (a moving, unreleased ref) while README/example were pinned to the tag.

Drive set_component_ref() off a COMPONENT_REF_FILES list that also includes docs/esphome-powermeters.md, and extend the release.sh test to assert every snippet in that doc is pinned on main and reset to develop afterwards.

https://claude.ai/code/session_01Nt4cUn5eWEjUxZEjGafwsR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved release process to consistently update component references across all documentation and example files.

* **Tests**
  * Enhanced test coverage to verify complete documentation and example reference updates during release cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->