### PR TITLE
Fix MQTT Insights device_id default to match Python add-on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Changed** transient meter-read failures (in the Shelly emulator and the CT002/CT003 emulator, e.g. when an HTTP source times out) now log a single-line warning instead of a full stack trace; the traceback is included only when running at `LOG_LEVEL = DEBUG` ([#404](https://github.com/tomquist/astrameter/issues/404)).
 - **Added** the Hampel outlier filter and PID controller as optional fields in the Home Assistant add-on Configuration tab (alongside the existing smoothing/deadband options) — all optional and off unless you set them. The web config generator gained a "Home Assistant add-on" target that produces a ready-to-paste add-on options block including these filters.
 - **Fixed** the power sensors published via MQTT Insights now carry `state_class: measurement`, so the instantly-updated grid/target/reported power entities can be used as power sources in the Home Assistant energy dashboard ([#416](https://github.com/tomquist/astrameter/issues/416)).
+- **Fixed** the ESPHome MQTT Insights `device_id` now defaults to `device-1` (matching the Python add-on) instead of the ESPHome `ct002:` component id, so both stacks publish the same Home Assistant discovery node (e.g. `astrameter_ct002_device-1`). Existing ESPHome users who want to keep their previous device can set `device_id:` explicitly under `mqtt_insights:`.
 
 
 ## 2.1.0

--- a/esphome.example.yaml
+++ b/esphome.example.yaml
@@ -175,6 +175,8 @@ ct002:
   # Uncomment together with the top-level `mqtt:` block above.
   # mqtt_insights:
   #   base_topic: astrameter         # per-installation namespace
+  #   device_id: device-1            # HA discovery node id; defaults to
+  #                                  # "device-1" to match the Python add-on
   #   ha_discovery: true             # publish HA Device Discovery
   #   ha_discovery_prefix: homeassistant
   #   marstek_mqtt_enabled: true     # answer Marstek-app polls on the broker

--- a/esphome/components/ct002/__init__.py
+++ b/esphome/components/ct002/__init__.py
@@ -238,8 +238,10 @@ MQTT_INSIGHTS_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(MqttInsightsComponent),
             cv.Optional(CONF_BASE_TOPIC, default="astrameter"): cv.string_strict,
-            # device_id defaults to the parent ct002 id at to_code time when
-            # left blank (see _to_code_mqtt_insights).
+            # device_id defaults to "device-1" at to_code time when left
+            # blank, matching the Python add-on's default (see main.py) so
+            # both stacks publish the same HA discovery node_id. See
+            # _to_code_mqtt_insights.
             cv.Optional(CONF_DEVICE_ID, default=""): cv.string,
             cv.Optional(CONF_HA_DISCOVERY, default=True): cv.boolean,
             cv.Optional(
@@ -456,7 +458,7 @@ async def _to_code_mqtt_insights(config, ct002_var):
     var = cg.new_Pvariable(sub[CONF_ID])
     await cg.register_component(var, sub)
     cg.add(var.set_ct002(ct002_var))
-    device_id = sub[CONF_DEVICE_ID] or str(config[CONF_ID])
+    device_id = sub[CONF_DEVICE_ID] or "device-1"
     cg.add(var.set_device_id(device_id))
     cg.add(var.set_base_topic(sub[CONF_BASE_TOPIC]))
     cg.add(var.set_ha_discovery(sub[CONF_HA_DISCOVERY]))

--- a/esphome/components/ct002/__init__.py
+++ b/esphome/components/ct002/__init__.py
@@ -233,15 +233,30 @@ CONF_DEVICE_ID = "device_id"
 CONF_MARSTEK_MQTT_ENABLED = "marstek_mqtt_enabled"
 CONF_MARSTEK_MQTT_INTERVAL = "marstek_mqtt_interval"
 
+# Fallback `device_id:` when the sub-block leaves it blank. Matches the Python
+# add-on's default (see main.py) so both stacks publish the same HA discovery
+# node (`astrameter_ct002_device-1`). Keep in sync with the C++ member default
+# in mqtt_insights.h.
+DEFAULT_MQTT_INSIGHTS_DEVICE_ID = "device-1"
+
+
+def _resolve_mqtt_insights_device_id(device_id_opt: str) -> str:
+    """Resolve the configured `device_id:` to the value handed to firmware.
+
+    A blank/omitted value falls back to ``DEFAULT_MQTT_INSIGHTS_DEVICE_ID``.
+    """
+    return device_id_opt or DEFAULT_MQTT_INSIGHTS_DEVICE_ID
+
+
 MQTT_INSIGHTS_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(MqttInsightsComponent),
             cv.Optional(CONF_BASE_TOPIC, default="astrameter"): cv.string_strict,
-            # device_id defaults to "device-1" at to_code time when left
-            # blank, matching the Python add-on's default (see main.py) so
-            # both stacks publish the same HA discovery node_id. See
-            # _to_code_mqtt_insights.
+            # device_id defaults to DEFAULT_MQTT_INSIGHTS_DEVICE_ID at
+            # to_code time when left blank (see _resolve_mqtt_insights_device_id),
+            # matching the Python add-on so both stacks publish the same HA
+            # discovery node_id.
             cv.Optional(CONF_DEVICE_ID, default=""): cv.string,
             cv.Optional(CONF_HA_DISCOVERY, default=True): cv.boolean,
             cv.Optional(
@@ -458,7 +473,7 @@ async def _to_code_mqtt_insights(config, ct002_var):
     var = cg.new_Pvariable(sub[CONF_ID])
     await cg.register_component(var, sub)
     cg.add(var.set_ct002(ct002_var))
-    device_id = sub[CONF_DEVICE_ID] or "device-1"
+    device_id = _resolve_mqtt_insights_device_id(sub[CONF_DEVICE_ID])
     cg.add(var.set_device_id(device_id))
     cg.add(var.set_base_topic(sub[CONF_BASE_TOPIC]))
     cg.add(var.set_ha_discovery(sub[CONF_HA_DISCOVERY]))

--- a/esphome/components/ct002/mqtt_insights.h
+++ b/esphome/components/ct002/mqtt_insights.h
@@ -96,7 +96,7 @@ class MqttInsightsComponent : public Component {
   // Configuration.
   ct002::CT002Component *ct002_{nullptr};
   mqtt::MQTTClientComponent *mqtt_{nullptr};
-  std::string device_id_{"ct002_main"};
+  std::string device_id_{"device-1"};
   std::string base_topic_{"astrameter"};
   bool ha_discovery_{true};
   std::string ha_discovery_prefix_{"homeassistant"};

--- a/tests/components/ct002/test_codegen.py
+++ b/tests/components/ct002/test_codegen.py
@@ -84,3 +84,39 @@ def test_three_phase_validator_rejects_only_l3():
     }
     with pytest.raises(cv.Invalid):
         ct002_component._validate_three_phase_sensors(config)
+
+
+def test_mqtt_insights_device_id_defaults_to_python_default():
+    # A blank device_id must fall back to the same default the Python add-on
+    # uses, so both stacks publish HA discovery under astrameter_ct002_device-1
+    # (regression: ESPHome used to derive it from the ct002: component id,
+    # yielding astrameter_ct002_ct002_main).
+    assert ct002_component.DEFAULT_MQTT_INSIGHTS_DEVICE_ID == "device-1"
+    assert ct002_component._resolve_mqtt_insights_device_id("") == "device-1"
+
+
+def test_mqtt_insights_device_id_uses_explicit_value():
+    assert ct002_component._resolve_mqtt_insights_device_id("garage") == "garage"
+
+
+def test_mqtt_insights_schema_device_id_blank_by_default():
+    # The schema default must stay blank so _resolve_mqtt_insights_device_id
+    # (not the schema) owns the fallback at to_code time. The sub-block schema
+    # gates on an `mqtt:` component via cv.requires_component, so mark it loaded.
+    from esphome.core import CORE
+
+    added = "mqtt" not in CORE.loaded_integrations
+    if added:
+        CORE.loaded_integrations.add("mqtt")
+    try:
+        config = ct002_component.MQTT_INSIGHTS_SCHEMA({})
+    finally:
+        if added:
+            CORE.loaded_integrations.discard("mqtt")
+    assert config[ct002_component.CONF_DEVICE_ID] == ""
+    assert (
+        ct002_component._resolve_mqtt_insights_device_id(
+            config[ct002_component.CONF_DEVICE_ID]
+        )
+        == "device-1"
+    )


### PR DESCRIPTION
## Summary

The ESPHome CT002 component was deriving the MQTT Insights `device_id` from the ct002 component ID when left blank, causing a mismatch with the Python add-on's default. Both stacks now use `"device-1"` as the fallback, ensuring they publish Home Assistant discovery under the same node ID (`astrameter_ct002_device-1`).

## Changes

- **`esphome/components/ct002/__init__.py`**
  - Added `DEFAULT_MQTT_INSIGHTS_DEVICE_ID = "device-1"` constant to match the Python add-on's default
  - Introduced `_resolve_mqtt_insights_device_id()` function to handle the fallback logic at code generation time
  - Updated `_to_code_mqtt_insights()` to use the new resolver instead of deriving from the ct002 component ID
  - Updated schema documentation to clarify the new fallback behavior

- **`esphome/components/ct002/mqtt_insights.h`**
  - Changed C++ member default from `"ct002_main"` to `"device-1"` for parity with Python

- **`esphome.example.yaml`**
  - Added documentation comment showing the `device_id` option and its default behavior

- **`tests/components/ct002/test_codegen.py`**
  - Added three new tests to verify the constant, resolver function, and schema behavior

- **`CHANGELOG.md`**
  - Documented the fix under the `## Next` section

## Implementation Details

The fix ensures Python ↔ ESPHome parity by centralizing the fallback logic in `_resolve_mqtt_insights_device_id()`, which is called at code generation time. The schema continues to default to an empty string, allowing the resolver to own the fallback decision rather than embedding it in the schema layer. This matches the pattern used by the Python add-on and prevents accidental duplication of the default value across multiple code paths.

https://claude.ai/code/session_012HecJKfZ357bEYkSr8Frco