### PR TITLE
Add exception handling to CT readings for Shelly

### DIFF
--- a/src/astrameter/main.py
+++ b/src/astrameter/main.py
@@ -71,11 +71,16 @@ async def read_ct_powermeter(
                 "serving last known value",
                 type(powermeter).__name__,
             )
-    values = await powermeter.get_powermeter_watts()
-    value1 = values[0] if len(values) > 0 else 0
-    value2 = values[1] if len(values) > 1 else 0
-    value3 = values[2] if len(values) > 2 else 0
-    return [value1, value2, value3]
+    try:
+        values = await powermeter.get_powermeter_watts()
+        value1 = values[0] if len(values) > 0 else 0
+        value2 = values[1] if len(values) > 1 else 0
+        value3 = values[2] if len(values) > 2 else 0
+        return [value1, value2, value3]
+    except Exception as e:
+       logger.info("Could not get CT values:"+str(e))
+       return None
+
 
 
 async def test_powermeter(powermeter: Powermeter, client_filter: ClientFilter):

--- a/src/astrameter/powermeter/shelly.py
+++ b/src/astrameter/powermeter/shelly.py
@@ -37,22 +37,16 @@ class Shelly(Powermeter):
     async def _get_json(self, path: str) -> dict:
         assert self._session is not None
         url = f"http://{self.ip}{path}"
-        try:
-            async with self._session.get(url) as resp:
-                resp.raise_for_status()
-                return await resp.json(content_type=None)
-        except Exception as e:
-            raise
+        async with self._session.get(url) as resp:
+            resp.raise_for_status()
+            return await resp.json(content_type=None)
 
     async def _get_rpc_json(self, path: str) -> dict:
         assert self._rpc_session is not None
         url = f"http://{self.ip}/rpc{path}"
-        try:
-            async with self._rpc_session.get(url) as resp:
-                resp.raise_for_status()
-                return await resp.json(content_type=None)
-        except Exception as e:
-            raise
+        async with self._rpc_session.get(url) as resp:
+            resp.raise_for_status()
+            return await resp.json(content_type=None)
 
     async def get_powermeter_watts(self) -> list[float]:
         raise NotImplementedError()
@@ -60,48 +54,33 @@ class Shelly(Powermeter):
 
 class Shelly1PM(Shelly):
     async def get_powermeter_watts(self) -> list[float]:
-        try:
-            if self.emeterindex:
-                meter = await self._get_json(f"/meter/{self.emeterindex}")
-                return [int(meter["power"])]
-            else:
-                status = await self._get_json("/status")
-                return [int(meter["power"]) for meter in status["meters"]]
-        except Exception as e:
-            raise
+        if self.emeterindex:
+            meter = await self._get_json(f"/meter/{self.emeterindex}")
+            return [int(meter["power"])]
+        else:
+            status = await self._get_json("/status")
+            return [int(meter["power"]) for meter in status["meters"]]
 
 class ShellyPlus1PM(Shelly):
     async def get_powermeter_watts(self) -> list[float]:
-        try:
-            response = await self._get_rpc_json("/Switch.GetStatus?id=0")
-            return [int(response["apower"])]
-        except Exception as e:
-            raise
+        response = await self._get_rpc_json("/Switch.GetStatus?id=0")
+        return [int(response["apower"])]
 
 class ShellyEM(Shelly):
     async def get_powermeter_watts(self) -> list[float]:
-        try:
-            if self.emeterindex:
-                emeter = await self._get_json(f"/emeter/{self.emeterindex}")
-                return [int(emeter["power"])]
-            else:
-                status = await self._get_json("/status")
-                return [int(emeter["power"]) for emeter in status["emeters"]]
-        except Exception as e:
-            raise
+        if self.emeterindex:
+            emeter = await self._get_json(f"/emeter/{self.emeterindex}")
+            return [int(emeter["power"])]
+        else:
+            status = await self._get_json("/status")
+            return [int(emeter["power"]) for emeter in status["emeters"]]
 
 class Shelly3EM(Shelly):
     async def get_powermeter_watts(self) -> list[float]:
-        try:
-            status = await self._get_json("/status")
-            return [int(emeter["power"]) for emeter in status["emeters"]]
-        except Exception as e:
-            raise
+        status = await self._get_json("/status")
+        return [int(emeter["power"]) for emeter in status["emeters"]]
 
 class Shelly3EMPro(Shelly):
     async def get_powermeter_watts(self) -> list[float]:
-        try:
-            response = await self._get_rpc_json("/EM.GetStatus?id=0")
-            return [int(response["total_act_power"])]
-        except Exception as e:
-            raise
+        response = await self._get_rpc_json("/EM.GetStatus?id=0")
+        return [int(response["total_act_power"])]

