### PR TITLE
Add Home Assistant add-on UI configuration generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Added** the Hampel outlier filter and PID controller as optional fields in the Home Assistant add-on Configuration tab (alongside the existing smoothing/deadband options) — all optional and off unless you set them. The web config generator gained a "Home Assistant add-on" target that produces a ready-to-paste add-on options block including these filters.
+
 
 ## 2.1.0
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ The AstraMeter project can be installed and run in several ways depending on you
      - `shellyproem50`: Shelly Pro EM50 emulator
      
      **Tip:** Use `ct002`/`ct003` for multiple devices; use a Shelly type (e.g. `shellypro3em` or `_old`/`_new`) otherwise.
+   - Optional signal-conditioning filters are also available as Configuration fields (all optional, off by default): power offset/multiplier, smoothing (EMA), deadband, the Hampel outlier filter (see [General Configuration](#general-configuration)), and the [PID Controller](#pid-controller). Leave them empty to keep them disabled.
    - Click "Save" to apply the configuration
+
+   Prefer a guided setup? The [config generator](https://tomquist.github.io/astrameter/generator.html) can produce a ready-to-paste Home Assistant add-on options block (including the filters above) — pick the "Home Assistant add-on" target.
 
    B) Using a Custom Configuration File for Advanced Configuration:
    - Create a `config.ini` file based on the examples in the [Configuration](#configuration) section

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -60,5 +60,13 @@ schema:
   smooth_target_alpha: float(0,1)?
   max_smooth_step: float(0,)?
   deadband: float(0,)?
+  hampel_window: int(0,)?
+  hampel_n_sigma: float(0,)?
+  hampel_min_threshold: float(0,)?
+  pid_kp: float(0,)?
+  pid_ki: float?
+  pid_kd: float?
+  pid_output_max: float(0,)?
+  pid_mode: list(bias|replace)?
   custom_config: str?
   mqtt_uri: str?

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -155,6 +155,30 @@ else
         if bashio::config.has_value 'deadband'; then
             echo "DEADBAND=$(bashio::config 'deadband')"
         fi
+        if bashio::config.has_value 'hampel_window'; then
+            echo "HAMPEL_WINDOW=$(bashio::config 'hampel_window')"
+        fi
+        if bashio::config.has_value 'hampel_n_sigma'; then
+            echo "HAMPEL_N_SIGMA=$(bashio::config 'hampel_n_sigma')"
+        fi
+        if bashio::config.has_value 'hampel_min_threshold'; then
+            echo "HAMPEL_MIN_THRESHOLD=$(bashio::config 'hampel_min_threshold')"
+        fi
+        if bashio::config.has_value 'pid_kp'; then
+            echo "PID_KP=$(bashio::config 'pid_kp')"
+        fi
+        if bashio::config.has_value 'pid_ki'; then
+            echo "PID_KI=$(bashio::config 'pid_ki')"
+        fi
+        if bashio::config.has_value 'pid_kd'; then
+            echo "PID_KD=$(bashio::config 'pid_kd')"
+        fi
+        if bashio::config.has_value 'pid_output_max'; then
+            echo "PID_OUTPUT_MAX=$(bashio::config 'pid_output_max')"
+        fi
+        if bashio::config.has_value 'pid_mode'; then
+            echo "PID_MODE=$(bashio::config 'pid_mode')"
+        fi
 
         # Fetch this add-on's slug from the supervisor so MQTT discovery can
         # link discovered meter devices to the add-on device via_device.

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -59,3 +59,27 @@ configuration:
   deadband:
     name: Deadband (W)
     description: "Optional. Readings with absolute value below this threshold are reported as 0 W to stop battery micro-cycling near zero demand (e.g. 5). Leave empty or 0 to disable."
+  hampel_window:
+    name: Hampel Window
+    description: "Optional. Rejects sudden outlier spikes (e.g. WiFi/MQTT glitches) by comparing each reading to a rolling median. This sets the window size; try 5-7. Leave empty or 0 to disable."
+  hampel_n_sigma:
+    name: Hampel Sensitivity (sigma)
+    description: "Optional. How far from the median a reading must be to count as an outlier. Lower = more aggressive filtering. Default 3.0. Only used when Hampel Window is set."
+  hampel_min_threshold:
+    name: Hampel Minimum Threshold (W)
+    description: "Optional. Smallest spike (in watts) that may be rejected, so tiny fluctuations on a steady signal are never filtered. Try 50. Leave empty or 0 for no floor. Only used when Hampel Window is set."
+  pid_kp:
+    name: PID Proportional Gain (Kp)
+    description: "Optional. Enables a PID controller that steers grid power toward zero. Start at 0.5 (stable between 0 and 1). Leave empty or 0 to disable PID."
+  pid_ki:
+    name: PID Integral Gain (Ki)
+    description: "Optional. Integral gain for the PID controller. Usually leave empty (0) to avoid wind-up. Only used when PID Proportional Gain is set."
+  pid_kd:
+    name: PID Derivative Gain (Kd)
+    description: "Optional. Derivative gain for the PID controller. Usually leave empty (0) - it tends to be noisy on real meters. Only used when PID Proportional Gain is set."
+  pid_output_max:
+    name: PID Output Limit (W)
+    description: "Optional. Caps the PID adjustment to plus/minus this many watts. Default 800. Only used when PID Proportional Gain is set."
+  pid_mode:
+    name: PID Mode
+    description: "Optional. 'bias' adds the PID adjustment to the meter reading (recommended); 'replace' uses the PID output instead of the reading. Default bias. Only used when PID Proportional Gain is set."

--- a/web/generator.html
+++ b/web/generator.html
@@ -6,7 +6,7 @@
     <title>Config Generator — AstraMeter</title>
     <meta
       name="description"
-      content="A friendly, step-by-step generator for AstraMeter — build a Python config.ini or an ESPHome YAML for your Marstek battery's emulated power meter, no prior knowledge needed."
+      content="A friendly, step-by-step generator for AstraMeter — build Home Assistant add-on options, a Python config.ini, or an ESPHome YAML for your Marstek battery's emulated power meter, no prior knowledge needed."
     />
     <meta name="theme-color" content="#020617" />
     <link rel="icon" type="image/svg+xml" href="assets/astrameter-icon.svg" />

--- a/web/ts/app.ts
+++ b/web/ts/app.ts
@@ -194,6 +194,14 @@ const HA_ADDON_METER_FIELDS = new Set([
   "POWER_OUTPUT_ALIAS",
 ]);
 
+// CT / Marstek fields the add-on actually accepts as options. Everything else
+// (active control, balancer, saturation, Marstek base URL / timezone, …) is set
+// automatically or only reachable via a custom config.ini, so it's hidden for
+// the Home Assistant target.
+const HA_ADDON_CT_FIELDS = new Set(["CT_MAC", "MIN_EFFICIENT_POWER", "EFFICIENCY_ROTATION_INTERVAL"]);
+const HA_ADDON_MARSTEK_FIELDS = new Set(["MAILBOX", "PASSWORD"]);
+const HA_ADDON_INSIGHTS_FIELDS = new Set(["BROKER", "PORT", "USERNAME", "PASSWORD", "TLS"]);
+
 // The Home Assistant add-on only reads grid power from a Home Assistant sensor
 // and runs a single meter, so collapse to one homeassistant meter when that
 // target is chosen (keeping the existing one if it already matches).
@@ -287,10 +295,11 @@ function deviceCard(): HTMLElement {
     el("details", { class: "adv" }, [
       el("summary", { text: "Advanced general options" }),
       el("div", { class: "field-grid" }, [
-        fieldControl({ key: "deviceIds", label: "Device IDs", help: "Optional fixed IDs (comma-separated, same order as the meters above). Leave blank to auto-generate.", type: "text", placeholder: "shellypro3em-c59b15461a21" }, g, {}),
-        fieldControl({ key: "skipPowermeterTest", label: "Skip power meter test on startup", help: "Skip the connection check when AstraMeter starts.", type: "checkbox" }, g, {}),
-        fieldControl({ key: "webConfigEnabled", label: "Enable built-in web config editor", help: "Opt-in editor at http://<host>:<port>/config.", type: "checkbox" }, g, { structural: true }),
-        g.webConfigEnabled ? fieldControl({ key: "webServerPort", label: "Web server port", help: "Default 52500.", type: "number", placeholder: "52500" }, g, {}) : null,
+        // Device IDs, skip-test and the built-in web editor aren't add-on options.
+        state.target === "homeassistant" ? null : fieldControl({ key: "deviceIds", label: "Device IDs", help: "Optional fixed IDs (comma-separated, same order as the meters above). Leave blank to auto-generate.", type: "text", placeholder: "shellypro3em-c59b15461a21" }, g, {}),
+        state.target === "homeassistant" ? null : fieldControl({ key: "skipPowermeterTest", label: "Skip power meter test on startup", help: "Skip the connection check when AstraMeter starts.", type: "checkbox" }, g, {}),
+        state.target === "homeassistant" ? null : fieldControl({ key: "webConfigEnabled", label: "Enable built-in web config editor", help: "Opt-in editor at http://<host>:<port>/config.", type: "checkbox" }, g, { structural: true }),
+        state.target !== "homeassistant" && g.webConfigEnabled ? fieldControl({ key: "webServerPort", label: "Web server port", help: "Default 52500.", type: "number", placeholder: "52500" }, g, {}) : null,
         fieldControl({ key: "throttleInterval", label: "Global throttle interval (s)", help: "Minimum seconds between readings for every meter. 0 = off. You can override per meter below.", type: "number", placeholder: "0" }, g, {}),
         fieldControl({ key: "waitForNextMessage", label: "Wait for fresh push (global)", help: "Wait up to 2s for the newest reading from push-based meters.", type: "select", options: [{ value: "", label: "Default (on)" }, { value: "true", label: "On" }, { value: "false", label: "Off" }] }, g, {}),
         fieldControl({ key: "dedupeTimeWindow", label: "Dedupe window (s)", help: "Ignore repeated requests from the same client within this window. 0 = off.", type: "number", placeholder: "0" }, g, {}),
@@ -309,6 +318,12 @@ function meterEditor(meter: Meter, index: number): HTMLElement {
     state.target === "homeassistant"
       ? pm.fields.filter((f) => HA_ADDON_METER_FIELDS.has(f.key))
       : pm.fields;
+  // Throttle / wait-for-push are set once in the General section for the HA
+  // target, so drop them from this per-meter list to avoid duplication.
+  const tuningFields =
+    state.target === "homeassistant"
+      ? PER_METER_TUNING.filter((f) => f.key !== "THROTTLE_INTERVAL" && f.key !== "WAIT_FOR_NEXT_MESSAGE")
+      : PER_METER_TUNING;
 
   const sourceSelect = el(
     "select",
@@ -385,7 +400,7 @@ function meterEditor(meter: Meter, index: number): HTMLElement {
     el("details", { class: "adv" }, [
       el("summary", { text: "Fine-tuning (smoothing, calibration, throttling, PID)" }),
       el("p", { class: "help", text: "All optional. These shape the reading before it reaches your battery." }),
-      el("div", { class: "field-grid" }, fieldGroup(PER_METER_TUNING, meter.tuning, { phases: meter.phases })),
+      el("div", { class: "field-grid" }, fieldGroup(tuningFields, meter.tuning, { phases: meter.phases })),
     ]),
     netmaskField,
     removeBtn,
@@ -425,10 +440,19 @@ function meterCard(): HTMLElement {
 }
 
 function ctCard(): HTMLElement | null {
-  const showFlat = (state.target === "python" || state.target === "homeassistant") && (state.general.deviceTypes.includes("ct002") || state.general.deviceTypes.includes("ct003"));
+  const isHa = state.target === "homeassistant";
+  const showFlat = (state.target === "python" || isHa) && (state.general.deviceTypes.includes("ct002") || state.general.deviceTypes.includes("ct003"));
   const show = state.target === "esphome" || showFlat;
   if (!show) return null;
   const f = state.ct.fields;
+  // The add-on only exposes a handful of CT options; show just those for the HA
+  // target (the rest need a custom config.ini).
+  if (isHa) {
+    const haFields = [...CT_BASIC, ...CT_EFFICIENCY].filter((fl) => HA_ADDON_CT_FIELDS.has(fl.key));
+    return card(4, "Battery steering (CT002 / CT003)", "Optional CT options exposed by the add-on. Leave them blank to use the defaults.", [
+      el("div", { class: "field-grid" }, haFields.map((fl) => fieldControl(fl, f, {}))),
+    ]);
+  }
   const group = (title: string, fields: Field[], openByDefault = false): HTMLElement =>
     el("details", { class: "adv", ...(openByDefault ? { open: true } : {}) }, [
       el("summary", { text: title }),
@@ -446,21 +470,33 @@ function ctCard(): HTMLElement | null {
 function extrasCard(): HTMLElement {
   const m = state.marstek;
   const mi = state.mqttInsights;
+  const isHa = state.target === "homeassistant";
+  // For the HA target the add-on hardcodes the Marstek base URL/timezone and uses
+  // HA's built-in broker, so only the credential / custom-broker fields apply.
+  const marstekFields = isHa ? MARSTEK_FIELDS.filter((fl) => HA_ADDON_MARSTEK_FIELDS.has(fl.key)) : MARSTEK_FIELDS;
+  const insightsFields = isHa ? MQTT_INSIGHTS_FIELDS.filter((fl) => HA_ADDON_INSIGHTS_FIELDS.has(fl.key)) : MQTT_INSIGHTS_FIELDS;
+
   const marstekBody = [
     fieldControl({ key: "enabled", label: "Auto-register a managed CT device in the Marstek cloud", help: "Optional. Creates a fake CT in your Marstek account so the app can select it. Credentials are only needed once.", type: "checkbox" }, m, { structural: true }),
   ];
-  if (m.enabled) marstekBody.push(el("div", { class: "field-grid" }, MARSTEK_FIELDS.map((fl) => fieldControl(fl, m.fields, {}))));
+  if (m.enabled) marstekBody.push(el("div", { class: "field-grid" }, marstekFields.map((fl) => fieldControl(fl, m.fields, {}))));
 
+  const insightsLabel = isHa
+    ? "Use a custom MQTT broker"
+    : "Publish internal state to MQTT (Home Assistant discovery)";
+  const insightsHelp = isHa
+    ? "Optional. The add-on uses Home Assistant's built-in MQTT broker automatically. Turn this on only to point MQTT Insights at a different broker."
+    : "Optional. Exposes grid power, targets and per-battery state to Home Assistant via MQTT.";
   const insightsBody = [
-    fieldControl({ key: "enabled", label: "Publish internal state to MQTT (Home Assistant discovery)", help: "Optional. Exposes grid power, targets and per-battery state to Home Assistant via MQTT.", type: "checkbox" }, mi, { structural: true }),
+    fieldControl({ key: "enabled", label: insightsLabel, help: insightsHelp, type: "checkbox" }, mi, { structural: true }),
   ];
-  if (mi.enabled) insightsBody.push(el("div", { class: "field-grid" }, fieldGroup(MQTT_INSIGHTS_FIELDS, mi.fields, {})));
+  if (mi.enabled) insightsBody.push(el("div", { class: "field-grid" }, fieldGroup(insightsFields, mi.fields, {})));
 
-  return card(5, "Optional extras", "Skip this unless you want Marstek-app integration or Home Assistant MQTT insights.", [
+  return card(5, "Optional extras", "Skip this unless you want Marstek-app integration or a custom MQTT broker.", [
     el("h3", { text: "Marstek cloud registration" }),
     ...marstekBody,
     el("hr", {}),
-    el("h3", { text: "MQTT Insights / Home Assistant" }),
+    el("h3", { text: isHa ? "Custom MQTT broker" : "MQTT Insights / Home Assistant" }),
     ...insightsBody,
   ]);
 }

--- a/web/ts/app.ts
+++ b/web/ts/app.ts
@@ -199,6 +199,10 @@ const HA_ADDON_METER_FIELDS = new Set([
 // automatically or only reachable via a custom config.ini, so it's hidden for
 // the Home Assistant target.
 const HA_ADDON_CT_FIELDS = new Set(["CT_MAC", "MIN_EFFICIENT_POWER", "EFFICIENCY_ROTATION_INTERVAL"]);
+
+function hasCtType(types: string[]): boolean {
+  return types.includes("ct002") || types.includes("ct003");
+}
 const HA_ADDON_MARSTEK_FIELDS = new Set(["MAILBOX", "PASSWORD"]);
 const HA_ADDON_INSIGHTS_FIELDS = new Set(["BROKER", "PORT", "USERNAME", "PASSWORD", "TLS"]);
 
@@ -275,9 +279,19 @@ function deviceCard(): HTMLElement {
         class: "pill" + (active ? " active" : ""),
         title: d.help,
         onclick: () => {
+          const hadCt = hasCtType(g.deviceTypes);
           if (active) g.deviceTypes = g.deviceTypes.filter((t) => t !== d.value);
           else g.deviceTypes = [...g.deviceTypes, d.value];
           if (g.deviceTypes.length === 0) g.deviceTypes = [d.value];
+          // Marstek registration + MQTT Insights are CT002/CT003 features, so
+          // flip their defaults when CT emulation is switched on or off. This is
+          // edge-triggered (only on a CT-membership change), so a user can still
+          // uncheck them afterwards without the next pill click snapping them back.
+          const hasCt = hasCtType(g.deviceTypes);
+          if (hasCt !== hadCt) {
+            state.marstek.enabled = hasCt;
+            state.mqttInsights.enabled = hasCt;
+          }
           rerenderAll();
         },
       },

--- a/web/ts/app.ts
+++ b/web/ts/app.ts
@@ -289,7 +289,7 @@ function deviceCard(): HTMLElement {
   // (user-controlled) is used only as a membership filter, not rendered.
   const selectedHelp = DEVICE_TYPES.filter((d) => g.deviceTypes.includes(d.value)).map((d) => el("li", { html: `<strong>${d.label}:</strong> ${d.help}` }));
 
-  return card(2, "Which meter should AstraMeter pretend to be?", "Your battery talks to a power meter it trusts. AstraMeter impersonates one. One battery → keep Shelly Pro 3EM. Two or more batteries that should share load → choose CT002.", [
+  return card(2, "Which meter should AstraMeter pretend to be?", "Your battery talks to a power meter it trusts. AstraMeter impersonates one. Two or more batteries that should share load → keep CT002. A single battery → Shelly Pro 3EM works too.", [
     el("div", { class: "pill-row" }, typeButtons),
     el("ul", { class: "pill-help" }, selectedHelp),
     el("details", { class: "adv" }, [

--- a/web/ts/app.ts
+++ b/web/ts/app.ts
@@ -184,8 +184,16 @@ function card(n: number | null, title: string, subtitle: string | null, body: El
   ]);
 }
 
+// The Home Assistant add-on only reads grid power from a Home Assistant sensor
+// and runs a single meter, so collapse to one homeassistant meter when that
+// target is chosen (keeping the existing one if it already matches).
+function coerceHaMeter(): void {
+  const first = state.meters[0];
+  state.meters = first && first.type === "homeassistant" ? [first] : [newMeter("homeassistant")];
+}
+
 function targetCard(): HTMLElement {
-  function choice(value: "python" | "esphome", title: string, desc: string): HTMLElement {
+  function choice(value: State["target"], title: string, desc: string): HTMLElement {
     const active = state.target === value;
     return el(
       "button",
@@ -194,15 +202,17 @@ function targetCard(): HTMLElement {
         type: "button",
         onclick: () => {
           state.target = value;
+          if (value === "homeassistant") coerceHaMeter();
           rerenderAll();
         },
       },
       [el("strong", { text: title }), el("span", { text: desc })],
     );
   }
-  return card(1, "How will you run AstraMeter?", "Pick where the emulator runs. Not sure? Choose the Home Assistant / Docker option — it's the most common.", [
+  return card(1, "How will you run AstraMeter?", "Pick where the emulator runs. Not sure? Choose the Home Assistant add-on option — it's the most common.", [
     el("div", { class: "choice-row" }, [
-      choice("python", "Home Assistant add-on, Docker, or a PC", "Generates a config.ini file. AstraMeter runs as software and talks to your power meter over the network."),
+      choice("homeassistant", "Home Assistant add-on (UI options)", "Generates the add-on Configuration options (YAML) you paste into the add-on's Configuration tab. Reads grid power from a Home Assistant sensor."),
+      choice("python", "config.ini (Docker, a PC, or advanced add-on)", "Generates a config.ini file. AstraMeter runs as software and talks to your power meter over the network."),
       choice("esphome", "On an ESP32 chip (ESPHome)", "Generates an ESPHome YAML file. The emulator runs on a tiny ESP32 board that reads a grid-power sensor."),
     ]),
   ]);
@@ -301,6 +311,16 @@ function meterEditor(meter: Meter, index: number): HTMLElement {
       ? esphomeBadge(pm)
       : null;
 
+  // The HA add-on target is locked to a single Home Assistant sensor, so show a
+  // static label instead of the power-meter type picker.
+  const typeField =
+    state.target === "homeassistant"
+      ? el("div", { class: "field grow" }, [
+          el("label", { class: "field-label", text: "Power source" }),
+          el("p", { class: "blurb", text: "Home Assistant sensor — the add-on reads grid power from an HA entity." }),
+        ])
+      : el("div", { class: "field grow" }, [el("label", { class: "field-label", text: "Power meter type" }), sourceSelect]);
+
   const phaseToggle = canPhase
     ? el("div", { class: "field" }, [
         el("label", { class: "field-label", text: "How many phases?" }),
@@ -337,7 +357,7 @@ function meterEditor(meter: Meter, index: number): HTMLElement {
 
   return el("div", { class: "meter" }, [
     el("div", { class: "meter-head" }, [
-      el("div", { class: "field grow" }, [el("label", { class: "field-label", text: "Power meter type" }), sourceSelect]),
+      typeField,
       badge,
     ]),
     el("p", { class: "blurb", text: pm.blurb }),
@@ -377,13 +397,19 @@ function meterCard(): HTMLElement {
   const intro =
     state.target === "esphome"
       ? "On an ESP32 the emulator reads one grid-power sensor. Pick the source below — the badge shows how well each works on ESP32."
-      : "Tell us where AstraMeter should read your real grid power. Add more than one only for advanced multi-network setups.";
-  return card(3, "Your power meter", intro, [...meters, addBtn]);
+      : state.target === "homeassistant"
+        ? "The add-on reads your grid power from one Home Assistant sensor. Enter the entity below."
+        : "Tell us where AstraMeter should read your real grid power. Add more than one only for advanced multi-network setups.";
+  const customConfigNote =
+    state.target === "homeassistant"
+      ? el("p", { class: "note", html: "The add-on supports a single Home Assistant power source. For other meter types, multiple meters, or options the add-on UI doesn't expose, switch to the <strong>config.ini</strong> target above, save the file to <code>/addon_configs/a0ef98c5_b2500_meter/</code>, and set the add-on's <em>Custom Config</em> option to its filename. See the <a href='" + ghDoc("README.md#home-assistant-app-installation") + "' target='_blank' rel='noopener'>custom configuration docs ↗</a>." })
+      : null;
+  return card(3, "Your power meter", intro, [...meters, addBtn, customConfigNote]);
 }
 
 function ctCard(): HTMLElement | null {
-  const showPython = state.target === "python" && (state.general.deviceTypes.includes("ct002") || state.general.deviceTypes.includes("ct003"));
-  const show = state.target === "esphome" || showPython;
+  const showFlat = (state.target === "python" || state.target === "homeassistant") && (state.general.deviceTypes.includes("ct002") || state.general.deviceTypes.includes("ct003"));
+  const show = state.target === "esphome" || showFlat;
   if (!show) return null;
   const f = state.ct.fields;
   const group = (title: string, fields: Field[], openByDefault = false): HTMLElement =>
@@ -448,6 +474,12 @@ function esphomeStepsCard(): HTMLElement | null {
 }
 
 // ── preview + actions ─────────────────────────────────────────────────────────
+function outputFilename(): string {
+  if (state.target === "esphome") return "astrameter.yaml";
+  if (state.target === "homeassistant") return "astrameter-options.yaml";
+  return "config.ini";
+}
+
 function refreshPreview(): void {
   const pre = document.getElementById("preview-code");
   if (!pre) return;
@@ -459,12 +491,12 @@ function refreshPreview(): void {
   }
   pre.textContent = text;
   const fn = document.getElementById("preview-filename");
-  if (fn) fn.textContent = state.target === "esphome" ? "astrameter.yaml" : "config.ini";
+  if (fn) fn.textContent = outputFilename();
   saveState();
 }
 
 function previewPanel(): HTMLElement {
-  const filename = state.target === "esphome" ? "astrameter.yaml" : "config.ini";
+  const filename = outputFilename();
   return el("aside", { class: "preview", id: "preview" }, [
     el("div", { class: "preview-head" }, [
       el("span", { text: "Live preview — " }),
@@ -499,8 +531,7 @@ function copyConfig(): void {
 function downloadConfig(): void {
   const text = safeGenerate();
   if (text == null) return;
-  const name = state.target === "esphome" ? "astrameter.yaml" : "config.ini";
-  downloadText(name, text);
+  downloadText(outputFilename(), text);
 }
 
 function downloadText(filename: string, text: string): void {

--- a/web/ts/app.ts
+++ b/web/ts/app.ts
@@ -184,6 +184,16 @@ function card(n: number | null, title: string, subtitle: string | null, body: El
   ]);
 }
 
+// Fields of the `homeassistant` meter that the add-on does NOT configure for
+// you (the host/port/token/API-path are set automatically by the add-on). Only
+// these grid-power entity fields are surfaced for the Home Assistant target.
+const HA_ADDON_METER_FIELDS = new Set([
+  "CURRENT_POWER_ENTITY",
+  "POWER_CALCULATE",
+  "POWER_INPUT_ALIAS",
+  "POWER_OUTPUT_ALIAS",
+]);
+
 // The Home Assistant add-on only reads grid power from a Home Assistant sensor
 // and runs a single meter, so collapse to one homeassistant meter when that
 // target is chosen (keeping the existing one if it already matches).
@@ -292,6 +302,13 @@ function deviceCard(): HTMLElement {
 function meterEditor(meter: Meter, index: number): HTMLElement {
   const pm = getPowermeter(meter.type) || POWERMETERS[0];
   const canPhase = PHASE_CAPABLE.has(meter.type);
+  // The HA add-on fills in the connection details automatically (host, port,
+  // token, API path), so for that target only the grid-power entity fields are
+  // shown — the rest would be ignored.
+  const fields =
+    state.target === "homeassistant"
+      ? pm.fields.filter((f) => HA_ADDON_METER_FIELDS.has(f.key))
+      : pm.fields;
 
   const sourceSelect = el(
     "select",
@@ -364,7 +381,7 @@ function meterEditor(meter: Meter, index: number): HTMLElement {
     pm.docPython ? el("a", { class: "doclink", href: ghDoc(pm.docPython!), target: "_blank", rel: "noopener" }, "Reference for this meter ↗") : null,
     suffixField,
     phaseToggle,
-    el("div", { class: "field-grid" }, fieldGroup(pm.fields, meter.fields, { phases: meter.phases })),
+    el("div", { class: "field-grid" }, fieldGroup(fields, meter.fields, { phases: meter.phases })),
     el("details", { class: "adv" }, [
       el("summary", { text: "Fine-tuning (smoothing, calibration, throttling, PID)" }),
       el("p", { class: "help", text: "All optional. These shape the reading before it reaches your battery." }),

--- a/web/ts/generate.test.ts
+++ b/web/ts/generate.test.ts
@@ -1,6 +1,6 @@
 // Lightweight assertions for the config generators. Run with:
 //   node web/js/generate.test.mjs
-import { generateConfigIni, generateEsphome } from "./generate.js";
+import { generateConfigIni, generateEsphome, generateHomeAssistant } from "./generate.js";
 
 let failures = 0;
 function ok(cond, msg) {
@@ -223,6 +223,74 @@ const eyEnvoy = generateEsphome({
 });
 has(eyEnvoy, "no ESPHome component yet", "esp/envoy: warning emitted");
 has(eyEnvoy, "TODO: publish your grid power", "esp/envoy: placeholder sensor");
+
+// ── Home Assistant add-on options: full filter set ───────────────────────────
+const haOpts = generateHomeAssistant({
+  target: "homeassistant",
+  general: { deviceTypes: ["ct002"], throttleInterval: "2", waitForNextMessage: "false" },
+  meters: [
+    {
+      type: "homeassistant",
+      phases: 1,
+      fields: { CURRENT_POWER_ENTITY: "sensor.grid_power" },
+      tuning: {
+        POWER_OFFSET: "-20",
+        SMOOTH_TARGET_ALPHA: "0.3",
+        DEADBAND: "5",
+        HAMPEL_WINDOW: "5",
+        HAMPEL_N_SIGMA: "3.0",
+        HAMPEL_MIN_THRESHOLD: "50",
+        PID_KP: "0.5",
+        PID_OUTPUT_MAX: "800",
+        PID_MODE: "bias",
+      },
+    },
+  ],
+  ct: { fields: { CT_MAC: "abc123" } },
+});
+has(haOpts, "power_input_alias: \"sensor.grid_power\"", "ha-opts: power input alias");
+has(haOpts, "device_types: \"ct002\"", "ha-opts: device types");
+has(haOpts, "throttle_interval: 2", "ha-opts: throttle interval");
+has(haOpts, "wait_for_next_message: false", "ha-opts: wait for next message");
+has(haOpts, "ct_mac: \"abc123\"", "ha-opts: ct mac");
+has(haOpts, "power_offset: -20", "ha-opts: power offset");
+has(haOpts, "smooth_target_alpha: 0.3", "ha-opts: smoothing alpha");
+has(haOpts, "deadband: 5", "ha-opts: deadband");
+has(haOpts, "hampel_window: 5", "ha-opts: hampel window");
+has(haOpts, "hampel_n_sigma: 3.0", "ha-opts: hampel sigma");
+has(haOpts, "hampel_min_threshold: 50", "ha-opts: hampel min threshold");
+has(haOpts, "pid_kp: 0.5", "ha-opts: pid kp");
+has(haOpts, "pid_output_max: 800", "ha-opts: pid output max");
+has(haOpts, "pid_mode: \"bias\"", "ha-opts: pid mode");
+has(haOpts, "Custom Config", "ha-opts: mentions custom config fallback");
+
+// ── Home Assistant add-on options: empty filters omitted ─────────────────────
+const haMin = generateHomeAssistant({
+  target: "homeassistant",
+  general: { deviceTypes: ["shellypro3em"] },
+  meters: [{ type: "homeassistant", phases: 1, fields: { CURRENT_POWER_ENTITY: "sensor.p" }, tuning: {} }],
+  ct: { fields: {} },
+});
+lacks(haMin, "hampel_window", "ha-opts: omits unset hampel");
+lacks(haMin, "pid_kp", "ha-opts: omits unset pid");
+lacks(haMin, "deadband", "ha-opts: omits unset deadband");
+
+// ── Home Assistant add-on options: calculate from in/out ─────────────────────
+const haCalc = generateHomeAssistant({
+  target: "homeassistant",
+  general: { deviceTypes: ["shellypro3em"] },
+  meters: [
+    {
+      type: "homeassistant",
+      phases: 1,
+      fields: { POWER_CALCULATE: "True", POWER_INPUT_ALIAS: "sensor.in", POWER_OUTPUT_ALIAS: "sensor.out" },
+      tuning: {},
+    },
+  ],
+  ct: { fields: {} },
+});
+has(haCalc, "power_input_alias: \"sensor.in\"", "ha-opts: calc input alias");
+has(haCalc, "power_output_alias: \"sensor.out\"", "ha-opts: calc output alias");
 
 console.log("\n" + (failures ? `${failures} FAILED` : "ALL PASSED"));
 process.exit(failures ? 1 : 0);

--- a/web/ts/generate.test.ts
+++ b/web/ts/generate.test.ts
@@ -109,6 +109,17 @@ has(extras, "MAILBOX = a@b.c", "extras: marstek mailbox");
 has(extras, "[MQTT_INSIGHTS]", "extras: insights section");
 has(extras, "BROKER = 192.168.1.9", "extras: insights broker");
 
+// ── config.ini: enabled-but-empty extras are omitted (default-on safety) ──────
+const extrasEmpty = generateConfigIni({
+  target: "python",
+  general: { deviceTypes: ["ct002"] },
+  meters: [{ type: "shelly", phases: 1, fields: { TYPE: "1PM", IP: "1.1.1.1" }, tuning: {} }],
+  marstek: { enabled: true, fields: {} },
+  mqttInsights: { enabled: true, fields: {} },
+});
+lacks(extrasEmpty, "[MARSTEK]", "extras-empty: omits marstek without credentials");
+lacks(extrasEmpty, "[MQTT_INSIGHTS]", "extras-empty: omits insights without a broker");
+
 // ── ESPHome: Home Assistant native, 3-phase ──────────────────────────────────
 const eyHa = generateEsphome({
   target: "esphome",

--- a/web/ts/generate.test.ts
+++ b/web/ts/generate.test.ts
@@ -264,7 +264,7 @@ has(haOpts, "device_types: \"ct002\"", "ha-opts: device types");
 has(haOpts, "throttle_interval: 2", "ha-opts: throttle interval");
 has(haOpts, "wait_for_next_message: false", "ha-opts: wait for next message");
 has(haOpts, "ct_mac: \"abc123\"", "ha-opts: ct mac");
-has(haOpts, "power_offset: -20", "ha-opts: power offset");
+has(haOpts, 'power_offset: "-20"', "ha-opts: power offset (quoted str)");
 has(haOpts, "smooth_target_alpha: 0.3", "ha-opts: smoothing alpha");
 has(haOpts, "deadband: 5", "ha-opts: deadband");
 has(haOpts, "hampel_window: 5", "ha-opts: hampel window");
@@ -302,6 +302,26 @@ const haCalc = generateHomeAssistant({
 });
 has(haCalc, "power_input_alias: \"sensor.in\"", "ha-opts: calc input alias");
 has(haCalc, "power_output_alias: \"sensor.out\"", "ha-opts: calc output alias");
+
+// ── Home Assistant add-on options: all-digit MAC stays a quoted string ───────
+const haMac = generateHomeAssistant({
+  target: "homeassistant",
+  general: { deviceTypes: ["ct002"] },
+  meters: [{ type: "homeassistant", phases: 1, fields: { CURRENT_POWER_ENTITY: "sensor.p" }, tuning: {} }],
+  ct: { fields: { CT_MAC: "001122334455" } },
+});
+has(haMac, 'ct_mac: "001122334455"', "ha-opts: all-digit ct_mac is quoted (keeps leading zeros)");
+
+// ── Home Assistant add-on options: mqtt_uri TLS + credential encoding ────────
+const haUri = generateHomeAssistant({
+  target: "homeassistant",
+  general: { deviceTypes: ["ct002"] },
+  meters: [{ type: "homeassistant", phases: 1, fields: { CURRENT_POWER_ENTITY: "sensor.p" }, tuning: {} }],
+  ct: { fields: {} },
+  mqttInsights: { enabled: true, fields: { BROKER: "broker.local", PORT: "1883", USERNAME: "a@b", PASSWORD: "p:w/d", TLS: "false" } },
+});
+has(haUri, "mqtt://a%40b:p%3Aw%2Fd@broker.local:1883", "ha-opts: mqtt_uri encodes creds and TLS string 'false' stays mqtt");
+lacks(haUri, "mqtts://", "ha-opts: string 'false' TLS is not treated as enabled");
 
 console.log("\n" + (failures ? `${failures} FAILED` : "ALL PASSED"));
 process.exit(failures ? 1 : 0);

--- a/web/ts/generate.ts
+++ b/web/ts/generate.ts
@@ -552,6 +552,105 @@ export function generateEsphome(state: State): string {
   return out.join("\n\n") + "\n";
 }
 
+// ── Home Assistant add-on options (YAML) ──────────────────────────────────────
+//
+// The add-on can only read grid power from a Home Assistant sensor and runs a
+// single meter, so this emits the flat `key: value` options block you paste into
+// the add-on's Configuration → "Edit in YAML". Anything the UI can't express
+// (other powermeter sources, multiple meters) needs a custom config.ini instead.
+
+// Render a YAML scalar: numbers and booleans bare, everything else quoted so
+// comma lists, MACs, entity ids and passwords survive parsing intact.
+function yamlScalar(value: unknown): string {
+  const s = String(value).trim();
+  if (s === "true" || s === "false") return s;
+  if (/^-?\d+(\.\d+)?$/.test(s)) return s;
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+export function generateHomeAssistant(state: State): string {
+  const opts: string[] = [];
+  const add = (key: string, value: unknown): void => {
+    if (isBlank(value)) return;
+    opts.push(`${key}: ${yamlScalar(value)}`);
+  };
+
+  const g = state.general || {};
+  const meter = (state.meters && state.meters[0]) || ({} as Meter);
+  const f = meter.fields || {};
+  const tuning = meter.tuning || {};
+
+  // Grid-power source: a single signed sensor, or separate import/export entities.
+  const calc = f.POWER_CALCULATE === "True" || f.POWER_CALCULATE === true;
+  if (calc && !isBlank(f.POWER_INPUT_ALIAS)) {
+    add("power_input_alias", f.POWER_INPUT_ALIAS);
+    add("power_output_alias", f.POWER_OUTPUT_ALIAS);
+  } else {
+    add("power_input_alias", f.CURRENT_POWER_ENTITY);
+  }
+
+  const types = (g.deviceTypes && g.deviceTypes.length ? g.deviceTypes : ["shellypro3em"]).join(",");
+  add("device_types", types);
+
+  // throttle / wait are top-level add-on options; the add-on has no per-meter
+  // override, so prefer the global value and fall back to the meter tuning.
+  add("throttle_interval", !isBlank(g.throttleInterval) ? g.throttleInterval : tuning.THROTTLE_INTERVAL);
+  add("wait_for_next_message", !isBlank(g.waitForNextMessage) ? g.waitForNextMessage : tuning.WAIT_FOR_NEXT_MESSAGE);
+  add("dedupe_time_window", g.dedupeTimeWindow);
+
+  // CT identity / efficiency options.
+  const ctf = (state.ct && state.ct.fields) || {};
+  add("ct_mac", ctf.CT_MAC);
+  add("min_efficient_power", ctf.MIN_EFFICIENT_POWER);
+  add("efficiency_rotation_interval", ctf.EFFICIENCY_ROTATION_INTERVAL);
+
+  // Signal-conditioning filters (transform, smoothing, deadband, hampel, pid).
+  // Option names are the lower-cased INI keys; throttle/wait handled above.
+  for (const field of PER_METER_TUNING) {
+    if (field.key === "THROTTLE_INTERVAL" || field.key === "WAIT_FOR_NEXT_MESSAGE") continue;
+    add(field.key.toLowerCase(), tuning[field.key]);
+  }
+
+  // Marstek managed CT registration.
+  if (state.marstek && state.marstek.enabled) {
+    const m = state.marstek.fields || {};
+    if (!isBlank(m.MAILBOX) && !isBlank(m.PASSWORD)) {
+      add("marstek_auto_register_ct_device", true);
+      add("marstek_mailbox", m.MAILBOX);
+      add("marstek_password", m.PASSWORD);
+    }
+  }
+
+  // MQTT Insights: only a custom external broker maps to an add-on option; the
+  // add-on uses Home Assistant's internal broker automatically otherwise.
+  if (state.mqttInsights && state.mqttInsights.enabled) {
+    const mi = state.mqttInsights.fields || {};
+    if (!isBlank(mi.BROKER)) {
+      const scheme = mi.TLS ? "mqtts" : "mqtt";
+      const user = !isBlank(mi.USERNAME) ? String(mi.USERNAME).trim() : "";
+      const pass = !isBlank(mi.PASSWORD) ? String(mi.PASSWORD).trim() : "";
+      const cred = user ? `${user}${pass ? ":" + pass : ""}@` : "";
+      const port = !isBlank(mi.PORT) ? `:${String(mi.PORT).trim()}` : "";
+      add("mqtt_uri", `${scheme}://${cred}${String(mi.BROKER).trim()}${port}`);
+    }
+  }
+
+  const header = [
+    "# AstraMeter — Home Assistant add-on options.",
+    "# Paste this into the add-on's Configuration tab via the ⋮ menu → \"Edit in YAML\".",
+    "#",
+    "# The add-on reads grid power from a Home Assistant sensor and runs a single",
+    "# meter. For anything this UI can't express (other power-meter sources,",
+    "# multiple meters), generate a config.ini instead (switch the target above),",
+    "# drop it in /addon_configs/a0ef98c5_b2500_meter/, and set the add-on's",
+    "# \"Custom Config\" option to its filename.",
+  ].join("\n");
+
+  return header + "\n" + opts.join("\n") + "\n";
+}
+
 export function generate(state: State): string {
-  return state.target === "esphome" ? generateEsphome(state) : generateConfigIni(state);
+  if (state.target === "esphome") return generateEsphome(state);
+  if (state.target === "homeassistant") return generateHomeAssistant(state);
+  return generateConfigIni(state);
 }

--- a/web/ts/generate.ts
+++ b/web/ts/generate.ts
@@ -565,20 +565,42 @@ export function generateEsphome(state: State): string {
 // the add-on's Configuration → "Edit in YAML". Anything the UI can't express
 // (other powermeter sources, multiple meters) needs a custom config.ini instead.
 
-// Render a YAML scalar: numbers and booleans bare, everything else quoted so
-// comma lists, MACs, entity ids and passwords survive parsing intact.
-function yamlScalar(value: unknown): string {
+// Add-on options that are string-typed in the schema (entity ids, MACs, comma
+// lists, credentials, URIs). These must always be quoted so an all-digit value
+// like a MAC ("001122334455") keeps its leading zeros and isn't read as a
+// number, and so float-ish transform values aren't coerced for a `str?` field.
+const QUOTED_OPTION_KEYS = new Set([
+  "power_input_alias",
+  "power_output_alias",
+  "device_types",
+  "ct_mac",
+  "power_offset",
+  "power_multiplier",
+  "pid_mode",
+  "marstek_mailbox",
+  "marstek_password",
+  "mqtt_uri",
+]);
+
+function quoteYaml(s: string): string {
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+// Render a YAML scalar. String-typed option keys are always quoted; for other
+// keys, bare booleans and numbers pass through and everything else is quoted.
+function yamlScalar(value: unknown, key?: string): string {
   const s = String(value).trim();
+  if (key && QUOTED_OPTION_KEYS.has(key)) return quoteYaml(s);
   if (s === "true" || s === "false") return s;
   if (/^-?\d+(\.\d+)?$/.test(s)) return s;
-  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  return quoteYaml(s);
 }
 
 export function generateHomeAssistant(state: State): string {
   const opts: string[] = [];
   const add = (key: string, value: unknown): void => {
     if (isBlank(value)) return;
-    opts.push(`${key}: ${yamlScalar(value)}`);
+    opts.push(`${key}: ${yamlScalar(value, key)}`);
   };
 
   const g = state.general || {};
@@ -632,9 +654,14 @@ export function generateHomeAssistant(state: State): string {
   if (state.mqttInsights && state.mqttInsights.enabled) {
     const mi = state.mqttInsights.fields || {};
     if (!isBlank(mi.BROKER)) {
-      const scheme = mi.TLS ? "mqtts" : "mqtt";
-      const user = !isBlank(mi.USERNAME) ? String(mi.USERNAME).trim() : "";
-      const pass = !isBlank(mi.PASSWORD) ? String(mi.PASSWORD).trim() : "";
+      // TLS is a boolean from the UI, but restored state may carry a string;
+      // treat only an explicit true / "true" / "1" as on.
+      const tlsOn = mi.TLS === true || mi.TLS === "true" || mi.TLS === "1";
+      const scheme = tlsOn ? "mqtts" : "mqtt";
+      // Percent-encode credentials so special characters (@, :, /, …) don't
+      // break the URI and survive parse_mqtt_uri's unquoting.
+      const user = !isBlank(mi.USERNAME) ? encodeURIComponent(String(mi.USERNAME).trim()) : "";
+      const pass = !isBlank(mi.PASSWORD) ? encodeURIComponent(String(mi.PASSWORD).trim()) : "";
       const cred = user ? `${user}${pass ? ":" + pass : ""}@` : "";
       const port = !isBlank(mi.PORT) ? `:${String(mi.PORT).trim()}` : "";
       add("mqtt_uri", `${scheme}://${cred}${String(mi.BROKER).trim()}${port}`);

--- a/web/ts/generate.ts
+++ b/web/ts/generate.ts
@@ -125,6 +125,9 @@ function marstekSection(state: State): string {
   const m = state.marstek || {};
   if (!m.enabled) return "";
   const f = m.fields || {};
+  // Registration needs credentials; skip the section while it's enabled but
+  // unconfigured so the default-on toggle never emits a broken [MARSTEK].
+  if (isBlank(f.MAILBOX) || isBlank(f.PASSWORD)) return "";
   const lines = ["[MARSTEK]", "ENABLE = True"];
   for (const field of MARSTEK_FIELDS) {
     const line = iniLine(field, f[field.key]);
@@ -137,6 +140,9 @@ function mqttInsightsSection(state: State): string {
   const mi = state.mqttInsights || {};
   if (!mi.enabled) return "";
   const f = mi.fields || {};
+  // Insights needs a broker to connect to; skip while enabled but unconfigured
+  // so the default-on toggle never emits an empty [MQTT_INSIGHTS] section.
+  if (isBlank(f.BROKER)) return "";
   const lines = ["[MQTT_INSIGHTS]"];
   for (const field of MQTT_INSIGHTS_FIELDS) {
     const line = iniLine(field, f[field.key]);

--- a/web/ts/schema.ts
+++ b/web/ts/schema.ts
@@ -97,12 +97,12 @@ export const DEVICE_TYPES: DeviceType[] = [
   {
     value: "ct002",
     label: "Marstek CT002 (HME-4)",
-    help: "Marstek's own CT clamp. Recommended when you have two or more batteries that should share the load.",
+    help: "Marstek's CT with clamps around the phases. Recommended when you have two or more batteries that should share the load.",
   },
   {
     value: "ct003",
     label: "Marstek CT003 (HME-3)",
-    help: "Like CT002 but the older HME-3 variant.",
+    help: "Marstek's CT that reads via the electricity meter's interface instead of clamps around the phases. Same protocol as CT002 — pick whichever matches your hardware.",
   },
   {
     value: "shellypro3em_old",

--- a/web/ts/schema.ts
+++ b/web/ts/schema.ts
@@ -97,12 +97,12 @@ export const DEVICE_TYPES: DeviceType[] = [
   {
     value: "ct002",
     label: "Marstek CT002 (HME-4)",
-    help: "Marstek's CT with clamps around the phases. Recommended when you have two or more batteries that should share the load.",
+    help: "Marstek's CT meter. Recommended when you have two or more batteries that should share the load.",
   },
   {
     value: "ct003",
     label: "Marstek CT003 (HME-3)",
-    help: "Marstek's CT that reads via the electricity meter's interface instead of clamps around the phases. Same protocol as CT002 — pick whichever matches your hardware.",
+    help: "Marstek's other CT meter. Emulated identically to CT002 (same protocol) — from the battery's perspective there's no difference, so either works.",
   },
   {
     value: "shellypro3em_old",

--- a/web/ts/state.test.ts
+++ b/web/ts/state.test.ts
@@ -97,6 +97,14 @@ ok(old.esphome && old.esphome.board, "migrate: backfills missing esphome default
 ok(old.ct && old.ct.fields, "migrate: backfills missing ct.fields");
 ok(old.meters[0].phases === 1 && old.meters[0].tuning, "migrate: backfills missing meter keys");
 
+// HA target restores to exactly one Home Assistant meter, dropping extras and
+// coercing a non-HA first meter (matches the UI's coerceHaMeter contract).
+const haRestore = migrate({ target: "homeassistant", meters: [{ type: "shelly", fields: { IP: "1.1.1.1" } }, { type: "mqtt", fields: {} }] });
+ok(haRestore.meters.length === 1, "migrate(ha): collapses to a single meter");
+ok(haRestore.meters[0].type === "homeassistant", "migrate(ha): coerces the meter to homeassistant");
+const haKeep = migrate({ target: "homeassistant", meters: [{ type: "homeassistant", fields: { CURRENT_POWER_ENTITY: "sensor.p" } }] });
+ok(haKeep.meters.length === 1 && haKeep.meters[0].fields.CURRENT_POWER_ENTITY === "sensor.p", "migrate(ha): keeps an existing HA meter and its fields");
+
 if (failures) {
   console.error(`\n${failures} FAILED`);
   process.exit(1);

--- a/web/ts/state.ts
+++ b/web/ts/state.ts
@@ -17,7 +17,7 @@ export interface Meter {
 }
 
 export interface State {
-  target: "python" | "esphome";
+  target: "python" | "esphome" | "homeassistant";
   general: {
     deviceTypes: string[];
     deviceIds: string;
@@ -119,7 +119,7 @@ export function migrate(s: any): State {
   return {
     ...d,
     ...s,
-    target: s.target === "esphome" ? "esphome" : "python",
+    target: s.target === "esphome" || s.target === "homeassistant" ? s.target : "python",
     general: ((): State["general"] => {
       const sg = s.general && typeof s.general === "object" ? s.general : {};
       const dg = d.general;

--- a/web/ts/state.ts
+++ b/web/ts/state.ts
@@ -60,8 +60,11 @@ export function defaultState(): State {
     },
     meters: [newMeter("shelly")],
     ct: { fields: {} },
-    marstek: { enabled: false, fields: {} },
-    mqttInsights: { enabled: false, fields: {} },
+    // Marstek registration + MQTT Insights default on because the default device
+    // type is CT002 (they're most useful for CT002/CT003). The device-type card
+    // keeps these in sync when CT emulation is toggled.
+    marstek: { enabled: true, fields: {} },
+    mqttInsights: { enabled: true, fields: {} },
     esphome: {
       name: "astrameter-ct002",
       friendlyName: "AstraMeter CT002",

--- a/web/ts/state.ts
+++ b/web/ts/state.ts
@@ -49,7 +49,7 @@ export function defaultState(): State {
   return {
     target: "python",
     general: {
-      deviceTypes: ["shellypro3em"],
+      deviceTypes: ["ct002"],
       deviceIds: "",
       skipPowermeterTest: false,
       webConfigEnabled: false,

--- a/web/ts/state.ts
+++ b/web/ts/state.ts
@@ -118,11 +118,20 @@ export function cleanMeter(m: any): Meter {
 export function migrate(s: any): State {
   const d = defaultState();
   s = s && typeof s === "object" ? s : {};
-  const meters = Array.isArray(s.meters) && s.meters.length ? s.meters : d.meters;
+  const target = s.target === "esphome" || s.target === "homeassistant" ? s.target : "python";
+  const rawMeters = Array.isArray(s.meters) && s.meters.length ? s.meters : d.meters;
+  let meters = rawMeters.map(cleanMeter);
+  // The Home Assistant target is locked to a single Home Assistant meter (see the
+  // UI's coerceHaMeter). Enforce that on restore too so generateHomeAssistant()
+  // always reads a correct first meter, regardless of what was saved/shared.
+  if (target === "homeassistant") {
+    const first = meters[0];
+    meters = [first && first.type === "homeassistant" ? first : cleanMeter(newMeter("homeassistant"))];
+  }
   return {
     ...d,
     ...s,
-    target: s.target === "esphome" || s.target === "homeassistant" ? s.target : "python",
+    target,
     general: ((): State["general"] => {
       const sg = s.general && typeof s.general === "object" ? s.general : {};
       const dg = d.general;
@@ -141,6 +150,6 @@ export function migrate(s: any): State {
     ct: { fields: asObject(s.ct && s.ct.fields) },
     marstek: { enabled: !!(s.marstek && s.marstek.enabled), fields: asObject(s.marstek && s.marstek.fields) },
     mqttInsights: { enabled: !!(s.mqttInsights && s.mqttInsights.enabled), fields: asObject(s.mqttInsights && s.mqttInsights.fields) },
-    meters: meters.map(cleanMeter),
+    meters,
   };
 }


### PR DESCRIPTION
## Summary
Adds a new "Home Assistant add-on (UI options)" target to the web config generator that produces YAML configuration options for the Home Assistant add-on's Configuration tab. This complements the existing `config.ini` and ESPHome targets, making it easier for users to configure the add-on through the UI without manually editing YAML.

## Key Changes

- **New generator function** (`generateHomeAssistant`) that emits YAML key-value pairs for the add-on's Configuration schema, including:
  - Grid power source (single sensor or calculated from import/export entities)
  - Device types and throttling/wait options
  - CT identity and efficiency settings
  - Signal-conditioning filters (smoothing, deadband, Hampel outlier filter, PID controller)
  - Marstek and MQTT Insights configuration
  - Proper YAML scalar escaping for strings, numbers, and booleans

- **Updated state model** to support `"homeassistant"` as a valid target alongside `"python"` and `"esphome"`

- **UI improvements**:
  - New target choice button for "Home Assistant add-on (UI options)"
  - Automatic meter coercion to a single Home Assistant sensor when this target is selected
  - Contextual help text explaining the add-on's single-meter limitation
  - Custom config fallback note directing users to `config.ini` for advanced setups
  - Static "Power source" label (instead of meter type picker) when Home Assistant target is active
  - Dynamic output filename (`astrameter-options.yaml` for this target)

- **Add-on configuration schema** (`config.yaml`) and **translations** (`en.yaml`) extended with new filter options:
  - `hampel_window`, `hampel_n_sigma`, `hampel_min_threshold` (Hampel outlier filter)
  - `pid_kp`, `pid_ki`, `pid_kd`, `pid_output_max`, `pid_mode` (PID controller)

- **Add-on runtime** (`run.sh`) updated to pass these new filter options from the Configuration tab to the generated config

- **Tests** added to verify correct YAML generation for full filter sets, minimal configs, and calculated power scenarios

- **Documentation** updated (README, CHANGELOG) to reflect the new target and explain the add-on's single-meter constraint

## Implementation Details

The generator intelligently handles:
- Blank/empty values (omitted from output)
- Type-aware YAML scalars (bare numbers/booleans, quoted strings with proper escaping)
- Fallback logic (global throttle/wait options preferred over per-meter tuning)
- Power calculation mode (separate import/export entities vs. single signed sensor)
- Conditional sections (Marstek, MQTT only included if enabled and required fields present)

The UI enforces the add-on's architectural constraint (single Home Assistant sensor) by automatically collapsing the meter list when this target is selected, while still allowing users to switch back to `config.ini` for multi-meter or advanced scenarios.

https://claude.ai/code/session_01QFtgjskrRiwoJ96kstNyX2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Home Assistant add-on target to the web config generator, producing ready-to-paste configuration blocks.
  * Introduced optional signal-conditioning filters: Hampel outlier filter and PID controller for Home Assistant configuration.

* **Documentation**
  * Updated installation guides with filter configuration instructions and guided setup references.
  * Added CHANGELOG entries documenting new optional filter parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->