### PR TITLE
Introduce NetOutputW type and to_grid_reading() boundary

### DIFF
--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -433,11 +433,11 @@ std::optional<std::array<float, 3>> LoadBalancer::compute_probe_target_(
     }
     if (desired_total < 0.0f && desired_probe > 0.0f) desired_probe = -desired_probe;
     probe.requested_power_abs = std::fabs(desired_probe);
-    const float target = desired_probe - probe_actual;
-    state.last_target = target;
+    const float reading = to_grid_reading(NetOutputW(desired_probe), probe_actual);
+    state.last_target = reading;
     ReportMap cand_only;
     cand_only[candidate_id] = cand_it->second;
-    return split_by_phase_(target, cand_only);
+    return split_by_phase_(reading, cand_only);
   }
 
   // Seed backup_weights from the per-consumer efficiency partition the
@@ -458,9 +458,9 @@ std::optional<std::array<float, 3>> LoadBalancer::compute_probe_target_(
       *consumer_id, support_reports, backup_weights, desired_total - qualified_probe_actual);
   auto sup_it = support_reports.find(*consumer_id);
   const float reported = (sup_it != support_reports.end()) ? sup_it->second.power : 0.0f;
-  const float target = desired - reported;
-  state.last_target = target;
-  return split_by_phase_(target, support_reports, &backup_weights);
+  const float reading = to_grid_reading(NetOutputW(desired), reported);
+  state.last_target = reading;
+  return split_by_phase_(reading, support_reports, &backup_weights);
 }
 
 std::array<float, 3> LoadBalancer::steer_to_zero_(
@@ -475,14 +475,15 @@ std::array<float, 3> LoadBalancer::steer_to_zero_(
       phase = it->second.phase.empty() ? "A" : it->second.phase;
     }
   }
-  if (reported == 0.0f) return {0.0f, 0.0f, 0.0f};
+  const float reading = to_grid_reading(NetOutputW(0.0f), reported);
+  if (reading == 0.0f) return {0.0f, 0.0f, 0.0f};
   for (auto &c : phase) c = static_cast<char>(std::toupper(c));
   std::array<float, 3> result{0.0f, 0.0f, 0.0f};
   size_t idx = 0;
   if (phase == "A") idx = 0;
   else if (phase == "B") idx = 1;
   else if (phase == "C") idx = 2;
-  result[idx] = -reported;
+  result[idx] = reading;
   return result;
 }
 
@@ -543,9 +544,9 @@ std::array<float, 3> LoadBalancer::compute_target(
     const float reported = active_reports.count(*consumer_id)
                                ? active_reports[*consumer_id].power
                                : 0.0f;
-    const float target = mode.manual_value - reported;
-    state->last_target = target;
-    return split_by_phase_(target, active_reports);
+    const float reading = to_grid_reading(NetOutputW(mode.manual_value), reported);
+    state->last_target = reading;
+    return split_by_phase_(reading, active_reports);
   }
 
   ReportMap auto_reports;