--- a/src/astrameter/powermeter/shelly.py
+++ b/src/astrameter/powermeter/shelly.py
@@ -37,16 +37,22 @@ class Shelly(Powermeter):
     async def _get_json(self, path: str) -> dict:
         assert self._session is not None
         url = f"http://{self.ip}{path}"
-        async with self._session.get(url) as resp:
-            resp.raise_for_status()
-            return await resp.json(content_type=None)
+        try:
+            async with self._session.get(url) as resp:
+                resp.raise_for_status()
+                return await resp.json(content_type=None)
+        except Exception as e:
+            raise
 
     async def _get_rpc_json(self, path: str) -> dict:
         assert self._rpc_session is not None
         url = f"http://{self.ip}/rpc{path}"
-        async with self._rpc_session.get(url) as resp:
-            resp.raise_for_status()
-            return await resp.json(content_type=None)
+        try:
+            async with self._rpc_session.get(url) as resp:
+                resp.raise_for_status()
+                return await resp.json(content_type=None)
+        except Exception as e:
+            raise
 
     async def get_powermeter_watts(self) -> list[float]:
         raise NotImplementedError()
@@ -54,37 +60,48 @@ class Shelly(Powermeter):
 
 class Shelly1PM(Shelly):
     async def get_powermeter_watts(self) -> list[float]:
-        if self.emeterindex:
-            meter = await self._get_json(f"/meter/{self.emeterindex}")
-            return [int(meter["power"])]
-        else:
-            status = await self._get_json("/status")
-            return [int(meter["power"]) for meter in status["meters"]]
-
+        try:
+            if self.emeterindex:
+                meter = await self._get_json(f"/meter/{self.emeterindex}")
+                return [int(meter["power"])]
+            else:
+                status = await self._get_json("/status")
+                return [int(meter["power"]) for meter in status["meters"]]
+        except Exception as e:
+            raise
 
 class ShellyPlus1PM(Shelly):
     async def get_powermeter_watts(self) -> list[float]:
-        response = await self._get_rpc_json("/Switch.GetStatus?id=0")
-        return [int(response["apower"])]
-
+        try:
+            response = await self._get_rpc_json("/Switch.GetStatus?id=0")
+            return [int(response["apower"])]
+        except Exception as e:
+            raise
 
 class ShellyEM(Shelly):
     async def get_powermeter_watts(self) -> list[float]:
-        if self.emeterindex:
-            emeter = await self._get_json(f"/emeter/{self.emeterindex}")
-            return [int(emeter["power"])]
-        else:
-            status = await self._get_json("/status")
-            return [int(emeter["power"]) for emeter in status["emeters"]]
-
+        try:
+            if self.emeterindex:
+                emeter = await self._get_json(f"/emeter/{self.emeterindex}")
+                return [int(emeter["power"])]
+            else:
+                status = await self._get_json("/status")
+                return [int(emeter["power"]) for emeter in status["emeters"]]
+        except Exception as e:
+            raise
 
 class Shelly3EM(Shelly):
     async def get_powermeter_watts(self) -> list[float]:
-        status = await self._get_json("/status")
-        return [int(emeter["power"]) for emeter in status["emeters"]]
-
+        try:
+            status = await self._get_json("/status")
+            return [int(emeter["power"]) for emeter in status["emeters"]]
+        except Exception as e:
+            raise
 
 class Shelly3EMPro(Shelly):
     async def get_powermeter_watts(self) -> list[float]:
-        response = await self._get_rpc_json("/EM.GetStatus?id=0")
-        return [int(response["total_act_power"])]
+        try:
+            response = await self._get_rpc_json("/EM.GetStatus?id=0")
+            return [int(response["total_act_power"])]
+        except Exception as e:
+            raise

--- a/src/astrameter/shelly/shelly.py
+++ b/src/astrameter/shelly/shelly.py
@@ -230,7 +230,11 @@ class Shelly:
                             "serving last known value",
                             type(powermeter).__name__,
                         )
-                powers = await powermeter.get_powermeter_watts()
+                try:
+                    powers = await powermeter.get_powermeter_watts()
+                except Exception as e:
+                    logger.info("Could not get CT values:"+str(e))
+                    return
 
                 if request.get("method") == "EM.GetStatus":
                     response = self._create_em_response(request["id"], powers)


### PR DESCRIPTION
I added exception handling for Shelly devices. For applications like mine which show occasional outages on CT readings (probably due to some WiFi interference), it helps to understand how bad it is, as with this change there is only one info line showing the exception for a missed reading recorded instead of the full trace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when reading power meters: communication failures are now logged and handled without crashing.
  * Power readings are normalized into up to three phase values (missing phases filled as zero) so downstream displays remain stable when some data is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->