### PR TITLE
Add state_class: measurement to power sensors in MQTT discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - **Added** the Hampel outlier filter and PID controller as optional fields in the Home Assistant add-on Configuration tab (alongside the existing smoothing/deadband options) — all optional and off unless you set them. The web config generator gained a "Home Assistant add-on" target that produces a ready-to-paste add-on options block including these filters.
+- **Fixed** the power sensors published via MQTT Insights now carry `state_class: measurement`, so the instantly-updated grid/target/reported power entities can be used as power sources in the Home Assistant energy dashboard ([#416](https://github.com/tomquist/astrameter/issues/416)).
 
 
 ## 2.1.0

--- a/esphome/components/ct002/ha_discovery.cpp
+++ b/esphome/components/ct002/ha_discovery.cpp
@@ -70,6 +70,7 @@ void add_power_sensor(JsonObject components, const std::string &key, const std::
   comp["platform"] = "sensor";
   comp["unique_id"] = uid_prefix + "_" + key;
   comp["device_class"] = "power";
+  comp["state_class"] = "measurement";
   comp["unit_of_measurement"] = "W";
   comp["state_topic"] = state_topic;
   comp["value_template"] = tmpl;
@@ -348,6 +349,7 @@ std::pair<std::string, std::string> build_ct002_device_discovery(
     st["unique_id"] = uid_prefix + "_smooth_target";
     st["name"] = nullptr;
     st["device_class"] = "power";
+    st["state_class"] = "measurement";
     st["unit_of_measurement"] = "W";
     st["state_topic"] = state_topic;
     st["value_template"] = "{{ value_json.smooth_target }}";

--- a/src/astrameter/mqtt_insights/discovery.py
+++ b/src/astrameter/mqtt_insights/discovery.py
@@ -68,6 +68,7 @@ def build_ct002_consumer_discovery(
             "platform": "sensor",
             "unique_id": f"{uid_prefix}_{key}",
             "device_class": "power",
+            "state_class": "measurement",
             "unit_of_measurement": "W",
             "state_topic": state_topic,
             "value_template": tmpl,
@@ -278,6 +279,7 @@ def build_ct002_device_discovery(
             "unique_id": f"{uid_prefix}_smooth_target",
             "name": None,  # primary
             "device_class": "power",
+            "state_class": "measurement",
             "unit_of_measurement": "W",
             "state_topic": state_topic,
             "value_template": "{{ value_json.smooth_target }}",
@@ -358,6 +360,7 @@ def build_shelly_battery_discovery(
             "platform": "sensor",
             "unique_id": f"{uid_prefix}_{key}",
             "device_class": "power",
+            "state_class": "measurement",
             "unit_of_measurement": "W",
             "state_topic": state_topic,
             "value_template": tmpl,

--- a/src/astrameter/mqtt_insights/mqtt_insights_test.py
+++ b/src/astrameter/mqtt_insights/mqtt_insights_test.py
@@ -92,6 +92,22 @@ def test_ct002_consumer_discovery_structure():
     # Primary entity has name: null
     assert comps["grid_power_total"]["name"] is None
 
+    # Power sensors carry state_class measurement so they are usable as
+    # power source entities in the Home Assistant energy dashboard.
+    for power_key in (
+        "grid_power_total",
+        "grid_power_l1",
+        "grid_power_l2",
+        "grid_power_l3",
+        "target_l1",
+        "target_l2",
+        "target_l3",
+        "reported_power",
+        "last_target",
+    ):
+        assert comps[power_key]["device_class"] == "power"
+        assert comps[power_key]["state_class"] == "measurement"
+
     # Switch has correct topics — each control uses its own retained command
     # sub-topic so Home Assistant persists the value across restarts.
     switch = comps["active"]
@@ -180,6 +196,8 @@ def test_ct002_device_discovery_structure():
     assert "active_control" in comps
     assert "consumer_count" in comps
     assert comps["smooth_target"]["name"] is None  # primary
+    assert comps["smooth_target"]["device_class"] == "power"
+    assert comps["smooth_target"]["state_class"] == "measurement"
 
     # Force rotation button
     btn = comps["force_rotation"]
@@ -201,6 +219,14 @@ def test_shelly_battery_discovery_structure():
     assert "active" in comps
     assert "last_seen" in comps
     assert "poll_interval" in comps
+    for power_key in (
+        "grid_power_total",
+        "grid_power_l1",
+        "grid_power_l2",
+        "grid_power_l3",
+    ):
+        assert comps[power_key]["device_class"] == "power"
+        assert comps[power_key]["state_class"] == "measurement"
     poll = comps["poll_interval"]
     assert poll["device_class"] == "duration"
     assert poll["unit_of_measurement"] == "s"


### PR DESCRIPTION
## Summary
Power sensors published via MQTT Insights now include `state_class: measurement` in their Home Assistant discovery payloads, enabling them to be used as power sources in the Home Assistant energy dashboard.

## Changes
- **Python discovery** (`src/astrameter/mqtt_insights/discovery.py`):
  - Added `"state_class": "measurement"` to all power sensor definitions in `build_ct002_consumer_discovery()`, `build_ct002_device_discovery()`, and `build_shelly_battery_discovery()`
  
- **ESPHome discovery** (`esphome/components/ct002/ha_discovery.cpp`):
  - Added `state_class: measurement` to power sensors in `add_power_sensor()` and `build_ct002_device_discovery()` to maintain parity with Python implementation
  
- **Tests** (`src/astrameter/mqtt_insights/mqtt_insights_test.py`):
  - Added assertions verifying `device_class: power` and `state_class: measurement` for all power sensors across CT002 consumer, CT002 device, and Shelly battery discovery structures

## Implementation Details
The `state_class: measurement` attribute is required by Home Assistant's energy dashboard to recognize power entities as valid power sources. This change applies to:
- Grid power sensors (total and per-phase)
- Target power sensors (per-phase and smooth)
- Reported power sensors
- All power sensors in battery-backed Shelly device discovery

Python and ESPHome implementations are kept in sync per project conventions.

Fixes #416

https://claude.ai/code/session_015hFREh38SGZ7cRieVjXJmd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Power sensors published via MQTT Insights are now compatible with Home Assistant's energy dashboard. Grid power, target power, and reported power entities can now be configured as power sources for energy consumption tracking.

* **Tests**
  * Updated tests to verify proper state class metadata on power sensor components across device discovery configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->