@@ -711,9 +712,9 @@ std::array<float, 3> LoadBalancer::compute_auto_target_(
     float total_fade = 0.0f;
     for (const auto &r : reports) total_fade += this->get_consumer_(r.first).fade_weight;
     const float desired = (total_fade > 0.0f) ? demand * fade_w / total_fade : 0.0f;
-    const float target = desired - reported;
-    state.last_target = target;
-    return split_by_phase_(target, reports, &eff_part);
+    const float reading = to_grid_reading(NetOutputW(desired), reported);
+    state.last_target = reading;
+    return split_by_phase_(reading, reports, &eff_part);
   }
 
   for (const auto &kv : faded_adjustments) {
@@ -749,20 +750,30 @@ std::array<float, 3> LoadBalancer::compute_auto_target_(
     fair_share = grid_total / num_consumers;
   }
 
-  float target;
+  // fair_share / balance_correction_ produce the residual: this consumer's
+  // slice of the grid imbalance to fold into its current output. The absolute
+  // net-output target is "what I report now plus my residual" (NetOutputW wrap
+  // below).
+  float residual;
   if (!this->cfg_.fair_distribution || !consumer_id ||
       reports.find(*consumer_id) == reports.end()) {
-    target = fair_share;
+    residual = fair_share;
   } else if (eff_part.count(*consumer_id)) {
-    target = this->balance_correction_(*consumer_id, reports, eff_part, fair_share);
+    residual = this->balance_correction_(*consumer_id, reports, eff_part, fair_share);
   } else {
-    target = fair_share;
+    residual = fair_share;
   }
-  if ((grid_total < 0.0f && target > 0.0f) || (grid_total > 0.0f && target < 0.0f)) {
-    target = 0.0f;
+  if ((grid_total < 0.0f && residual > 0.0f) || (grid_total > 0.0f && residual < 0.0f)) {
+    residual = 0.0f;
   }
-  if (consumer_id) this->get_consumer_(*consumer_id).last_target = target;
-  return split_by_phase_(target, reports, &eff_part);
+  float reported = 0.0f;
+  if (consumer_id) {
+    auto it = reports.find(*consumer_id);
+    if (it != reports.end()) reported = it->second.power;
+  }
+  const float reading = to_grid_reading(NetOutputW(reported + residual), reported);
+  if (consumer_id) this->get_consumer_(*consumer_id).last_target = reading;
+  return split_by_phase_(reading, reports, &eff_part);
 }
 
 float LoadBalancer::balance_correction_(const std::string &consumer_id,

--- a/esphome/components/ct002/balancer.h
+++ b/esphome/components/ct002/balancer.h
@@ -27,6 +27,26 @@ inline constexpr double SATURATION_LONG_GAP_SECONDS = 30.0;
 
 bool is_ac_chargeable(const std::string &device_type);
 
+// Absolute net-output target in watts: the single currency of all control
+// logic (mirrors balancer.py NetOutputW). Sign convention, defined once:
+//   +  =  net discharge (export to grid / serve load)
+//   -  =  net charge     (import from grid)
+// A distinct type so a net-output target can never be silently mixed with a
+// grid-meter reading (the relative delta a battery adds to its own output).
+struct NetOutputW {
+  float value{0.0f};
+  explicit NetOutputW(float v = 0.0f) : value(v) {}
+};
+
+// Single boundary between the control currency (NetOutputW, an absolute net
+// output) and the grid-meter reading a battery integrates via
+// new_output = reported + reading. Returns target - reported so the battery
+// lands on the absolute target; positive = grid import (raise net output).
+// Callers phase-split the scalar result (see LoadBalancer::split_by_phase_).
+inline float to_grid_reading(NetOutputW target, float reported) {
+  return target.value - reported;
+}
+
 struct BalancerConfig {
   bool fair_distribution{true};
   float balance_gain{0.2f};

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -5,11 +5,59 @@ from __future__ import annotations
 import dataclasses
 import time
 from collections.abc import Callable
-from typing import Literal, NamedTuple
+from typing import Literal, NamedTuple, NewType
 
 from astrameter.config.logger import logger
 
 from .protocol import parse_int
+
+# ---------------------------------------------------------------------------
+# Net-output target: the single currency of all control logic
+# ---------------------------------------------------------------------------
+
+# An absolute net-output target in watts.  This is the ONE value every control
+# policy (steer-to-zero, manual, fair-share, probing) is allowed to declare:
+# "this is the net power I want the battery to deliver at the grid coupling
+# point", independent of whatever the battery currently reports.
+#
+# Sign convention, defined here exactly once:
+#     +  =  net discharge  (export to grid / serve house load)
+#     -  =  net charge      (import from grid)
+#
+# It is a distinct type (``NewType``) so a net-output *target* can never be
+# silently mixed with a grid-meter *reading* -- the relative, sign-loaded delta
+# a battery integrates into its own output.  Control authors produce a
+# ``NetOutputW``; the conversion to a reading happens in exactly one audited
+# place, :func:`to_grid_reading`.
+NetOutputW = NewType("NetOutputW", float)
+
+
+def to_grid_reading(target: NetOutputW, reported: float) -> float:
+    """Convert an absolute net-output *target* into the grid-meter reading.
+
+    This is the single boundary between the balancer's control currency
+    (:class:`NetOutputW`, an absolute net output) and what each battery
+    actually consumes: a *grid-meter reading* it adds to its own output via
+    ``new_output = reported + reading``.  Concretely::
+
+        reading = target - reported
+
+    so that ``reported + reading == target`` — the battery lands on the
+    absolute target we asked for, regardless of where it started.
+
+    The returned value is a meter reading by convention: **positive = grid
+    import** (the battery should raise net output by this much, i.e. discharge
+    more or charge less), **negative = grid export** (lower net output).  It is
+    the relative/integral/sign-loaded quantity that used to be hand-computed at
+    every call site; keeping it in one place means "increase discharge vs
+    reduce charge" is no longer something any control author has to reason
+    about.
+
+    The caller is responsible for the phase split (see
+    :meth:`LoadBalancer._split_by_phase`), which distributes this scalar
+    reading across phases A/B/C.
+    """
+    return float(target) - reported
 
 
 def _report_weight(report: dict) -> float:
@@ -617,9 +665,9 @@ class LoadBalancer:
             if desired_total < 0 and desired_probe > 0:
                 desired_probe = -desired_probe
             probe.requested_power_abs = abs(desired_probe)
-            target = desired_probe - probe_actual
-            state.last_target = target
-            return self._split_by_phase(target, {candidate_id: reports[candidate_id]})
+            reading = to_grid_reading(NetOutputW(desired_probe), probe_actual)
+            state.last_target = reading
+            return self._split_by_phase(reading, {candidate_id: reports[candidate_id]})
 
         backup_weights = {
             cid: max(0.01, eff_part.get(cid, 1.0))
@@ -634,9 +682,9 @@ class LoadBalancer:
             desired_total - qualified_probe_actual,
         )
         reported = parse_int(support_reports.get(consumer_id, {}).get("power", 0))
-        target = desired - reported
-        state.last_target = target
-        return self._split_by_phase(target, support_reports, backup_weights)
+        reading = to_grid_reading(NetOutputW(desired), reported)
+        state.last_target = reading
+        return self._split_by_phase(reading, support_reports, backup_weights)
 
     # ------------------------------------------------------------------
     # Primary interface
@@ -700,9 +748,9 @@ class LoadBalancer:
         # --- Manual override ---
         if consumer_mode.mode == "manual" and consumer_id and state:
             reported = parse_int(active_reports.get(consumer_id, {}).get("power", 0))
-            target = consumer_mode.manual_value - reported
-            state.last_target = target
-            return self._split_by_phase(target, active_reports)
+            reading = to_grid_reading(NetOutputW(consumer_mode.manual_value), reported)
+            state.last_target = reading
+            return self._split_by_phase(reading, active_reports)
 
         # Auto-pool reports (exclude manual consumers)
         reports = {cid: r for cid, r in active_reports.items() if cid not in manual}
@@ -791,19 +839,20 @@ class LoadBalancer:
     # ------------------------------------------------------------------
 
     def _steer_to_zero(self, consumer_id: str | None, reports: dict) -> list[float]:
-        """Drive a consumer's output to zero."""
+        """Drive a consumer's output to zero (``NetOutputW(0)``)."""
         if consumer_id:
             self._get_consumer(consumer_id).last_target = 0
         reported = parse_int(
             reports.get(consumer_id, {}).get("power", 0) if consumer_id else 0
         )
-        if reported == 0:
+        reading = to_grid_reading(NetOutputW(0), reported)
+        if reading == 0:
             return [0, 0, 0]
         phase = (
             reports.get(consumer_id, {}).get("phase") or "A" if consumer_id else "A"
         ).upper()
         result = [0.0, 0.0, 0.0]
-        result[{"A": 0, "B": 1, "C": 2}.get(phase, 0)] = float(-reported)
+        result[{"A": 0, "B": 1, "C": 2}.get(phase, 0)] = reading
         return result
 
     @staticmethod
@@ -950,11 +999,11 @@ class LoadBalancer:
             demand = total_battery + grid_total
             total_fade = sum(self._get_consumer(cid).fade_weight for cid in reports)
             desired = demand * fade_w / total_fade if total_fade > 0 else 0.0
-            target = desired - reported
+            reading = to_grid_reading(NetOutputW(desired), reported)
 
-            state.last_target = target
+            state.last_target = reading
 
-            return self._split_by_phase(target, reports, eff_part)
+            return self._split_by_phase(reading, reports, eff_part)
 
         # --- Non-fading path ---
         for cid, fade_w in faded_adjustments.items():
@@ -990,28 +1039,39 @@ class LoadBalancer:
         )
 
         cfg = self._cfg
+        # ``fair_share`` / ``_balance_correction`` produce the residual: this
+        # consumer's slice of the grid imbalance to fold into its current
+        # output.  The absolute net-output target is therefore "what I report
+        # now plus my residual share" — see the NetOutputW wrap below.
         if (
             not cfg.fair_distribution
             or consumer_id is None
             or consumer_id not in reports
         ):
-            target = fair_share
+            residual = fair_share
         elif consumer_id in eff_part:
-            target = self._balance_correction(
+            residual = self._balance_correction(
                 consumer_id, reports, eff_part, fair_share
             )
         else:
-            target = fair_share
+            residual = fair_share
 
         # Clamp sign disagreement: prevent the inverter from acting
         # against the current grid direction.
-        if (grid_total < 0 and target > 0) or (grid_total > 0 and target < 0):
-            target = 0
+        if (grid_total < 0 and residual > 0) or (grid_total > 0 and residual < 0):
+            residual = 0
+
+        reported = (
+            parse_int(reports.get(consumer_id, {}).get("power", 0))
+            if consumer_id
+            else 0
+        )
+        reading = to_grid_reading(NetOutputW(reported + residual), reported)
 
         if consumer_id:
-            self._get_consumer(consumer_id).last_target = target
+            self._get_consumer(consumer_id).last_target = reading
 
-        return self._split_by_phase(target, reports, eff_part)
+        return self._split_by_phase(reading, reports, eff_part)
 
     def _balance_correction(
         self,

--- a/tests/components/ct002/host_balancer_test.cpp
+++ b/tests/components/ct002/host_balancer_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <unordered_set>
+#include <utility>
 
 #include "esphome/components/ct002/balancer.h"
 
@@ -19,7 +20,9 @@ using esphome::ct002::ConsumerModeKind;
 using esphome::ct002::ConsumerReport;
 using esphome::ct002::is_ac_chargeable;
 using esphome::ct002::LoadBalancer;
+using esphome::ct002::NetOutputW;
 using esphome::ct002::ReportMap;
+using esphome::ct002::to_grid_reading;
 
 LoadBalancer make_balancer(BalancerConfig cfg = {}, double *clock = nullptr) {
   static double dummy = 0.0;
@@ -28,6 +31,23 @@ LoadBalancer make_balancer(BalancerConfig cfg = {}, double *clock = nullptr) {
                       /*sat_decay=*/0.995f, /*sat_grace=*/90.0f,
                       /*sat_stall=*/60.0f, /*sat_enabled=*/false,
                       [clock]() { return *clock; }, nullptr);
+}
+
+TEST(ToGridReading, ConvertsAbsoluteTargetToMeterReading) {
+  // Mirrors tests/test_balancer.py TestToGridReading: the single audited
+  // boundary that turns an absolute net-output target into the grid reading a
+  // battery adds to its own output (positive = grid import).
+  EXPECT_FLOAT_EQ(to_grid_reading(NetOutputW(25.0f), 10.0f), 15.0f);
+  EXPECT_FLOAT_EQ(to_grid_reading(NetOutputW(0.0f), 200.0f), -200.0f);
+}
+
+TEST(ToGridReading, ReportedPlusReadingLandsOnTarget) {
+  for (const auto &tc : {std::pair<float, float>{25.0f, 10.0f},
+                         std::pair<float, float>{0.0f, 200.0f},
+                         std::pair<float, float>{-100.0f, 50.0f}}) {
+    const float reading = to_grid_reading(NetOutputW(tc.first), tc.second);
+    EXPECT_FLOAT_EQ(tc.second + reading, tc.first);
+  }
 }
 
 TEST(IsAcChargeable, IdentifiesVenusPrefixes) {

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -6,8 +6,31 @@ from astrameter.ct002.balancer import (
     BalancerConfig,
     BalancerConsumerState,
     LoadBalancer,
+    NetOutputW,
     SaturationTracker,
+    to_grid_reading,
 )
+
+
+class TestToGridReading:
+    """The single audited boundary: absolute net-output target -> meter reading.
+
+    A grid reading is what the battery adds to its own output
+    (``new_output = reported + reading``); positive = grid import.
+    """
+
+    def test_raise_output_toward_target(self):
+        # Want 25 W net out, already at 10 W -> reading of +15 lands on target.
+        assert to_grid_reading(NetOutputW(25), reported=10) == 15
+
+    def test_steer_to_zero_from_discharge(self):
+        # Want 0 W net out while reporting 200 W -> reading of -200 (charge).
+        assert to_grid_reading(NetOutputW(0), reported=200) == -200
+
+    def test_reported_plus_reading_lands_on_target(self):
+        for target, reported in ((25.0, 10.0), (0.0, 200.0), (-100.0, 50.0)):
+            reading = to_grid_reading(NetOutputW(target), reported)
+            assert reported + reading == target
 
 
 class _FakeClock:


### PR DESCRIPTION
## Summary

Refactor the balancer's control logic to use an explicit `NetOutputW` type for absolute net-output targets and a single audited conversion function `to_grid_reading()` that translates targets into grid-meter readings. This eliminates hand-computed sign conversions scattered throughout the codebase and makes the relationship between absolute targets and relative meter readings explicit and testable.

## Key Changes

- **New type `NetOutputW`**: A `NewType` wrapping `float` to represent absolute net-output targets in watts (positive = discharge/export, negative = charge/import). Prevents silent mixing with grid-meter readings.

- **New function `to_grid_reading()`**: Single audited boundary that converts an absolute net-output target and a reported power value into a grid-meter reading via `target - reported`. This is the only place the sign conversion happens; all call sites now use this function instead of computing `target - reported` locally.

- **Refactored all control paths**: Updated `_steer_to_zero()`, `_compute_probe_target()`, `compute_target()` (manual mode), and `_compute_auto_target()` to use `NetOutputW` and `to_grid_reading()`. Renamed intermediate variables from `target` to `reading` or `residual` to clarify intent.

- **C++ parity**: Mirrored all changes in `esphome/components/ct002/balancer.h` and `balancer.cpp`, including the new `NetOutputW` struct and `to_grid_reading()` inline function.

- **Tests**: Added `TestToGridReading` class in Python and corresponding C++ tests to verify the conversion boundary works correctly and that `reported + reading == target` always holds.

## Implementation Details

- The `residual` variable in `_compute_auto_target()` now explicitly represents the consumer's slice of grid imbalance, making it clear that the absolute target is `reported + residual`.
- All `last_target` assignments now store the grid reading (the value sent to the battery), not the intermediate residual.
- The phase-split logic (`_split_by_phase()`) continues to work with scalar readings as before; the conversion from absolute target to reading happens before the split.

https://claude.ai/code/session_01Tr6oLwyTJaGePfnt9EYY5n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal load-balancer target computation logic with enhanced type safety and consistency checks.

* **Tests**
  * Added comprehensive test coverage for load-balancer target conversion across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->