### PR TITLE
Log meter read failures as one-liners, full traceback at DEBUG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- **Changed** a transient meter-read failure in the Shelly emulator (e.g. an HTTP source timing out) now logs a single warning line instead of a full stack trace; the traceback is only included when running at `LOG_LEVEL = DEBUG` ([#404](https://github.com/tomquist/astrameter/issues/404)).
 - **Added** the Hampel outlier filter and PID controller as optional fields in the Home Assistant add-on Configuration tab (alongside the existing smoothing/deadband options) — all optional and off unless you set them. The web config generator gained a "Home Assistant add-on" target that produces a ready-to-paste add-on options block including these filters.
 - **Fixed** the power sensors published via MQTT Insights now carry `state_class: measurement`, so the instantly-updated grid/target/reported power entities can be used as power sources in the Home Assistant energy dashboard ([#416](https://github.com/tomquist/astrameter/issues/416)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Changed** a transient meter-read failure in the Shelly emulator (e.g. an HTTP source timing out) now logs a single warning line instead of a full stack trace; the traceback is only included when running at `LOG_LEVEL = DEBUG` ([#404](https://github.com/tomquist/astrameter/issues/404)).
+- **Changed** a transient meter-read failure (the Shelly emulator and the CT002/CT003 emulator, e.g. an HTTP source timing out) now logs a single warning line instead of a full stack trace; the traceback is only included when running at `LOG_LEVEL = DEBUG` ([#404](https://github.com/tomquist/astrameter/issues/404)).
 - **Added** the Hampel outlier filter and PID controller as optional fields in the Home Assistant add-on Configuration tab (alongside the existing smoothing/deadband options) — all optional and off unless you set them. The web config generator gained a "Home Assistant add-on" target that produces a ready-to-paste add-on options block including these filters.
 - **Fixed** the power sensors published via MQTT Insights now carry `state_class: measurement`, so the instantly-updated grid/target/reported power entities can be used as power sources in the Home Assistant energy dashboard ([#416](https://github.com/tomquist/astrameter/issues/416)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Changed** a transient meter-read failure (the Shelly emulator and the CT002/CT003 emulator, e.g. an HTTP source timing out) now logs a single warning line instead of a full stack trace; the traceback is only included when running at `LOG_LEVEL = DEBUG` ([#404](https://github.com/tomquist/astrameter/issues/404)).
+- **Changed** transient meter-read failures (in the Shelly emulator and the CT002/CT003 emulator, e.g. when an HTTP source times out) now log a single-line warning instead of a full stack trace; the traceback is included only when running at `LOG_LEVEL = DEBUG` ([#404](https://github.com/tomquist/astrameter/issues/404)).
 - **Added** the Hampel outlier filter and PID controller as optional fields in the Home Assistant add-on Configuration tab (alongside the existing smoothing/deadband options) — all optional and off unless you set them. The web config generator gained a "Home Assistant add-on" target that produces a ready-to-paste add-on options block including these filters.
 - **Fixed** the power sensors published via MQTT Insights now carry `state_class: measurement`, so the instantly-updated grid/target/reported power entities can be used as power sources in the Home Assistant energy dashboard ([#416](https://github.com/tomquist/astrameter/issues/416)).
 

--- a/src/astrameter/config/logger.py
+++ b/src/astrameter/config/logger.py
@@ -19,6 +19,17 @@ class _AutoExcInfoFilter(logging.Filter):
         return True
 
 
+def debug_traceback() -> bool:
+    """Return ``True`` only when the logger is at DEBUG level.
+
+    Use as ``exc_info=debug_traceback()`` on an ``except``-block log call to
+    emit a one-line message at the normal level while still including the full
+    traceback when the user runs with ``LOG_LEVEL = DEBUG``. Passing ``False``
+    also opts the record out of the auto-exc-info filter above.
+    """
+    return logger.isEnabledFor(logging.DEBUG)
+
+
 def setLogLevel(inLevel: str):
     level = levels.get(inLevel.lower())
     if level is None:

--- a/src/astrameter/config/logger_test.py
+++ b/src/astrameter/config/logger_test.py
@@ -50,6 +50,15 @@ def test_set_log_level_configures_timestamped_log_output():
     assert kwargs["force"] is True
 
 
+@pytest.mark.parametrize(
+    ("level_name", "expected"),
+    [("debug", True), ("info", False), ("warning", False)],
+)
+def test_debug_traceback_reflects_log_level(level_name, expected):
+    setLogLevel(level_name)
+    assert logger_module.debug_traceback() is expected
+
+
 def test_warning_inside_except_block_includes_traceback():
     setLogLevel("warning")
     root = logging.getLogger()

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -9,7 +9,7 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from typing import Any, Literal, cast
 
-from astrameter.config.logger import logger
+from astrameter.config.logger import debug_traceback, logger
 from astrameter.request_dedupe import RequestDeduplicator
 
 from .balancer import (
@@ -579,7 +579,7 @@ class CT002:
                     self._before_send_failure_count,
                     addr,
                     exc,
-                    exc_info=True,
+                    exc_info=debug_traceback(),
                 )
                 self._before_send_last_warn = now
             return None

--- a/src/astrameter/shelly/shelly.py
+++ b/src/astrameter/shelly/shelly.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from astrameter.config import ClientFilter
-from astrameter.config.logger import logger
+from astrameter.config.logger import debug_traceback, logger
 from astrameter.powermeter import Powermeter
 from astrameter.request_dedupe import RequestDeduplicator
 
@@ -230,7 +230,21 @@ class Shelly:
                             "serving last known value",
                             type(powermeter).__name__,
                         )
-                powers = await powermeter.get_powermeter_watts()
+                try:
+                    powers = await powermeter.get_powermeter_watts()
+                except Exception as exc:
+                    # Reading the meter can fail transiently (e.g. an HTTP
+                    # source timing out). Log a one-liner at the normal level
+                    # and reserve the full traceback for DEBUG so an outage
+                    # doesn't flood the log with stack traces on every poll.
+                    logger.warning(
+                        "Could not read meter values from %s (%s): %s",
+                        type(powermeter).__name__,
+                        addr[0],
+                        exc,
+                        exc_info=debug_traceback(),
+                    )
+                    return
 
                 if request.get("method") == "EM.GetStatus":
                     response = self._create_em_response(request["id"], powers)

--- a/src/astrameter/shelly/shelly_udp_test.py
+++ b/src/astrameter/shelly/shelly_udp_test.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import socket
 from ipaddress import IPv4Network
 
@@ -21,6 +22,11 @@ class DummyPowermeter(Powermeter):
         # Same physical reading as get_powermeter_watts; do not bump call_count so
         # throttling/dedupe tests that only observe get_powermeter_watts stay stable.
         return [1.0]
+
+
+class FailingPowermeter(Powermeter):
+    async def get_powermeter_watts(self):
+        raise TimeoutError("Connection timeout to host http://192.168.2.17/")
 
 
 class _FakeClock:
@@ -115,6 +121,43 @@ async def test_multiple_requests_with_throttling():
         )
     finally:
         await shelly.stop()
+
+
+async def _drive_failing_read(caplog, level):
+    """Send one request to a Shelly backed by a failing meter and return the
+    single captured log record (and the fake transport, to assert no reply)."""
+    cf = ClientFilter([IPv4Network("127.0.0.1/32")])
+    shelly = Shelly([(FailingPowermeter(), cf, False)], udp_port=0, device_id="test")
+    transport = _FakeTransport()
+    req = json.dumps(
+        {"id": 1, "src": "cli", "method": "EM.GetStatus", "params": {"id": 0}}
+    ).encode()
+
+    with caplog.at_level(level, logger="astrameter"):
+        await shelly._handle_request(transport, req, ("127.0.0.1", 54321))
+
+    records = [
+        r for r in caplog.records if "Could not read meter values" in r.getMessage()
+    ]
+    assert len(records) == 1
+    return records[0], transport
+
+
+async def test_meter_read_failure_logs_one_liner_without_traceback(caplog):
+    record, transport = await _drive_failing_read(caplog, logging.WARNING)
+    # No response is sent to the battery when the meter read fails.
+    assert transport.sent == []
+    assert record.levelno == logging.WARNING
+    # At the normal level the traceback is suppressed: just the one-liner.
+    assert not record.exc_info
+    assert "Connection timeout" in record.getMessage()
+
+
+async def test_meter_read_failure_includes_traceback_at_debug(caplog):
+    record, _ = await _drive_failing_read(caplog, logging.DEBUG)
+    # At DEBUG the full traceback is attached.
+    assert record.exc_info is not None
+    assert record.exc_info[0] is TimeoutError
 
 
 async def _send_req(port, request_id, timeout=2.0):

--- a/tests/test_e2e_probe_lockup.py
+++ b/tests/test_e2e_probe_lockup.py
@@ -511,6 +511,12 @@ class TestProbeLockup:
                 f"{[r.getMessage() for r in stale_warnings]}"
             )
 
+            # At WARNING level the stale warnings are one-liners: the full
+            # traceback is reserved for DEBUG (see logger.debug_traceback()).
+            assert all(not r.exc_info for r in stale_warnings), (
+                "Stale warnings should not carry a traceback at WARNING level"
+            )
+
             # Batteries held their state — they did NOT get commanded
             # off-axis by the balancer acting on bad data.  Tolerance
             # is generous because the balancer can still emit small


### PR DESCRIPTION
## Summary

Transient meter-read failures (e.g., HTTP timeouts from Shelly or CT002/CT003 emulators) now log a single warning line instead of a full stack trace. The complete traceback is only included when running at `LOG_LEVEL = DEBUG`, preventing log spam during outages while preserving debugging information when needed.

## Changes

- **New utility function** `debug_traceback()` in `src/astrameter/config/logger.py` returns `True` only when the logger is at DEBUG level, allowing conditional inclusion of tracebacks via `exc_info=debug_traceback()`.

- **Shelly meter read error handling** (`src/astrameter/shelly/shelly.py`): Wrapped `powermeter.get_powermeter_watts()` in a try-except block that logs a one-liner warning with the exception message, returning early without sending a response to the client.

- **CT002 error handling** (`src/astrameter/ct002/ct002.py`): Updated `_call_before_send()` to use `exc_info=debug_traceback()` instead of always including the traceback.

- **Comprehensive test coverage**:
  - Added `FailingPowermeter` mock class and helper `_drive_failing_read()` in `src/astrameter/shelly/shelly_udp_test.py`
  - New tests verify one-liner logging at WARNING level and full traceback at DEBUG level
  - Added parametrized test for `debug_traceback()` in `src/astrameter/config/logger_test.py`
  - Updated e2e probe lockup test to verify stale warnings don't carry tracebacks at WARNING level

- **Documentation**: Updated `CHANGELOG.md` with user-facing change summary.

## Implementation Details

The `debug_traceback()` function leverages Python's logging `exc_info` parameter, which accepts a boolean. When `False`, it prevents automatic exception info capture; when `True`, it includes the full traceback. This allows a single log call to emit a clean one-liner at normal levels while preserving the stack trace for DEBUG-level debugging.

https://claude.ai/code/session_01DyFcRJMWUZmT1X6MQ3R25D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transient meter-read failures (e.g., temporary device or network timeouts) now emit a single-line warning by default instead of a full stack trace; full traceback is included only when LOG_LEVEL = DEBUG.

* **Documentation**
  * Changelog updated to clearly describe the new logging behavior for transient meter-read failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->