### PR TITLE
Fix meter unavailability handling to send zero-delta hold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Added** a **Min DC Output** option that keeps a DC battery's inverter (e.g. the Marstek B2500) from switching off at 0 W and falling asleep under high PV surplus. Set it globally (`MIN_DC_OUTPUT`) or per battery from Home Assistant; off by default ([#425](https://github.com/tomquist/astrameter/issues/425)).
 - **Fixed** a phantom empty "Unnamed Device" that kept reappearing under the MQTT integration in Home Assistant, even after deleting it. AstraMeter now publishes a proper top-level **AstraMeter** device — with **Status**, **Version**, and **Consumer Count** entities — that the meter devices are grouped under ([#421](https://github.com/tomquist/astrameter/issues/421)).
+- **Fixed** batteries drifting or losing their phase reference during a brief power-meter dropout (e.g. a Home Assistant sensor going `unavailable`). The CT002/CT003 emulator now sends a zero adjustment so each battery holds its current output while the meter is down, instead of re-driving control from the last-known reading — which could wind a battery up or feed stale per-phase values into a Venus phase self-diagnosis ([#403](https://github.com/tomquist/astrameter/issues/403)).
 
 
 ## 2.1.1

--- a/esphome/components/ct002/test_hooks.cpp
+++ b/esphome/components/ct002/test_hooks.cpp
@@ -142,6 +142,13 @@ void CT002Component::handle_control_command_(const std::string &cmd,
     // Inject grid power straight into the sensor cache, stamped now so the
     // SensorBackedPowermeter freshness check passes. matched-1 values given;
     // missing phases default to 0.
+    //
+    // Iterate the full size-3 array (not num_phases_): unlike sensor_stale
+    // below — which only needs to invalidate the [0, num_phases_) stamps the
+    // reader inspects — `grid` fully (re)defines every slot of raw_values_ /
+    // raw_stamp_ms_ (both std::array<…, 3>) so the injected snapshot is
+    // completely specified and the reply can echo all three, regardless of how
+    // many phases this binary reads.
     const uint32_t now_ms = ::esphome::millis();
     const double vals[3] = {a, b, c};
     for (uint8_t p = 0; p < 3; ++p) {

--- a/esphome/components/ct002/test_hooks.cpp
+++ b/esphome/components/ct002/test_hooks.cpp
@@ -16,6 +16,10 @@
 //                         what the balancer/saturation/eviction/dedup care
 //                         about, so this is the usual driver)
 //   clock_real            disengage the mock clock (back to millis())
+//   sensor_stale          back-date the sensor stamps past max_sensor_age so
+//                         the next read reports the grid sensor unavailable
+//                         (SensorBackedPowermeter returns {}), which the
+//                         handler maps to [0,0,0] — the meter-outage path.
 //
 // Every command replies with "ok ..." (or "err ...") to the sender so the
 // test can synchronise (send command, await ack, then poll the CT002 port).
@@ -171,6 +175,16 @@ void CT002Component::handle_control_command_(const std::string &cmd,
     char tmp[48];
     std::snprintf(tmp, sizeof(tmp), "ok dedupe %u", this->dedupe_window_ms_);
     reply = tmp;
+  } else if (matched >= 1 && std::strcmp(verb, "sensor_stale") == 0) {
+    // Force the SensorBackedPowermeter freshness check to fail: back-date the
+    // per-phase stamps past max_sensor_age_ms_ so the next read reports the
+    // sensor unavailable (returns {}), which handle_request_ maps to [0,0,0].
+    // Deterministic — no real-time sleep needed. A subsequent `grid` command
+    // re-stamps "now" and restores freshness.
+    const uint32_t now = ::esphome::millis();
+    const uint32_t past = now - (this->max_sensor_age_ms_ + 1000);  // unsigned wrap is fine
+    for (uint8_t p = 0; p < 3; ++p) this->raw_stamp_ms_[p] = past;
+    reply = "ok sensor_stale";
   } else if (matched >= 1 && std::strcmp(verb, "force_rotation") == 0) {
     // Mirror ct002.force_efficiency_rotation() for the rotation tests.
     this->force_balancer_rotation();

--- a/esphome/components/ct002/test_hooks.cpp
+++ b/esphome/components/ct002/test_hooks.cpp
@@ -183,7 +183,9 @@ void CT002Component::handle_control_command_(const std::string &cmd,
     // re-stamps "now" and restores freshness.
     const uint32_t now = ::esphome::millis();
     const uint32_t past = now - (this->max_sensor_age_ms_ + 1000);  // unsigned wrap is fine
-    for (uint8_t p = 0; p < 3; ++p) this->raw_stamp_ms_[p] = past;
+    // Iterate over the active phases the freshness check reads (mirrors
+    // SensorBackedPowermeter::get_powermeter_watts in sensor_backed.cpp).
+    for (uint8_t p = 0; p < this->num_phases_; ++p) this->raw_stamp_ms_[p] = past;
     reply = "ok sensor_stale";
   } else if (matched >= 1 && std::strcmp(verb, "force_rotation") == 0) {
     // Mirror ct002.force_efficiency_rotation() for the rotation tests.

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -570,8 +570,16 @@ class CT002:
         return response_fields
 
     async def _call_before_send(self, addr, fields, consumer_id):
+        """Invoke the ``before_send`` powermeter hook.
+
+        Returns ``(result, failed)``.  ``failed`` is ``True`` only when the
+        hook *raised* (the powermeter is unavailable); the caller uses it to
+        send a zero-adjustment "hold" instead of re-driving control from a
+        stale cached reading.  A hook that simply returns ``None`` (e.g. no
+        powermeter matches this client) is *not* a failure.
+        """
         if not self.before_send:
-            return None
+            return None, False
         try:
             result = await self.before_send(addr, fields, consumer_id)
         except Exception as exc:
@@ -591,16 +599,16 @@ class CT002:
             ):
                 logger.warning(
                     "CT002 before_send failed (%d in a row) for %s: %s. "
-                    "The CT002 emulator is serving cached meter values "
-                    "until the powermeter recovers; batteries will hold "
-                    "their current output.",
+                    "The CT002 emulator is sending a zero adjustment so "
+                    "batteries hold their current output until the "
+                    "powermeter recovers.",
                     self._before_send_failure_count,
                     addr,
                     exc,
                     exc_info=debug_traceback(),
                 )
                 self._before_send_last_warn = now
-            return None
+            return None, True
         # Success path: if we were in a failure spell, log the recovery.
         if self._before_send_failure_count > 0:
             logger.info(
@@ -609,7 +617,7 @@ class CT002:
             )
             self._before_send_failure_count = 0
             self._before_send_last_warn = 0.0
-        return result
+        return result, False
 
     def _validate_ct_mac(self, request_fields):
         if not self.ct_mac:
@@ -692,13 +700,25 @@ class CT002:
             source_ip=str(addr[0]),
         )
 
-        updated = await self._call_before_send(addr, fields, consumer_id)
+        updated, meter_failed = await self._call_before_send(addr, fields, consumer_id)
         if updated is not None:
             self.set_consumer_value(consumer_id, updated)
 
-        values = self._get_consumer_value(consumer_id)
-        if values is None:
+        if meter_failed:
+            # Powermeter unavailable: do NOT re-drive control from the stale
+            # cached reading.  The CT002 instruction is a delta
+            # (``new_target = current_power + grid_field``), so re-issuing a
+            # delta derived from a frozen reading winds the battery up in
+            # active control, and feeds frozen per-phase values into a phase
+            # self-diagnosis in inspection mode (issue #403).  Send a zero
+            # adjustment instead so each battery holds its current output —
+            # matching the ESPHome component, which uses ``[0, 0, 0]`` when
+            # its sensor ages out (see esphome/components/ct002/ct002.cpp).
             values = [0, 0, 0]
+        else:
+            values = self._get_consumer_value(consumer_id)
+            if values is None:
+                values = [0, 0, 0]
         raw_values = ([*list(values), 0, 0, 0])[:3]
         meter_value = sum(parse_int(v, 0) for v in raw_values)
         is_active = self.is_consumer_active(consumer_id)

--- a/tests/components/ct002/test_shared_e2e.py
+++ b/tests/components/ct002/test_shared_e2e.py
@@ -98,6 +98,7 @@ class PythonBackend:
         self._loop = asyncio.new_event_loop()
         self._clock = _FakeClock()
         self._grid = [0.0, 0.0, 0.0]
+        self._meter_unavailable = False
         self.ct002 = CT002(
             udp_port=UDP_PORT,  # unused: we never start() a real socket
             ct_mac="",  # mirror mode, like the e2e YAML
@@ -110,12 +111,21 @@ class PythonBackend:
         )
 
         async def _before_send(_addr, _fields=None, _consumer_id=None):
+            if self._meter_unavailable:
+                # Mirror a powermeter that detects its own staleness and
+                # raises (HomeAssistant / HomeWizard). This is the #403 trigger.
+                raise ValueError("powermeter unavailable (test)")
             return list(self._grid)
 
         self.ct002.before_send = _before_send
 
     def set_grid(self, l1: float, l2: float = 0.0, l3: float = 0.0) -> None:
         self._grid = [float(l1), float(l2), float(l3)]
+
+    def set_meter_unavailable(self, unavailable: bool = True) -> None:
+        # The Python counterpart of the ESPHome `sensor_stale` hook: the next
+        # poll's before_send raises instead of returning a grid reading.
+        self._meter_unavailable = unavailable
 
     def set_clock(self, seconds: float) -> None:
         self._clock._now = float(seconds)
@@ -169,6 +179,11 @@ class EsphomeBackend:
 
     def set_dedupe(self, window_s: float) -> None:
         self._cmd(f"dedupe {int(window_s * 1000)}")
+
+    def set_sensor_stale(self) -> None:
+        # Back-date the sensor stamps so the next read reports the grid sensor
+        # unavailable (SensorBackedPowermeter returns {} -> handler uses [0,0,0]).
+        self._cmd("sensor_stale")
 
     def poll(self, mac: str, phase: str, power: int, timeout: float = 1.5):
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -505,6 +520,81 @@ def test_python_esphome_wire_identical() -> None:
                 assert not diffs, (
                     f"step {step} (mac={mac} phase={phase} power={reported} "
                     f"grid={grid}): wire mismatch:\n" + "\n".join(diffs)
+                )
+    finally:
+        py.close()
+
+
+@pytest.mark.timeout(60, func_only=True)
+def test_meter_unavailable_zero_delta_parity() -> None:
+    """Both stacks respond with a zero-delta hold when the grid meter is
+    unavailable (issue #403).
+
+    Python's powermeter hook raises (the HomeAssistant/HomeWizard staleness
+    error); ESPHome's sensor is back-dated past its freshness window so
+    ``SensorBackedPowermeter`` returns ``{}``. Both must then answer the
+    battery with a zero per-phase adjustment so it holds its current output —
+    NOT a delta re-derived from the last-known reading.
+
+    This is the cross-stack regression guard for the fix: before it, the Python
+    handler kept the stale ``consumer.values`` (the seeded 300 W) and re-ran the
+    balancer on them, so the response would carry that stale target instead of a
+    hold — diverging from ESPHome's ``[0, 0, 0]`` path.
+
+    A single battery is used so the hold is exactly zero: with one consumer the
+    balancer's inter-battery equalization term is zero, so a zero grid yields a
+    zero target on every phase. (Saturation is disabled on both stacks — the
+    documented float32/float64 byte-parity guard.)
+    """
+    py = PythonBackend(saturation_detection=False)
+    try:
+        with _running_esphome_backend() as esp:
+            esp._cmd("cfg saturation_enabled 0")
+            mac = "AAAA00000001"
+            phases = ["A", "B", "C", "0"]  # "0" = inspection / self-diagnosis
+            clock = 30000
+
+            # Seed both stacks with an identical NON-zero reading and a warm
+            # poll, so prior consumer state is in lockstep and the pre-fix
+            # stale-cache path would visibly diverge from a true hold.
+            clock += DEDUPE_WINDOW_S + 5
+            py.set_clock(clock)
+            esp.set_clock(clock)
+            py.set_grid(300)
+            esp.set_grid(300)
+            assert py.poll(mac, "A", 0) is not None
+            assert esp.poll(mac, "A", 0) is not None
+
+            # Meter goes unavailable on both stacks.
+            py.set_meter_unavailable(True)
+            esp.set_sensor_stale()
+
+            for step, (phase, reported) in enumerate(
+                (p, r) for p in phases for r in (-200, 0, 150)
+            ):
+                clock += DEDUPE_WINDOW_S + 5
+                py.set_clock(clock)
+                esp.set_clock(clock)
+                # ESPHome reads real millis() for freshness, so the clock-driven
+                # dedup advance doesn't refresh the sensor; the back-dated stamp
+                # from set_sensor_stale() persists until a `grid` command.
+
+                r_py = py.poll(mac, phase, reported)
+                r_esp = esp.poll(mac, phase, reported)
+                assert r_py is not None and r_esp is not None, (
+                    f"step {step}: a stack failed to answer "
+                    f"(python={r_py is not None}, esphome={r_esp is not None})"
+                )
+                # Zero-delta hold: per-phase A/B/C targets + total are all 0.
+                assert [r_py[i] for i in (4, 5, 6, 7)] == ["0", "0", "0", "0"], (
+                    f"[python] step {step} (phase={phase} power={reported}): "
+                    f"expected zero hold, got {r_py[4:8]}"
+                )
+                # And the two stacks agree field-by-field.
+                diffs = _diff_fields(r_py, r_esp)
+                assert not diffs, (
+                    f"step {step} (phase={phase} power={reported}): "
+                    "wire mismatch under meter outage:\n" + "\n".join(diffs)
                 )
     finally:
         py.close()

--- a/tests/test_ct002_protocol.py
+++ b/tests/test_ct002_protocol.py
@@ -303,6 +303,104 @@ async def test_handle_request_skips_instruction_update_in_inspection_mode():
     assert consumer.last_instructed_power == 0.0
 
 
+class _CaptureTransport:
+    """Captures the bytes CT002 sends back so the response can be decoded."""
+
+    def __init__(self) -> None:
+        self.sent: bytes | None = None
+
+    def sendto(self, data: bytes, _addr) -> None:
+        self.sent = data
+
+
+async def _drive_and_capture(
+    device: CT002,
+    battery_mac: str,
+    phase: str,
+    reported_power: int,
+    *,
+    before_send,
+) -> list[str]:
+    """Drive one request with *before_send* pinned and return the decoded
+    response fields (so per-phase deltas can be asserted)."""
+    transport = _CaptureTransport()
+    device.before_send = before_send
+    request = build_payload(
+        ["HMG-50", battery_mac, "HME-4", "112233445566", phase, str(reported_power)]
+    )
+    await device._handle_request(request, ("1.1.1.1", 12345), transport)
+    assert transport.sent is not None, "CT002 sent no response"
+    fields, error = parse_request(transport.sent)
+    assert error is None, error
+    return fields
+
+
+async def _seed_good_reading(device: CT002, battery_mac: str) -> None:
+    """Establish a non-zero cached grid reading via a successful poll."""
+
+    async def good(_addr, _fields, _consumer_id):
+        return [500, 0, 0]
+
+    await _drive_and_capture(device, battery_mac, "A", 0, before_send=good)
+
+
+async def _raise_stale(_addr, _fields, _consumer_id):
+    raise ValueError("powermeter unavailable (test)")
+
+
+async def test_handle_request_holds_with_zero_delta_when_before_send_fails():
+    """Issue #403: when the powermeter is unavailable (before_send raises),
+    the response must be a zero adjustment so the battery holds — not a delta
+    re-derived from the stale cached reading (which would wind it up)."""
+    device = CT002(ct_mac="112233445566", active_control=True, fair_distribution=True)
+    await _seed_good_reading(device, "AABBCCDDEEFF")
+    assert device._consumers["aabbccddeeff"].values == [500, 0, 0]
+
+    fields = await _drive_and_capture(
+        device, "AABBCCDDEEFF", "A", 250, before_send=_raise_stale
+    )
+
+    # Per-phase deltas + total are all zero (hold).
+    assert fields[4:8] == ["0", "0", "0", "0"], fields[4:8]
+    # The cached reading is preserved, not overwritten by the failure.
+    assert device._consumers["aabbccddeeff"].values == [500, 0, 0]
+    # The battery is instructed to hold at its reported output (delta 0).
+    assert device._consumers["aabbccddeeff"].last_instructed_power == 250.0
+
+
+async def test_handle_request_inspection_mode_holds_when_before_send_fails():
+    """A phase self-diagnosis poll (inspection marker) while the meter is down
+    must not be fed the frozen per-phase reading — feeding stale data is what
+    corrupts the Venus phase detection in #403."""
+    device = CT002(ct_mac="112233445566", active_control=True)
+    await _seed_good_reading(device, "AABBCCDDEEFF")
+
+    fields = await _drive_and_capture(
+        device, "AABBCCDDEEFF", "0", 0, before_send=_raise_stale
+    )
+
+    assert fields[4:7] == ["0", "0", "0"], fields[4:7]
+
+
+async def test_handle_request_uses_cache_when_before_send_returns_none():
+    """A before_send returning None (e.g. no powermeter matches this client)
+    is NOT a failure: the cached reading is still served. Guards that the hold
+    path keys on the raised exception, not on a None return."""
+    device = CT002(ct_mac="112233445566", active_control=True)
+    await _seed_good_reading(device, "AABBCCDDEEFF")
+
+    async def returns_none(_addr, _fields, _consumer_id):
+        return None
+
+    # Inspection mode skips the balancer, so the served value is the cached
+    # reading verbatim — proving None is treated as "use cache", not "hold".
+    fields = await _drive_and_capture(
+        device, "AABBCCDDEEFF", "0", 0, before_send=returns_none
+    )
+
+    assert fields[4] == "500", fields[4]
+
+
 def test_ct002_info_idx_increments_and_wraps():
     device = CT002()
     request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "A", "0"]


### PR DESCRIPTION
## Summary

Fixes issue #403 where the CT002 handler would re-derive control deltas from stale cached grid readings when the powermeter became unavailable, causing batteries to wind up instead of holding their current output. Both Python and ESPHome stacks now send a zero-adjustment "hold" when the meter fails.

## Changes

**Python (`src/astrameter/ct002/ct002.py`)**
- Modified `_call_before_send()` to return a tuple `(result, failed)` where `failed` indicates the hook raised an exception (meter unavailable), distinct from returning `None` (no matching powermeter)
- Updated `_handle_request()` to check the `meter_failed` flag: when true, use `[0, 0, 0]` values instead of re-driving control from the stale cached reading
- Updated warning log message to clarify that batteries hold their output, not that cached values are served
- Added docstring explaining the failure distinction

**ESPHome (`esphome/components/ct002/test_hooks.cpp`)**
- Added `sensor_stale` test command to back-date sensor timestamps past the freshness window, forcing `SensorBackedPowermeter` to return `{}` (which maps to `[0, 0, 0]`)
- This mirrors the Python meter-failure path for cross-stack regression testing

**Tests**
- Added `_CaptureTransport` and `_drive_and_capture()` helpers to decode CT002 responses in unit tests
- Added `_seed_good_reading()` to establish non-zero cached state
- Added three new unit tests:
  - `test_handle_request_holds_with_zero_delta_when_before_send_fails()` — verifies zero-delta hold when hook raises
  - `test_handle_request_inspection_mode_holds_when_before_send_fails()` — verifies inspection mode doesn't feed stale per-phase values
  - `test_handle_request_uses_cache_when_before_send_returns_none()` — guards that `None` return is not treated as failure
- Added `set_meter_unavailable()` and `set_sensor_stale()` methods to test backends
- Added `test_meter_unavailable_zero_delta_parity()` cross-stack e2e test verifying Python and ESPHome respond identically under meter outage

## Implementation Details

The fix distinguishes between two scenarios:
1. **Hook raises** (meter unavailable): send `[0, 0, 0]` → battery holds
2. **Hook returns `None`** (no matching powermeter): use cached reading → normal operation

This prevents the pre-fix behavior where a frozen cached reading (e.g., 300 W) would be re-balanced and sent as a delta, winding up the battery instead of holding it. The zero-delta approach matches ESPHome's `SensorBackedPowermeter` behavior when its sensor ages out.

Maintains Python ↔ ESPHome parity as required by project conventions.

https://claude.ai/code/session_01MwR3PFkWBLzniC9usKeRed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Batteries now hold steady with zero per-phase adjustments during brief power‑meter dropouts, preventing mis‑phased or stale per‑phase values.

* **Tests**
  * Added cross-backend regression tests and simulation controls (including a test-only command) to simulate meter outages and verify outage behavior and parity between backends.

* **Documentation**
  * Updated CHANGELOG entry under the Next release describing the outage/zero‑hold behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->