### PR TITLE
Add MIN_DC_OUTPUT floor to keep B2500 inverter awake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- **Added** a **Min DC Output** option that keeps a DC battery's inverter (e.g. the Marstek B2500) from switching off at 0 W and falling asleep under high PV surplus. Set it globally (`MIN_DC_OUTPUT`) or per battery from Home Assistant; off by default ([#425](https://github.com/tomquist/astrameter/issues/425)).
 - **Fixed** a phantom empty "Unnamed Device" that kept reappearing under the MQTT integration in Home Assistant, even after deleting it. AstraMeter now publishes a proper top-level **AstraMeter** device — with **Status**, **Version**, and **Consumer Count** entities — that the meter devices are grouped under ([#421](https://github.com/tomquist/astrameter/issues/421)).
 
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,13 @@ CT002/CT003 active-steering options (all under `[CT002]` or `[CT003]`):
 - **MAX_TARGET_STEP** (default 0 = unlimited) — Maximum change in a battery's target
   relative to its current output. A hard clamp on per-cycle change.
 
+- **MIN_DC_OUTPUT** (default 0 = disabled) — Minimum discharge in watts to keep a DC
+  battery's inverter from switching off at 0 W and falling asleep under high PV
+  surplus (a known behaviour of the Marstek B2500). Only applies to DC batteries that
+  have no inverter of their own; AC batteries (Venus) and Jupiter are unaffected. Can
+  also be set per battery from Home Assistant (see **Min DC Output** below). A value
+  of at least 20 W is recommended.
+
 *Battery efficiency optimization — concentrating power on fewer batteries,
 probing handoffs, and swapping away from ones that cannot follow:*
 
@@ -571,6 +578,10 @@ live from Home Assistant:
   proportion between batteries matters; `0` parks a battery at 0 W while
   leaving it in the pool. Tune it while watching the batteries — the change
   takes effect on the next control cycle.
+- **Min DC Output** — minimum discharge in watts to keep this battery's inverter
+  from switching off at 0 W and falling asleep (see **MIN_DC_OUTPUT** above). Only
+  shown for DC batteries where it has an effect (e.g. the Marstek B2500); overrides
+  the global setting for that battery.
 
 Each of these controls publishes its set-command **retained**, so Home
 Assistant restores your values across an AstraMeter restart without any extra

--- a/README.md
+++ b/README.md
@@ -281,12 +281,14 @@ CT002/CT003 active-steering options (all under `[CT002]` or `[CT003]`):
 - **MAX_TARGET_STEP** (default 0 = unlimited) — Maximum change in a battery's target
   relative to its current output. A hard clamp on per-cycle change.
 
+*DC battery keep-alive — applies to each DC-only battery on its own (also with a
+single battery, independent of balancing):*
 - **MIN_DC_OUTPUT** (default 0 = disabled) — Minimum discharge in watts to keep a DC
   battery's inverter from switching off at 0 W and falling asleep under high PV
-  surplus (a known behaviour of the Marstek B2500). Only applies to DC batteries that
-  have no inverter of their own; AC batteries (Venus) and Jupiter are unaffected. Can
-  also be set per battery from Home Assistant (see **Min DC Output** below). A value
-  of at least 20 W is recommended.
+  surplus (a known behaviour of the Marstek B2500). Applied individually to each
+  DC-only battery that has no inverter of its own; AC batteries (Venus) and Jupiter
+  are unaffected. Can also be set per battery from Home Assistant (see **Min DC
+  Output** below). A value of at least 20 W is recommended.
 
 *Battery efficiency optimization — concentrating power on fewer batteries,
 probing handoffs, and swapping away from ones that cannot follow:*

--- a/config.ini.example
+++ b/config.ini.example
@@ -79,10 +79,13 @@ THROTTLE_INTERVAL = 0
 ## Hard clamp on target change relative to current battery output (W). 0 disables.
 #MAX_TARGET_STEP = 0
 
-## Minimum discharge (W) to keep a DC battery (e.g. Marstek B2500) from
+## --- DC battery keep-alive ---
+## Applies per battery (independent of balancing — also relevant with a single
+## battery). Minimum discharge (W) to keep a DC battery (e.g. Marstek B2500) from
 ## switching its inverter off at 0 W and falling asleep under high PV surplus.
-## Only affects DC batteries that have no inverter of their own; 0 disables
-## (default). Can also be set per battery from Home Assistant. Recommended >= 20.
+## Only affects DC-only batteries that have no inverter of their own (Venus and
+## Jupiter are unaffected); 0 disables (default). Can also be set per battery from
+## Home Assistant. Recommended >= 20.
 #MIN_DC_OUTPUT = 0
 
 ## --- Saturation detection (full/empty battery handling) ---

--- a/config.ini.example
+++ b/config.ini.example
@@ -79,6 +79,12 @@ THROTTLE_INTERVAL = 0
 ## Hard clamp on target change relative to current battery output (W). 0 disables.
 #MAX_TARGET_STEP = 0
 
+## Minimum discharge (W) to keep a DC battery (e.g. Marstek B2500) from
+## switching its inverter off at 0 W and falling asleep under high PV surplus.
+## Only affects DC batteries that have no inverter of their own; 0 disables
+## (default). Can also be set per battery from Home Assistant. Recommended >= 20.
+#MIN_DC_OUTPUT = 0
+
 ## --- Saturation detection (full/empty battery handling) ---
 ## Track how well each battery follows its target. When a battery can't deliver
 ## (full or empty), its share is reduced and redistributed to others.

--- a/esphome.example.yaml
+++ b/esphome.example.yaml
@@ -149,6 +149,7 @@ ct002:
   #   error_reduce_threshold: 20
   #   max_correction_per_step: 80
   #   max_target_step: 0           # 0 = no per-step target clamp
+  #   min_dc_output: 0             # >0 keeps a DC battery (B2500) inverter awake
   #   min_efficient_power: 0       # >0 enables efficiency rotation
   #   probe_min_power: 80
   #   efficiency_rotation_interval: 15min

--- a/esphome/components/ct002/__init__.py
+++ b/esphome/components/ct002/__init__.py
@@ -102,6 +102,7 @@ CONF_PROBE_MIN_POWER = "probe_min_power"
 CONF_EFFICIENCY_ROTATION_INTERVAL = "efficiency_rotation_interval"
 CONF_EFFICIENCY_FADE_ALPHA = "efficiency_fade_alpha"
 CONF_EFFICIENCY_SATURATION_THRESHOLD = "efficiency_saturation_threshold"
+CONF_MIN_DC_OUTPUT = "min_dc_output"
 
 # Saturation tracker sub-block
 CONF_SATURATION = "saturation"
@@ -204,6 +205,7 @@ BALANCER_SCHEMA = cv.Schema(
         cv.Optional(CONF_EFFICIENCY_SATURATION_THRESHOLD, default=0.4): cv.float_range(
             min=0.0, max=1.0
         ),
+        cv.Optional(CONF_MIN_DC_OUTPUT, default=0.0): cv.float_range(min=0.0),
     }
 )
 
@@ -437,6 +439,7 @@ async def to_code(config):
             "efficiency_saturation_threshold",
             bal.get(CONF_EFFICIENCY_SATURATION_THRESHOLD, 0.4),
         ),
+        ("min_dc_output", bal.get(CONF_MIN_DC_OUTPUT, 0.0)),
     )
     cg.add(var.set_balancer_config(bcfg))
 

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -12,7 +12,17 @@ namespace ct002 {
 
 namespace {
 
-constexpr const char *AC_CHARGEABLE_PREFIXES[] = {"HMG", "VNS"};
+std::string to_upper(const std::string &s) {
+  std::string up;
+  up.reserve(s.size());
+  for (char c : s) up.push_back(static_cast<char>(std::toupper(c)));
+  return up;
+}
+
+bool starts_with(const std::string &s, const char *prefix) {
+  const size_t plen = std::strlen(prefix);
+  return s.size() >= plen && s.compare(0, plen, prefix) == 0;
+}
 
 template <typename Set>
 Set set_difference(const Set &a, const Set &b) {
@@ -51,16 +61,30 @@ std::string serialize_cache_key(const std::vector<float> &sample_id,
 
 }  // namespace
 
+DeviceCapabilities device_capabilities(const std::string &device_type) {
+  const std::string dt = to_upper(device_type);
+  // Venus A/D: built-in inverter + AC input + extra DC input. Checked before
+  // the generic VNS branch ("VNSA".startswith("VNS")).
+  if (starts_with(dt, "VNSA") || starts_with(dt, "VNSD")) return {true, true, true};
+  // Other Venus (HMG*, VNSE3, ...): built-in inverter + AC input, no DC input.
+  if (starts_with(dt, "HMG") || starts_with(dt, "VNS")) return {true, true, false};
+  // Jupiter: DC battery with a built-in inverter.
+  if (starts_with(dt, "HMN") || starts_with(dt, "HMM") || starts_with(dt, "JPLS"))
+    return {true, false, true};
+  // B2500 family: DC input feeding a SEPARATE inverter (no built-in inverter).
+  if (starts_with(dt, "HMA") || starts_with(dt, "HMJ") || starts_with(dt, "HMK"))
+    return {false, false, true};
+  // Unknown / future / empty: assume a modern AC-coupled battery.
+  return {true, true, false};
+}
+
 bool is_ac_chargeable(const std::string &device_type) {
-  if (device_type.empty()) return false;
-  std::string up;
-  up.reserve(device_type.size());
-  for (char c : device_type) up.push_back(static_cast<char>(std::toupper(c)));
-  for (const char *prefix : AC_CHARGEABLE_PREFIXES) {
-    const size_t plen = std::strlen(prefix);
-    if (up.size() >= plen && up.compare(0, plen, prefix) == 0) return true;
-  }
-  return false;
+  return device_capabilities(device_type).has_ac_input;
+}
+
+bool needs_dc_output_floor(const std::string &device_type) {
+  const DeviceCapabilities caps = device_capabilities(device_type);
+  return !caps.has_ac_input && !caps.has_builtin_inverter;
 }
 
 void BalancerConfig::clamp() {
@@ -79,6 +103,7 @@ void BalancerConfig::clamp() {
   if (efficiency_rotation_interval < 1.0f) efficiency_rotation_interval = 1.0f;
   clamp_v(efficiency_fade_alpha, 0.01f, 1.0f);
   clamp_v(efficiency_saturation_threshold, 0.0f, 1.0f);
+  if (min_dc_output < 0.0f) min_dc_output = 0.0f;
 }
 
 // -------------------------------------------------------------------------
@@ -463,6 +488,51 @@ std::optional<std::array<float, 3>> LoadBalancer::compute_probe_target_(
   return split_by_phase_(reading, support_reports, &backup_weights);
 }
 
+float LoadBalancer::effective_min_dc_output_(
+    const std::optional<std::string> &consumer_id, const ReportMap &reports) {
+  if (!consumer_id) return 0.0f;
+  auto it = reports.find(*consumer_id);
+  if (it == reports.end()) return 0.0f;
+  const ConsumerReport &report = it->second;
+  if (report.min_dc_output) return std::max(0.0f, *report.min_dc_output);
+  if (needs_dc_output_floor(report.device_type)) return this->cfg_.min_dc_output;
+  return 0.0f;
+}
+
+std::array<float, 3> LoadBalancer::apply_min_dc_output_(
+    const std::optional<std::string> &consumer_id, const ReportMap &reports,
+    std::array<float, 3> result) {
+  // Hold an external-inverter DC battery at MIN_DC_OUTPUT discharge so its
+  // DC-fed inverter doesn't sleep at 0 W. Mirrors balancer.py _apply_min_dc_output.
+  if (!consumer_id) return result;
+  auto it = reports.find(*consumer_id);
+  if (it == reports.end()) return result;
+  const float eff_min = this->effective_min_dc_output_(consumer_id, reports);
+  if (eff_min <= 0.0f) return result;
+  const ConsumerReport &report = it->second;
+  // Respect an explicit park (weight 0): don't silently wake it.
+  if (report.weight == 0.0f) return result;
+  const float reported = report.power;
+  // Use the consumer's FULL intended reading: split_by_phase preserves the
+  // total, so the sum recovers it regardless of phase distribution.
+  const float reading_self = result[0] + result[1] + result[2];
+  const float net_self = reported + reading_self;
+  // Floor whenever the commanded net output is below the floor — including
+  // negative (charge) commands: a floor-eligible battery can't charge, so the
+  // all-DC-under-surplus case (lone B2500, issue #425) must still be lifted.
+  if (net_self >= eff_min) return result;
+  const float reading = to_grid_reading(NetOutputW(eff_min), reported);
+  std::string phase = report.phase.empty() ? "A" : report.phase;
+  for (auto &c : phase) c = static_cast<char>(std::toupper(c));
+  size_t idx = 0;
+  if (phase == "B") idx = 1;
+  else if (phase == "C") idx = 2;
+  std::array<float, 3> out{0.0f, 0.0f, 0.0f};
+  out[idx] = reading;
+  this->get_consumer_(*consumer_id).last_target = reading;
+  return out;
+}
+
 std::array<float, 3> LoadBalancer::steer_to_zero_(
     const std::optional<std::string> &consumer_id, const ReportMap &reports) {
   if (consumer_id) this->get_consumer_(*consumer_id).last_target = 0.0f;
@@ -553,7 +623,9 @@ std::array<float, 3> LoadBalancer::compute_target(
   for (const auto &r : active_reports) {
     if (manual.find(r.first) == manual.end()) auto_reports[r.first] = r.second;
   }
-  return this->compute_auto_target_(consumer_id, auto_reports, grid_total, sample_id);
+  auto result =
+      this->compute_auto_target_(consumer_id, auto_reports, grid_total, sample_id);
+  return this->apply_min_dc_output_(consumer_id, auto_reports, result);
 }
 
 // -------------------------------------------------------------------------

--- a/esphome/components/ct002/balancer.h
+++ b/esphome/components/ct002/balancer.h
@@ -25,7 +25,22 @@ inline constexpr double SATURATION_STALL_TIMEOUT_SECONDS = 60.0;
 inline constexpr double SATURATION_REFERENCE_DT = 1.0;
 inline constexpr double SATURATION_LONG_GAP_SECONDS = 30.0;
 
+// Device capabilities — the single source of truth for every device-type
+// decision (mirrors balancer.py device_capabilities). All downstream policy
+// (AC-charge eligibility, the MIN_DC_OUTPUT wake floor) is derived from these.
+struct DeviceCapabilities {
+  bool has_builtin_inverter{false};
+  bool has_ac_input{false};
+  bool has_dc_input{false};
+};
+
+DeviceCapabilities device_capabilities(const std::string &device_type);
+
 bool is_ac_chargeable(const std::string &device_type);
+
+// True iff the battery depends on a sleep-prone external inverter (no built-in
+// inverter and no AC input — the B2500 family). Mirrors _needs_dc_output_floor.
+bool needs_dc_output_floor(const std::string &device_type);
 
 // Absolute net-output target in watts: the single currency of all control
 // logic (mirrors balancer.py NetOutputW). Sign convention, defined once:
@@ -61,6 +76,9 @@ struct BalancerConfig {
   float efficiency_rotation_interval{900.0f};
   float efficiency_fade_alpha{0.15f};
   float efficiency_saturation_threshold{0.4f};
+  // Minimum net discharge (W) to keep an external-inverter DC battery awake.
+  // 0 disables. See issue #425 and balancer.py.
+  float min_dc_output{0.0f};
 
   void clamp();
 };
@@ -102,6 +120,10 @@ struct ConsumerReport {
   // Relative fair-share weight (1.0 = neutral). Mirrors the Python reports
   // dict's "weight" key, set live via the MQTT "Distribution Weight" entity.
   float weight{1.0f};
+  // Per-device MIN_DC_OUTPUT override (W); unset = inherit the global setting.
+  // Mirrors the Python reports dict's "min_dc_output" key. Default-initialized
+  // so aggregate ``ConsumerReport{...}`` init stays warning-clean.
+  std::optional<float> min_dc_output{};
 };
 
 using ReportMap = std::unordered_map<std::string, ConsumerReport>;
@@ -176,6 +198,12 @@ class LoadBalancer {
   std::optional<std::array<float, 3>> compute_probe_target_(
       const std::optional<std::string> &consumer_id, const ReportMap &reports,
       float grid_total, const std::unordered_map<std::string, float> &eff_part);
+
+  float effective_min_dc_output_(const std::optional<std::string> &consumer_id,
+                                 const ReportMap &reports);
+  std::array<float, 3> apply_min_dc_output_(const std::optional<std::string> &consumer_id,
+                                            const ReportMap &reports,
+                                            std::array<float, 3> result);
 
   std::array<float, 3> steer_to_zero_(const std::optional<std::string> &consumer_id,
                                       const ReportMap &reports);

--- a/esphome/components/ct002/ct002.cpp
+++ b/esphome/components/ct002/ct002.cpp
@@ -654,9 +654,10 @@ void CT002Component::set_consumer_distribution_weight(const std::string &consume
 
 void CT002Component::set_consumer_min_dc_output(const std::string &consumer_id,
                                                 float value) {
-  // Per-device MIN_DC_OUTPUT override (W); same 0..1000 range the MQTT handler
-  // enforces. Ignore non-finite / out-of-range values.
-  if (!std::isfinite(value) || value < 0.0f || value > 1000.0f) return;
+  // Per-device MIN_DC_OUTPUT override (W); validation aligned with the Python
+  // setter (finite, >= 0, no upper bound). The MQTT command handler still
+  // enforces the 0..1000 entry range on both stacks.
+  if (!std::isfinite(value) || value < 0.0f) return;
   this->get_consumer_(consumer_id).min_dc_output = value;
 }
 

--- a/esphome/components/ct002/ct002.cpp
+++ b/esphome/components/ct002/ct002.cpp
@@ -401,6 +401,7 @@ ReportMap CT002Component::collect_reports_for_balancer_() const {
       r.phase = kv.second.phase;
       r.power = kv.second.power;
       r.weight = kv.second.distribution_weight;
+      r.min_dc_output = kv.second.min_dc_output;
       out[kv.first] = std::move(r);
     }
   }
@@ -565,6 +566,7 @@ CT002Component::ConsumerSnapshot CT002Component::snapshot_consumer(
   snap.auto_target = !c.manual_enabled;
   if (c.manual_enabled) snap.manual_target = c.manual_target;
   snap.distribution_weight = c.distribution_weight;
+  snap.min_dc_output = c.min_dc_output;
   snap.poll_interval = c.poll_interval;
   snap.timestamp = c.timestamp;
   snap.grid_power = this->last_grid_power_;
@@ -648,6 +650,14 @@ void CT002Component::set_consumer_distribution_weight(const std::string &consume
   // non-finite or out-of-range values rather than corrupting the split.
   if (!std::isfinite(weight) || weight < 0.0f || weight > 10.0f) return;
   this->get_consumer_(consumer_id).distribution_weight = weight;
+}
+
+void CT002Component::set_consumer_min_dc_output(const std::string &consumer_id,
+                                                float value) {
+  // Per-device MIN_DC_OUTPUT override (W); same 0..1000 range the MQTT handler
+  // enforces. Ignore non-finite / out-of-range values.
+  if (!std::isfinite(value) || value < 0.0f || value > 1000.0f) return;
+  this->get_consumer_(consumer_id).min_dc_output = value;
 }
 
 void CT002Component::set_consumer_auto_target(const std::string &consumer_id, bool auto_target) {

--- a/esphome/components/ct002/ct002.h
+++ b/esphome/components/ct002/ct002.h
@@ -43,6 +43,9 @@ struct Consumer {
   // Relative fair-share weight (1.0 = neutral). Tuned live via the MQTT
   // "Distribution Weight" entity; mirrors Python's Consumer.distribution_weight.
   float distribution_weight{1.0f};
+  // Per-device MIN_DC_OUTPUT override (W); unset = inherit global. Tuned live
+  // via the MQTT "Min DC Output" entity; mirrors Python's Consumer.min_dc_output.
+  std::optional<float> min_dc_output;
   // Net AC power the balancer last instructed this consumer to be at —
   // distinct from `power` (what the consumer reports). The cross-talk
   // *_chrg_power / *_dchrg_power fields aggregate THIS, not `power`,
@@ -116,6 +119,7 @@ class CT002Component : public Component {
     bool auto_target{true};
     std::optional<float> manual_target;
     float distribution_weight{1.0f};
+    std::optional<float> min_dc_output;
     std::optional<float> poll_interval;
     double timestamp{0.0};
     // Cross-phase grid power last observed at the pipeline head (post-
@@ -175,6 +179,7 @@ class CT002Component : public Component {
   void set_consumer_manual_target(const std::string &consumer_id, float target);
   void set_consumer_auto_target(const std::string &consumer_id, bool auto_target);
   void set_consumer_distribution_weight(const std::string &consumer_id, float weight);
+  void set_consumer_min_dc_output(const std::string &consumer_id, float value);
   void force_balancer_rotation();
 
   // Listener registration — mqtt_insights subscribes once at setup() to

--- a/esphome/components/ct002/ha_discovery.cpp
+++ b/esphome/components/ct002/ha_discovery.cpp
@@ -3,6 +3,7 @@
 #include <cctype>
 #include <functional>
 
+#include "balancer.h"
 #include "esphome/components/json/json_util.h"
 
 namespace esphome {
@@ -265,6 +266,27 @@ std::pair<std::string, std::string> build_ct002_consumer_discovery(
     dw["command_topic"] = state_topic + "/distribution_weight/set";
     dw["retain"] = true;
     dw["entity_category"] = "config";
+
+    // Min DC Output number — minimum discharge (W) to keep a DC battery's
+    // external inverter from switching off at 0 W. Only surfaced for batteries
+    // where it has an effect (B2500 family); Venus/Jupiter/unknown don't get it.
+    if (needs_dc_output_floor(device_type)) {
+      JsonObject mdo = components["min_dc_output"].to<JsonObject>();
+      mdo["platform"] = "number";
+      mdo["unique_id"] = uid_prefix + "_min_dc_output";
+      mdo["name"] = "Min DC Output";
+      mdo["unit_of_measurement"] = "W";
+      mdo["device_class"] = "power";
+      mdo["min"] = 0;
+      mdo["max"] = 1000;
+      mdo["step"] = 1;
+      mdo["mode"] = "box";
+      mdo["state_topic"] = state_topic;
+      mdo["value_template"] = "{{ value_json.min_dc_output | default(0) }}";
+      mdo["command_topic"] = state_topic + "/min_dc_output/set";
+      mdo["retain"] = true;
+      mdo["entity_category"] = "config";
+    }
 
     // Device info
     JsonObject device = root["device"].to<JsonObject>();

--- a/esphome/components/ct002/mqtt_insights.cpp
+++ b/esphome/components/ct002/mqtt_insights.cpp
@@ -240,6 +240,11 @@ void MqttInsightsComponent::publish_consumer_event_(const std::string &consumer_
     }
     root["auto_target"] = snap.auto_target;
     root["distribution_weight"] = snap.distribution_weight;
+    if (snap.min_dc_output.has_value()) {
+      root["min_dc_output"] = *snap.min_dc_output;
+    } else {
+      root["min_dc_output"] = nullptr;
+    }
   });
   this->mqtt_->publish(state_topic, state_buf, 0, true);
   this->mqtt_->publish(state_topic + "/availability", "online", 6, 0, true);
@@ -391,6 +396,15 @@ void MqttInsightsComponent::handle_consumer_field_command_(const std::string &co
       this->ct002_->set_consumer_distribution_weight(consumer_id, w);
     } else {
       ESP_LOGW(TAG, "Out-of-range distribution_weight for %s: %.2f", consumer_id.c_str(), w);
+    }
+  } else if (field == "min_dc_output") {
+    float v;
+    if (!parse_float_payload(payload, v)) {
+      ESP_LOGW(TAG, "Invalid min_dc_output for %s: %s", consumer_id.c_str(), payload.c_str());
+    } else if (std::isfinite(v) && v >= 0.0f && v <= 1000.0f) {
+      this->ct002_->set_consumer_min_dc_output(consumer_id, v);
+    } else {
+      ESP_LOGW(TAG, "Out-of-range min_dc_output for %s: %.1f", consumer_id.c_str(), v);
     }
   }
 }

--- a/esphome/components/ct002/test_hooks.cpp
+++ b/esphome/components/ct002/test_hooks.cpp
@@ -94,6 +94,7 @@ bool CT002Component::apply_cfg_(const std::string &key, double v) {
   else if (key == "efficiency_fade_alpha") this->balancer_cfg_.efficiency_fade_alpha = f;
   else if (key == "efficiency_saturation_threshold")
     this->balancer_cfg_.efficiency_saturation_threshold = f;
+  else if (key == "min_dc_output") this->balancer_cfg_.min_dc_output = f;
   // Saturation tracker fields.
   else if (key == "saturation_enabled") this->saturation_enabled_ = (v != 0.0);
   else if (key == "saturation_alpha") this->saturation_alpha_ = f;

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -95,23 +95,81 @@ SATURATION_REFERENCE_DT = 1.0
 # rather than dosing the EMA with a huge rise or decay step.
 SATURATION_LONG_GAP_SECONDS = 30.0
 
-# Device-type prefixes of the only Marstek battery families that can charge
-# via AC (the Venus lineup).  ``HMG`` covers HMG-*; ``VNS`` covers VNSE3,
-# VNSA, VNSD, and any other Venus-family variant.  Every other reporting
-# battery is assumed DC-coupled (B2500 family, Jupiter, etc.) and is
-# excluded from charge distribution under a grid surplus.  See issue #338.
-AC_CHARGEABLE_DEVICE_PREFIXES: tuple[str, ...] = ("HMG", "VNS")
+# ---------------------------------------------------------------------------
+# Device capabilities — the single source of truth for every device-type
+# decision in the balancer.  A battery is classified from its reported
+# device-type string into three independent capabilities; all downstream
+# policy (AC-charge eligibility, the MIN_DC_OUTPUT wake floor) is derived
+# from these rather than from ad-hoc prefix checks.
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class DeviceCapabilities:
+    """What a battery model can physically do.
+
+    - ``has_builtin_inverter``: the battery produces its own AC output, so it
+      never depends on a separate inverter that could sleep at low DC output.
+    - ``has_ac_input``: the battery can be charged from AC (Venus lineup).
+    - ``has_dc_input``: the battery has a DC (solar) input.
+    """
+
+    has_builtin_inverter: bool
+    has_ac_input: bool
+    has_dc_input: bool
+
+
+def device_capabilities(device_type: str) -> DeviceCapabilities:
+    """Classify *device_type* into its :class:`DeviceCapabilities`.
+
+    Known Marstek families:
+
+    - Venus A/D (``VNSA``/``VNSD``): built-in inverter, AC input, *and* an
+      extra DC input.  Checked before the generic ``VNS`` branch because
+      ``"VNSA".startswith("VNS")``.
+    - Other Venus (``HMG*``, ``VNSE3``, ...): built-in inverter + AC input.
+    - Jupiter (``HMN*``/``HMM*``/``JPLS*``): a DC battery, but with its own
+      built-in inverter — so it does *not* depend on an external inverter.
+    - B2500 family (``HMA*``/``HMJ*``/``HMK*``): DC input feeding a *separate*
+      inverter, with no built-in inverter and no AC input.
+
+    Unknown / future / empty device types are assumed to be modern AC-coupled
+    batteries (built-in inverter + AC input, no separate DC inverter), so they
+    are never floored by MIN_DC_OUTPUT and are treated as AC-chargeable.
+    """
+    dt = (device_type or "").upper()
+    if dt.startswith(("VNSA", "VNSD")):
+        return DeviceCapabilities(True, True, True)
+    if dt.startswith(("HMG", "VNS")):
+        return DeviceCapabilities(True, True, False)
+    if dt.startswith(("HMN", "HMM", "JPLS")):
+        return DeviceCapabilities(True, False, True)
+    if dt.startswith(("HMA", "HMJ", "HMK")):
+        return DeviceCapabilities(False, False, True)
+    return DeviceCapabilities(True, True, False)
 
 
 def _is_ac_chargeable(device_type: str) -> bool:
-    """True iff *device_type* identifies an AC-chargeable Marstek battery.
+    """True iff *device_type* can be charged from AC (the Venus lineup).
 
-    Empty / unknown device types are treated as DC-only — an unknown
-    battery cannot be assumed to accept charge commands.
+    Unrecognized/empty device types are assumed AC-chargeable (see
+    :func:`device_capabilities`).  This is used to exclude DC-only batteries
+    (B2500 family) from charge distribution under a grid surplus — see issue
+    #338.
     """
-    if not device_type:
-        return False
-    return device_type.upper().startswith(AC_CHARGEABLE_DEVICE_PREFIXES)
+    return device_capabilities(device_type).has_ac_input
+
+
+def _needs_dc_output_floor(device_type: str) -> bool:
+    """True iff *device_type* depends on a sleep-prone *external* inverter.
+
+    Such a battery has no built-in inverter and no AC input, so its only way
+    to stay awake is to keep discharging through its DC-fed external inverter.
+    This is exactly the B2500 family (``HMA*``/``HMJ*``/``HMK*``); Jupiter and
+    Venus are excluded because they have a built-in inverter.
+    """
+    caps = device_capabilities(device_type)
+    return not caps.has_ac_input and not caps.has_builtin_inverter
 
 
 # ---------------------------------------------------------------------------
@@ -136,6 +194,11 @@ class BalancerConfig:
     efficiency_rotation_interval: float = 900
     efficiency_fade_alpha: float = 0.15
     efficiency_saturation_threshold: float = 0.4
+    # Minimum net discharge (W) to hold an external-inverter DC battery at so
+    # its inverter doesn't switch off at 0 W and sleep.  0 disables.  Only
+    # applied to batteries selected by ``_needs_dc_output_floor`` (B2500
+    # family) unless overridden per-device.  See issue #425.
+    min_dc_output: float = 0
 
     def __post_init__(self) -> None:
         def _clamp(name: str, lo: float, hi: float) -> None:
@@ -156,6 +219,7 @@ class BalancerConfig:
         _clamp("efficiency_rotation_interval", 1, float("inf"))
         _clamp("efficiency_fade_alpha", 0.01, 1.0)
         _clamp("efficiency_saturation_threshold", 0.0, 1.0)
+        _clamp("min_dc_output", 0, float("inf"))
 
 
 # ---------------------------------------------------------------------------
@@ -755,7 +819,8 @@ class LoadBalancer:
         # Auto-pool reports (exclude manual consumers)
         reports = {cid: r for cid, r in active_reports.items() if cid not in manual}
 
-        return self._compute_auto_target(consumer_id, reports, grid_total, sample_id)
+        result = self._compute_auto_target(consumer_id, reports, grid_total, sample_id)
+        return self._apply_min_dc_output(consumer_id, reports, result)
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -838,6 +903,70 @@ class LoadBalancer:
     # Internal helpers
     # ------------------------------------------------------------------
 
+    def _effective_min_dc_output(self, consumer_id: str | None, reports: dict) -> float:
+        """Per-consumer MIN_DC_OUTPUT floor (W); 0 means no floor.
+
+        An explicit per-device override (``min_dc_output`` in the report) wins
+        for any battery; otherwise the global floor applies only to batteries
+        that depend on a sleep-prone external inverter (``_needs_dc_output_floor``).
+        """
+        report = reports.get(consumer_id, {}) if consumer_id else {}
+        override = report.get("min_dc_output")
+        if override is not None:
+            return max(0.0, float(override))
+        if _needs_dc_output_floor(report.get("device_type", "")):
+            return self._cfg.min_dc_output
+        return 0.0
+
+    def _apply_min_dc_output(
+        self, consumer_id: str | None, reports: dict, result: list[float]
+    ) -> list[float]:
+        """Hold an external-inverter DC battery at ``MIN_DC_OUTPUT`` discharge.
+
+        Wraps the auto-path result so a battery that would otherwise be
+        commanded below the floor (e.g. steered to 0 under surplus) keeps a
+        minimum net discharge — enough to stop its DC-fed inverter sleeping.
+        Only the auto path reaches here; manual/inactive return earlier.
+
+        NOTE: combining this with ``MIN_EFFICIENT_POWER`` rotation is in tension
+        — a unit parked at 0 for efficiency is instead held at the floor.  With
+        ``MIN_DC_OUTPUT >= saturation min_target`` they coexist stably (a parked,
+        empty unit still trips saturation and stays deprioritized while awake).
+        A value below the saturation ``min_target`` would mask saturation for a
+        floored unit (its target never clears the gate) — main.py warns on that.
+        """
+        if not consumer_id or consumer_id not in reports:
+            return result
+        eff_min = self._effective_min_dc_output(consumer_id, reports)
+        if eff_min <= 0:
+            return result
+        report = reports[consumer_id]
+        # Respect an explicit park: distribution_weight=0 means "take no share",
+        # i.e. sit at 0 — don't silently wake it (mirrors manual/inactive).
+        if _report_weight(report) == 0:
+            return result
+        reported = parse_int(report.get("power", 0))
+        # Use the consumer's FULL intended reading: ``_split_by_phase`` spreads
+        # the scalar across phases but preserves the total, so sum(result)
+        # recovers it regardless of phase distribution. ``result[idx]`` alone is
+        # only a phase-apportioned fragment.
+        net_self = reported + sum(result)
+        # Floor whenever the commanded net output is below the floor — including
+        # negative (charge) commands.  A floor-eligible battery has no AC input
+        # and cannot charge, so an all-DC-under-surplus fair-share that commands
+        # a (futile) charge must still be lifted to the minimum discharge,
+        # otherwise the lone-B2500 case (issue #425) would never engage.  An
+        # explicit per-device override on a chargeable battery thus also holds a
+        # minimum discharge — the user opted into that by setting it.
+        if net_self >= eff_min:
+            return result
+        reading = to_grid_reading(NetOutputW(eff_min), reported)
+        phase = (report.get("phase") or "A").upper()
+        out = [0.0, 0.0, 0.0]
+        out[{"A": 0, "B": 1, "C": 2}.get(phase, 0)] = reading
+        self._get_consumer(consumer_id).last_target = reading
+        return out
+
     def _steer_to_zero(self, consumer_id: str | None, reports: dict) -> list[float]:
         """Drive a consumer's output to zero (``NetOutputW(0)``)."""
         if consumer_id:
@@ -895,11 +1024,12 @@ class LoadBalancer:
         num_consumers = max(1, len(reports))
         eff_part = {cid: max(0.01, 1.0 - saturation.get(cid, 0.0)) for cid in reports}
 
-        # Exclude DC-only batteries (B2500 family, Jupiter, anything not
-        # in AC_CHARGEABLE_DEVICE_PREFIXES) from charge distribution
-        # whenever the grid is in charge territory.  The base gate is
-        # ``grid_total < 0`` (surplus), but we also extend it to the
-        # exact zero-crossing when an AC-chargeable battery is already
+        # Exclude batteries that can't charge from AC (``not
+        # _is_ac_chargeable(...)`` — the B2500 family and Jupiter; unknown /
+        # empty types are treated as AC-chargeable, see ``device_capabilities``)
+        # from charge distribution whenever the grid is in charge territory.
+        # The base gate is ``grid_total < 0`` (surplus), but we also extend it
+        # to the exact zero-crossing when an AC-chargeable battery is already
         # charging (``power < 0``) — that signals pass-through
         # equilibrium, which happens when a full B2500 is passing its DC
         # solar input through as AC output (+P W) while the Venus

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -87,6 +87,9 @@ class Consumer:
     # neutral; a battery with weight 2.0 takes roughly twice the share of a
     # weight-1.0 battery.  Tuned live via the MQTT "Distribution Weight" entity.
     distribution_weight: float = 1.0
+    # Per-device override (W) for the MIN_DC_OUTPUT wake floor; ``None`` inherits
+    # the global setting.  Tuned live via the MQTT "Min DC Output" entity.
+    min_dc_output: float | None = None
     # Last UDP source address seen for this consumer, if the protocol provides it.
     last_ip: str = ""
 
@@ -147,6 +150,7 @@ class CT002:
         efficiency_rotation_interval=900,
         efficiency_fade_alpha=0.15,
         efficiency_saturation_threshold=0.4,
+        min_dc_output=0,
         saturation_decay_factor=0.995,
         saturation_grace_seconds=SATURATION_GRACE_SECONDS,
         saturation_stall_timeout_seconds=SATURATION_STALL_TIMEOUT_SECONDS,
@@ -205,6 +209,7 @@ class CT002:
                 efficiency_rotation_interval=efficiency_rotation_interval,
                 efficiency_fade_alpha=efficiency_fade_alpha,
                 efficiency_saturation_threshold=efficiency_saturation_threshold,
+                min_dc_output=min_dc_output,
             ),
             saturation_alpha=saturation_alpha,
             saturation_min_target=min_target_for_saturation,
@@ -255,6 +260,18 @@ class CT002:
             msg = f"distribution weight must be in [0, 10], got {weight!r}"
             raise ValueError(msg)
         self._get_consumer(consumer_id).distribution_weight = value
+
+    def set_consumer_min_dc_output(self, consumer_id: str, value: float) -> None:
+        """Set the per-device MIN_DC_OUTPUT floor (W) for a battery.
+
+        Must be finite and ``>= 0``.  Overrides the global ``MIN_DC_OUTPUT`` for
+        this battery regardless of its type; ``0`` disables the floor for it.
+        """
+        v = float(value)
+        if not math.isfinite(v) or v < 0.0:
+            msg = f"min_dc_output must be finite and >= 0, got {value!r}"
+            raise ValueError(msg)
+        self._get_consumer(consumer_id).min_dc_output = v
 
     def set_consumer_auto_target(self, consumer_id: str, auto: bool) -> None:
         """Toggle auto target. auto=True means automatic control (default).
@@ -386,6 +403,7 @@ class CT002:
                 "power": c.power,
                 "device_type": c.device_type,
                 "weight": c.distribution_weight,
+                "min_dc_output": c.min_dc_output,
             }
             for cid, c in self._consumers.items()
             if c.timestamp > 0
@@ -767,6 +785,7 @@ class CT002:
                     "distribution_weight": (
                         consumer.distribution_weight if consumer else 1.0
                     ),
+                    "min_dc_output": consumer.min_dc_output if consumer else None,
                     "active_control": self.active_control,
                     "consumer_count": sum(
                         1 for c in self._consumers.values() if c.timestamp > 0

--- a/src/astrameter/main.py
+++ b/src/astrameter/main.py
@@ -193,6 +193,16 @@ async def run_device(
         saturation_decay_factor = cfg.getfloat(
             ct_section, "SATURATION_DECAY_FACTOR", fallback=0.995
         )
+        min_dc_output = cfg.getint(ct_section, "MIN_DC_OUTPUT", fallback=0)
+        if 0 < min_dc_output < min_target_for_saturation:
+            logger.warning(
+                "MIN_DC_OUTPUT (%dW) is below MIN_TARGET_FOR_SATURATION (%dW): a "
+                "floored battery's target never clears the saturation gate, so an "
+                "empty/full unit can't be detected. Consider MIN_DC_OUTPUT >= %d.",
+                min_dc_output,
+                min_target_for_saturation,
+                min_target_for_saturation,
+            )
 
         logger.debug(f"{device_type.upper()} Settings for {device_id}:")
         logger.debug(f"CT Type: {ct_type}")
@@ -247,6 +257,7 @@ async def run_device(
             efficiency_rotation_interval=efficiency_rotation_interval,
             efficiency_fade_alpha=efficiency_fade_alpha,
             efficiency_saturation_threshold=efficiency_saturation_threshold,
+            min_dc_output=min_dc_output,
             saturation_decay_factor=saturation_decay_factor,
             device_id=device_id or "",
             reset_fn=lambda: _reset_all_powermeters(powermeters),
@@ -348,6 +359,9 @@ async def run_device(
         )
         insights.register_distribution_weight_handler(
             device_id or "", device.set_consumer_distribution_weight
+        )
+        insights.register_min_dc_output_handler(
+            device_id or "", device.set_consumer_min_dc_output
         )
         insights.register_rotation_handler(
             device_id or "", device.force_efficiency_rotation

--- a/src/astrameter/main.py
+++ b/src/astrameter/main.py
@@ -193,10 +193,10 @@ async def run_device(
         saturation_decay_factor = cfg.getfloat(
             ct_section, "SATURATION_DECAY_FACTOR", fallback=0.995
         )
-        min_dc_output = cfg.getint(ct_section, "MIN_DC_OUTPUT", fallback=0)
+        min_dc_output = cfg.getfloat(ct_section, "MIN_DC_OUTPUT", fallback=0.0)
         if 0 < min_dc_output < min_target_for_saturation:
             logger.warning(
-                "MIN_DC_OUTPUT (%dW) is below MIN_TARGET_FOR_SATURATION (%dW): a "
+                "MIN_DC_OUTPUT (%gW) is below MIN_TARGET_FOR_SATURATION (%dW): a "
                 "floored battery's target never clears the saturation gate, so an "
                 "empty/full unit can't be detected. Consider MIN_DC_OUTPUT >= %d.",
                 min_dc_output,

--- a/src/astrameter/mqtt_insights/discovery.py
+++ b/src/astrameter/mqtt_insights/discovery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 
+from astrameter.ct002.balancer import _needs_dc_output_floor
 from astrameter.version_info import get_git_commit_sha
 
 _SAFE_ID_RE = re.compile(r"[^a-zA-Z0-9_-]")
@@ -213,6 +214,28 @@ def build_ct002_consumer_discovery(
         "retain": True,
         "entity_category": "config",
     }
+
+    # Min DC Output number — minimum discharge (W) to keep a DC battery's
+    # external inverter from switching off at 0 W.  Only surfaced for batteries
+    # where it has an effect (no built-in inverter, no AC input — the B2500
+    # family); Venus/Jupiter/unknown types don't get this entity.
+    if _needs_dc_output_floor(device_type):
+        components["min_dc_output"] = {
+            "platform": "number",
+            "unique_id": f"{uid_prefix}_min_dc_output",
+            "name": "Min DC Output",
+            "unit_of_measurement": "W",
+            "device_class": "power",
+            "min": 0,
+            "max": 1000,
+            "step": 1,
+            "mode": "box",
+            "state_topic": state_topic,
+            "value_template": "{{ value_json.min_dc_output | default(0) }}",
+            "command_topic": f"{state_topic}/min_dc_output/set",
+            "retain": True,
+            "entity_category": "config",
+        }
 
     mac_slug = _sanitize_id(consumer_id).lower().replace("-", "").replace("_", "")
 

--- a/src/astrameter/mqtt_insights/mqtt_insights_test.py
+++ b/src/astrameter/mqtt_insights/mqtt_insights_test.py
@@ -148,6 +148,37 @@ def test_ct002_consumer_discovery_structure():
     assert weight["max"] == 10
     assert weight["entity_category"] == "config"
 
+    # Min DC Output number entity — present for the B2500 family (HMJ-2).
+    min_dc = comps["min_dc_output"]
+    assert min_dc["platform"] == "number"
+    assert min_dc["command_topic"].endswith("/min_dc_output/set")
+    assert min_dc["retain"] is True
+    assert min_dc["min"] == 0
+    assert min_dc["max"] == 1000
+    assert min_dc["unit_of_measurement"] == "W"
+    assert min_dc["entity_category"] == "config"
+
+
+def test_min_dc_output_entity_only_for_external_inverter_types():
+    """The Min DC Output number is gated on the device-capabilities classifier."""
+
+    def _components(device_type: str) -> dict:
+        _, payload = build_ct002_consumer_discovery(
+            "astrameter",
+            "dev1",
+            "aabbccddeeff",
+            "homeassistant",
+            device_type=device_type,
+        )
+        return payload["components"]
+
+    # External-inverter DC families get the entity.
+    for dt in ("HMJ-1", "HMA-2", "HMK-1"):
+        assert "min_dc_output" in _components(dt), dt
+    # Venus / Jupiter / unknown do not.
+    for dt in ("HMG-50", "VNSD", "HMN-1", "UNKNOWN", ""):
+        assert "min_dc_output" not in _components(dt), dt
+
 
 def test_ct002_consumer_discovery_no_device_type():
     """Name omits device_type when empty."""
@@ -615,6 +646,7 @@ SAMPLE_CT002_DATA = {
     "manual_target": None,
     "auto_target": True,
     "distribution_weight": 1.5,
+    "min_dc_output": 25.0,
     "smooth_target": 500.0,
     "active_control": True,
     "consumer_count": 2,
@@ -655,6 +687,7 @@ async def test_publishes_state_on_ct002_event(mqtt_broker):
         assert payload["active"] is True
         assert payload["poll_interval"] == 5.0
         assert payload["distribution_weight"] == 1.5
+        assert payload["min_dc_output"] == 25.0
         assert str(received[0].topic) == f"{base}/ct002/dev1/consumer/consumer1"
     finally:
         await service.stop()
@@ -999,12 +1032,22 @@ def test_handle_consumer_field_command_dispatch() -> None:
     service.register_distribution_weight_handler(
         "dev1", lambda cid, v: calls.__setitem__("weight", v)
     )
+    service.register_min_dc_output_handler(
+        "dev1", lambda cid, v: calls.__setitem__("min_dc", v)
+    )
 
     service._handle_consumer_field_command("dev1", "c1", "active", "false")
     service._handle_consumer_field_command("dev1", "c1", "auto_target", "true")
     service._handle_consumer_field_command("dev1", "c1", "manual_target", "250")
     service._handle_consumer_field_command("dev1", "c1", "distribution_weight", "2.5")
-    assert calls == {"active": False, "auto": True, "manual": 250.0, "weight": 2.5}
+    service._handle_consumer_field_command("dev1", "c1", "min_dc_output", "25")
+    assert calls == {
+        "active": False,
+        "auto": True,
+        "manual": 250.0,
+        "weight": 2.5,
+        "min_dc": 25.0,
+    }
 
     # 0.0 is a valid weight (battery takes no share).
     calls.clear()
@@ -1016,6 +1059,8 @@ def test_handle_consumer_field_command_dispatch() -> None:
     service._handle_consumer_field_command("dev1", "c1", "distribution_weight", "11")
     service._handle_consumer_field_command("dev1", "c1", "manual_target", "nan")
     service._handle_consumer_field_command("dev1", "c1", "active", "maybe")
+    service._handle_consumer_field_command("dev1", "c1", "min_dc_output", "-5")
+    service._handle_consumer_field_command("dev1", "c1", "min_dc_output", "2000")
     # An empty (cleared) retained payload is ignored silently.
     service._handle_consumer_field_command("dev1", "c1", "distribution_weight", "")
     assert calls == {}

--- a/src/astrameter/mqtt_insights/service.py
+++ b/src/astrameter/mqtt_insights/service.py
@@ -104,6 +104,7 @@ class MqttInsightsService:
         self._manual_target_handlers: dict[str, Callable[[str, float], None]] = {}
         self._auto_target_handlers: dict[str, Callable[[str, bool], None]] = {}
         self._distribution_weight_handlers: dict[str, Callable[[str, float], None]] = {}
+        self._min_dc_output_handlers: dict[str, Callable[[str, float], None]] = {}
         self._rotation_handlers: dict[str, Callable[[], None]] = {}
         self._connected = asyncio.Event()
         # Marstek MQTT responder state — populated via register_marstek().
@@ -169,6 +170,11 @@ class MqttInsightsService:
     ) -> None:
         self._distribution_weight_handlers[device_id] = handler
 
+    def register_min_dc_output_handler(
+        self, device_id: str, handler: Callable[[str, float], None]
+    ) -> None:
+        self._min_dc_output_handlers[device_id] = handler
+
     def register_rotation_handler(
         self, device_id: str, handler: Callable[[], None]
     ) -> None:
@@ -180,6 +186,7 @@ class MqttInsightsService:
         self._manual_target_handlers.pop(device_id, None)
         self._auto_target_handlers.pop(device_id, None)
         self._distribution_weight_handlers.pop(device_id, None)
+        self._min_dc_output_handlers.pop(device_id, None)
         self._rotation_handlers.pop(device_id, None)
 
     # ── Marstek MQTT responder ────────────────────────────────────────
@@ -462,6 +469,7 @@ class MqttInsightsService:
             "manual_target": data.get("manual_target"),
             "auto_target": data.get("auto_target", True),
             "distribution_weight": data.get("distribution_weight", 1.0),
+            "min_dc_output": data.get("min_dc_output"),
         }
 
         await client.publish(
@@ -790,6 +798,32 @@ class MqttInsightsService:
                 device_id,
                 consumer_id,
                 weight,
+            )
+        elif field == "min_dc_output":
+            try:
+                min_dc = float(payload)
+            except ValueError:
+                logger.warning(
+                    "Invalid min_dc_output value for %s/%s: %r",
+                    device_id,
+                    consumer_id,
+                    payload,
+                )
+                return
+            if not math.isfinite(min_dc) or not 0.0 <= min_dc <= 1000.0:
+                logger.warning(
+                    "Out-of-range min_dc_output for %s/%s: %s",
+                    device_id,
+                    consumer_id,
+                    min_dc,
+                )
+                return
+            self._dispatch(
+                self._min_dc_output_handlers,
+                "min_dc_output",
+                device_id,
+                consumer_id,
+                min_dc,
             )
         else:
             logger.debug(

--- a/tests/components/ct002/fixtures/balancer_parity_harness.cpp
+++ b/tests/components/ct002/fixtures/balancer_parity_harness.cpp
@@ -67,14 +67,17 @@ int main() {
     if (cmd == "cfg") {
       int fair = 1, sat_enabled = 0;
       float min_eff = 0.0f, rot = 900.0f, sat_threshold = 0.4f, sat_alpha = 0.15f,
-            sat_min_target = 20.0f, sat_grace = 90.0f;
+            sat_min_target = 20.0f, sat_grace = 90.0f, min_dc = 0.0f;
       in >> fair >> min_eff >> rot >> sat_threshold >> sat_alpha >> sat_min_target >>
           sat_grace >> sat_enabled;
+      // Optional trailing global MIN_DC_OUTPUT (0 / absent = disabled).
+      in >> min_dc;
       BalancerConfig cfg;
       cfg.fair_distribution = (fair != 0);
       cfg.min_efficient_power = min_eff;
       cfg.efficiency_rotation_interval = rot;
       cfg.efficiency_saturation_threshold = sat_threshold;
+      cfg.min_dc_output = min_dc;
       balancer = std::make_unique<LoadBalancer>(
           cfg, sat_alpha, sat_min_target, /*sat_decay=*/0.995f, sat_grace,
           /*sat_stall=*/60.0f, sat_enabled != 0, []() { return g_clock; }, nullptr);
@@ -92,9 +95,11 @@ int main() {
       ReportMap reports;
       for (int i = 0; i < n; ++i) {
         std::string rc, dev, phase;
-        float power = 0.0f;
-        in >> rc >> dev >> phase >> power;
-        reports[rc] = ConsumerReport{dev, phase, power};
+        float power = 0.0f, md = -1.0f;
+        in >> rc >> dev >> phase >> power >> md;
+        ConsumerReport r{dev, phase, power};
+        if (md >= 0.0f) r.min_dc_output = md;
+        reports[rc] = r;
       }
       const auto out = balancer->compute_target(cid, parse_mode(mode_str, manual), reports,
                                                 grid, {}, {}, {});

--- a/tests/components/ct002/fixtures/balancer_parity_harness.cpp
+++ b/tests/components/ct002/fixtures/balancer_parity_harness.cpp
@@ -9,12 +9,15 @@
 //
 // Commands (one per line, whitespace separated):
 //   cfg <fair> <min_eff> <rot_interval> <sat_threshold> <sat_alpha> \
-//       <sat_min_target> <sat_grace> <sat_enabled>
+//       <sat_min_target> <sat_grace> <sat_enabled> [<min_dc_output>]
 //        (Re)create the balancer with the given config. Must be the first
-//        command. Saturation grace defaults are applied per consumer lazily.
+//        command. The trailing global MIN_DC_OUTPUT is optional (absent = 0).
+//        Saturation grace defaults are applied per consumer lazily.
 //   clock <seconds>           Set the mock clock to an absolute value.
 //   advance <seconds>         Advance the mock clock.
-//   target <cid> <mode> <manual> <grid> <n> [<cid> <dev> <phase> <power>]xN
+//   target <cid> <mode> <manual> <grid> <n> [<cid> <dev> <phase> <power> <md>]xN
+//        Each report carries a per-consumer min_dc_output token <md> (always
+//        emitted; < 0 means "unset" / inherit the global).
 //        Call compute_target for <cid> and print the resulting three phase
 //        targets. <mode> is auto|manual|inactive. The N reports describe the
 //        whole pool for this tick (inactive/manual sets are derived from each

--- a/tests/components/ct002/host_balancer_test.cpp
+++ b/tests/components/ct002/host_balancer_test.cpp
@@ -20,6 +20,7 @@ using esphome::ct002::ConsumerModeKind;
 using esphome::ct002::ConsumerReport;
 using esphome::ct002::is_ac_chargeable;
 using esphome::ct002::LoadBalancer;
+using esphome::ct002::needs_dc_output_floor;
 using esphome::ct002::NetOutputW;
 using esphome::ct002::ReportMap;
 using esphome::ct002::to_grid_reading;
@@ -55,9 +56,29 @@ TEST(IsAcChargeable, IdentifiesVenusPrefixes) {
   EXPECT_TRUE(is_ac_chargeable("hmg-50"));
   EXPECT_TRUE(is_ac_chargeable("VNSE3"));
   EXPECT_TRUE(is_ac_chargeable("VNSA"));
+  // B2500 family (DC-only, external inverter) is not AC-chargeable.
   EXPECT_FALSE(is_ac_chargeable("HMA-2"));
-  EXPECT_FALSE(is_ac_chargeable("HME-4"));
-  EXPECT_FALSE(is_ac_chargeable(""));
+  EXPECT_FALSE(is_ac_chargeable("HMJ-1"));
+  EXPECT_FALSE(is_ac_chargeable("HMK-1"));
+  // Jupiter (built-in inverter, DC battery) is not AC-chargeable either.
+  EXPECT_FALSE(is_ac_chargeable("HMN-1"));
+  // Unknown/empty types are assumed modern AC-coupled batteries (issue #425
+  // device-capabilities model): the former fail-closed-to-DC default was
+  // intentionally dropped.
+  EXPECT_TRUE(is_ac_chargeable("HME-4"));
+  EXPECT_TRUE(is_ac_chargeable(""));
+}
+
+TEST(NeedsDcOutputFloor, OnlyExternalInverterFamilies) {
+  // B2500 family: no built-in inverter, no AC input -> floor applies.
+  EXPECT_TRUE(needs_dc_output_floor("HMA-2"));
+  EXPECT_TRUE(needs_dc_output_floor("HMJ-1"));
+  EXPECT_TRUE(needs_dc_output_floor("HMK-1"));
+  // Built-in inverter or AC input -> excluded.
+  EXPECT_FALSE(needs_dc_output_floor("HMG-50"));   // Venus
+  EXPECT_FALSE(needs_dc_output_floor("VNSD"));      // Venus D (built-in + DC)
+  EXPECT_FALSE(needs_dc_output_floor("HMN-1"));     // Jupiter
+  EXPECT_FALSE(needs_dc_output_floor(""));          // unknown -> assumed AC
 }
 
 TEST(LoadBalancer, InactiveSteersConsumerOutputToZero) {

--- a/tests/components/ct002/test_balancer_parity.py
+++ b/tests/components/ct002/test_balancer_parity.py
@@ -107,11 +107,14 @@ class PyDriver:
                 sat_grace,
                 sat_enabled,
             ) = parts[1:9]
+            # Optional trailing global MIN_DC_OUTPUT (absent = disabled).
+            min_dc = float(parts[9]) if len(parts) > 9 else 0.0
             cfg = BalancerConfig(
                 fair_distribution=bool(int(fair)),
                 min_efficient_power=float(min_eff),
                 efficiency_rotation_interval=float(rot),
                 efficiency_saturation_threshold=float(sat_threshold),
+                min_dc_output=min_dc,
             )
             self.balancer = LoadBalancer(
                 cfg,
@@ -139,9 +142,14 @@ class PyDriver:
             reports = {}
             i = 6
             for _ in range(n):
-                rc, dev, phase, power = parts[i : i + 4]
-                reports[rc] = {"device_type": dev, "phase": phase, "power": int(power)}
-                i += 4
+                rc, dev, phase, power, md = parts[i : i + 5]
+                reports[rc] = {
+                    "device_type": dev,
+                    "phase": phase,
+                    "power": int(power),
+                    "min_dc_output": None if float(md) < 0 else float(md),
+                }
+                i += 5
             res = self.balancer.compute_target(
                 cid,
                 ConsumerMode(mode, float(manual)),
@@ -217,8 +225,11 @@ _CFG_DEFAULT = "cfg 0 0 900 0.4 0.15 20 90 0"
 _CFG_EFFICIENCY = "cfg 1 100 900 0.4 0.15 20 90 1"
 
 
-def _report(cid: str, phase: str, power: int, dev: str = "HMA-2") -> str:
-    return f"{cid} {dev} {phase} {power}"
+def _report(
+    cid: str, phase: str, power: int, dev: str = "HMA-2", min_dc: float = -1.0
+) -> str:
+    # min_dc < 0 encodes "unset" (inherit global / None).
+    return f"{cid} {dev} {phase} {power} {min_dc}"
 
 
 def _target(
@@ -291,6 +302,31 @@ def _scenario_efficiency_lifecycle() -> list[str]:
     return lines
 
 
+def _scenario_min_dc_output() -> list[str]:
+    """Exercise the MIN_DC_OUTPUT floor: global on a DC battery + Venus, and a
+    per-device override on the Venus, across surplus/discharge."""
+    lines = ["cfg 1 0 900 0.4 0.15 20 90 1 25", "clock 2000"]
+    pool = [_report("a", "A", 0, "HMA-2"), _report("b", "B", 0, "HMG-50")]
+    for grid in (-600, -300, 0, 300, -150):
+        lines.append(_target("a", pool, grid=grid))
+        lines.append(_target("b", pool, grid=grid))
+        lines.append("last a")
+        lines.append("last b")
+        lines.append("advance 1")
+    # Per-device override floors the Venus too.
+    pool2 = [_report("a", "A", 0, "HMA-2"), _report("b", "B", 0, "HMG-50", 40)]
+    for grid in (-600, 200):
+        lines.append(_target("b", pool2, grid=grid))
+        lines.append("last b")
+        lines.append("advance 1")
+    return lines
+
+
+def test_parity_min_dc_output(harness: Path) -> None:
+    lines = _scenario_min_dc_output()
+    _compare("min_dc_output", lines, _run_cpp(harness, lines), _run_py(lines))
+
+
 def test_parity_steer_and_split(harness: Path) -> None:
     lines = _scenario_steer_and_split()
     _compare("steer_split", lines, _run_cpp(harness, lines), _run_py(lines))
@@ -313,18 +349,25 @@ def _random_stream(seed: int, n_polls: int) -> list[str]:
     rot = rng.choice([20, 120, 900])
     sat_threshold = rng.choice([0.0, 0.3, 0.4])
     sat_enabled = rng.choice([0, 1])
+    min_dc = rng.choice([0, 0, 25, 50])
     lines = [
-        f"cfg {fair} {min_eff} {rot} {sat_threshold} 0.15 20 {90} {sat_enabled}",
+        f"cfg {fair} {min_eff} {rot} {sat_threshold} 0.15 20 {90} {sat_enabled} {min_dc}",
         f"clock {rng.randint(1000, 9000)}",
     ]
     n_consumers = rng.randint(1, 3)
     cids = ["a", "b", "c"][:n_consumers]
     phases = {cid: rng.choice(["A", "B", "C"]) for cid in cids}
-    devs = {cid: rng.choice(["HMA-2", "HME-4", "HMG-50"]) for cid in cids}
+    devs = {
+        cid: rng.choice(["HMA-2", "HME-4", "HMG-50", "HMN-1", "VNSD"]) for cid in cids
+    }
+    overrides = {cid: rng.choice([-1, -1, -1, 25, 80]) for cid in cids}
     for _ in range(n_polls):
         grid = rng.choice([-901, -300, -150, -1, 0, 1, 100, 300, 450, 901, 1500])
         powers = {cid: rng.choice([-200, -50, 0, 0, 50, 200]) for cid in cids}
-        pool = [_report(cid, phases[cid], powers[cid], devs[cid]) for cid in cids]
+        pool = [
+            _report(cid, phases[cid], powers[cid], devs[cid], overrides[cid])
+            for cid in cids
+        ]
         target_cid = rng.choice(cids)
         mode = rng.choice(["auto", "auto", "auto", "manual", "inactive"])
         manual = rng.choice([-300, 0, 250, 600])

--- a/tests/test_balancer_mixed_battery_charging.py
+++ b/tests/test_balancer_mixed_battery_charging.py
@@ -26,8 +26,9 @@ Positive grid (discharge) behaviour is unchanged.
 
 The tests here cover:
 
- * the legacy deadlock when ``device_type`` is missing (proves the
-   default-to-DC safety policy is in effect),
+ * unknown/empty ``device_type`` is now assumed AC-coupled (issue #425
+   device-capabilities model; the former fail-closed-to-DC default was
+   intentionally dropped),
  * the fix path with recognised Venus / B2500 prefixes,
  * discharge unaffected,
  * the degenerate all-DC-under-surplus case,
@@ -47,6 +48,8 @@ from astrameter.ct002.balancer import (
     BalancerConfig,
     ConsumerMode,
     LoadBalancer,
+    _is_ac_chargeable,
+    _needs_dc_output_floor,
 )
 
 
@@ -320,21 +323,16 @@ def test_all_known_venus_prefixes_are_charge_capable(venus_device_type: str) -> 
     "dc_device_type",
     [
         "HMA-X",
-        "HMB-X",
         "HMJ-X",
         "HMK-X",
         "hma-x",
-        "JUPITER-1",
-        "UNKNOWN",
-        "",
     ],
 )
-def test_non_venus_prefixes_are_treated_as_dc(dc_device_type: str) -> None:
-    """B2500 family, Jupiter, and anything unrecognised default to DC.
+def test_b2500_prefixes_are_treated_as_dc(dc_device_type: str) -> None:
+    """The B2500 family (``HMA``/``HMJ``/``HMK``) is DC-only.
 
     Paired with a recognised Venus, these must be held at 0 W under
-    surplus while the Venus absorbs everything.  Empty / unknown
-    device types share the same DC default (fail-closed policy).
+    surplus while the Venus absorbs everything.
     """
     dc = DCOnlyBattery("dc", device_type=dc_device_type)
     venus = ACBatteryWithStartupThreshold("venus", device_type="HMG-50")
@@ -349,6 +347,39 @@ def test_non_venus_prefixes_are_treated_as_dc(dc_device_type: str) -> None:
         f"Venus should absorb the surplus while the DC sibling is held at 0. "
         f"Venus tail: {power['venus'][-30:]}"
     )
+
+
+@pytest.mark.parametrize(
+    ("device_type", "expect_ac", "expect_floor"),
+    [
+        # B2500 family: DC-only, external inverter -> floor-eligible.
+        ("HMA-X", False, True),
+        ("HMJ-X", False, True),
+        ("HMK-X", False, True),
+        ("hmj-1", False, True),
+        # Venus (built-in inverter + AC input) -> AC-chargeable, no floor.
+        ("HMG-50", True, False),
+        ("VNSE3", True, False),
+        ("VNSA", True, False),
+        ("VNSD", True, False),
+        # Jupiter (built-in inverter, DC battery) -> not AC, no floor.
+        ("HMN-1", False, False),
+        ("HMM-1", False, False),
+        ("JPLS-1", False, False),
+        # Unknown / future / empty: assumed modern AC-coupled batteries.
+        # NOTE: this intentionally drops the old fail-closed-to-DC default
+        # (issue #338) in favour of the device-capabilities model (issue #425).
+        ("UNKNOWN", True, False),
+        ("JUPITER-1", True, False),  # not a real device-type string
+        ("", True, False),
+    ],
+)
+def test_device_classification(
+    device_type: str, expect_ac: bool, expect_floor: bool
+) -> None:
+    """The device-capabilities model drives AC-charge eligibility and the floor."""
+    assert _is_ac_chargeable(device_type) is expect_ac
+    assert _needs_dc_output_floor(device_type) is expect_floor
 
 
 # ---------------------------------------------------------------------------
@@ -467,28 +498,25 @@ def test_all_dc_under_surplus_holds_zero_and_logs(
 # ---------------------------------------------------------------------------
 
 
-def test_unknown_device_type_deadlock_persists() -> None:
-    """Protects the default-to-DC safety policy.
+def test_unknown_device_type_is_now_ac_chargeable() -> None:
+    """Unknown/empty device types are now assumed AC-coupled (issue #425).
 
-    The original bug reproduction used empty ``device_type`` strings:
-    both batteries look like unknown DC batteries to the balancer, so
-    nobody is asked to charge and the grid keeps feeding back the
-    surplus.  This is the expected fail-closed behaviour for consumers
-    we can't identify.  This also exercises the ``all_dc_under_surplus``
-    branch; the one-shot info-log emitted there is asserted separately
-    by ``test_all_dc_under_surplus_holds_zero_and_logs``.
+    This intentionally REPLACES the former fail-closed-to-DC behaviour
+    (issue #338): the device-capabilities model treats an unrecognized or
+    empty ``device_type`` as a modern AC-coupled battery, so it participates
+    in charge distribution and absorbs surplus rather than deadlocking the
+    grid at the full feed-in.  The trade-off (an unrecognized *DC* unit could
+    be told to charge and may not be able to) was accepted deliberately.
     """
-    b2500 = DCOnlyBattery("b2500_legacy", device_type="")
-    venus = ACBatteryWithStartupThreshold("venus_legacy", device_type="")
+    a = ACBatteryWithStartupThreshold("unknown_a", device_type="", startup_min=0.0)
+    b = ACBatteryWithStartupThreshold("unknown_b", device_type="", startup_min=0.0)
 
-    grid, power = _run_scenario([b2500, venus], surplus_watts=600.0, ticks=200)
+    grid, _ = _run_scenario([a, b], surplus_watts=600.0, ticks=200)
 
-    assert max(abs(p) for p in power["venus_legacy"][-30:]) < 1.0
-    assert max(abs(p) for p in power["b2500_legacy"][-30:]) < 1.0
     avg_grid = sum(grid[-30:]) / 30
-    assert avg_grid < -550, (
-        f"With unknown device_types nobody charges; expected grid ~= -600 W, got "
-        f"{avg_grid:.0f} W"
+    assert abs(avg_grid) < 50, (
+        f"Unknown device_types are now AC-chargeable and should absorb the "
+        f"surplus, draining the grid toward 0; got {avg_grid:.0f} W"
     )
 
 
@@ -600,3 +628,174 @@ def test_sustained_surplus_dc_only_balancer_never_asks_to_discharge() -> None:
 
     for m, peak in max_target_seen.items():
         assert peak <= 0, f"{m} peak target under surplus was {peak} (expected <= 0)"
+
+
+# ---------------------------------------------------------------------------
+# Issue #425: MIN_DC_OUTPUT — keep a DC battery's external inverter awake
+# ---------------------------------------------------------------------------
+
+
+def _make_balancer_min_dc(clock: _FakeClock, min_dc_output: float) -> LoadBalancer:
+    return LoadBalancer(
+        config=BalancerConfig(min_efficient_power=0, min_dc_output=min_dc_output),
+        saturation_alpha=0.15,
+        saturation_min_target=20,
+        saturation_decay_factor=0.995,
+        saturation_grace_seconds=90.0,
+        saturation_stall_timeout_seconds=60.0,
+        saturation_enabled=True,
+        clock=clock,
+    )
+
+
+def _run_floor_scenario(
+    batteries,
+    surplus_watts: float,
+    ticks: int,
+    *,
+    global_min_dc: float = 0.0,
+    overrides: dict[str, float] | None = None,
+    inactive: frozenset[str] = frozenset(),
+    manual: frozenset[str] = frozenset(),
+    weights: dict[str, float] | None = None,
+):
+    """Like ``_run_scenario`` but with MIN_DC_OUTPUT (global + per-device)."""
+    overrides = overrides or {}
+    weights = weights or {}
+    clock = _FakeClock()
+    lb = _make_balancer_min_dc(clock, global_min_dc)
+    grid_trace: list[float] = []
+    power_trace: dict[str, list[float]] = {b.mac: [] for b in batteries}
+
+    for tick in range(ticks):
+        reports = {
+            b.mac: {
+                "phase": "A",
+                "power": round(b.power),
+                "device_type": b.device_type,
+                "weight": weights.get(b.mac, 1.0),
+                "min_dc_output": overrides.get(b.mac),
+            }
+            for b in batteries
+        }
+        grid_total = -surplus_watts - sum(b.power for b in batteries)
+        grid_trace.append(grid_total)
+
+        deltas: dict[str, float] = {}
+        for b in batteries:
+            mode = ConsumerMode("auto")
+            if b.mac in inactive:
+                mode = ConsumerMode("inactive")
+            elif b.mac in manual:
+                mode = ConsumerMode("manual", 0.0)
+            phase_targets = lb.compute_target(
+                consumer_id=b.mac,
+                consumer_mode=mode,
+                all_reports=reports,
+                grid_total=grid_total,
+                inactive=inactive,
+                manual=manual,
+                sample_id=(tick,),
+            )
+            deltas[b.mac] = phase_targets[0]
+
+        for b in batteries:
+            b.step(deltas[b.mac], reports[b.mac]["power"])
+            power_trace[b.mac].append(b.power)
+        clock.advance(1.0)
+
+    return grid_trace, power_trace
+
+
+def test_lone_b2500_under_surplus_held_at_floor() -> None:
+    """The reporter's setup: a lone B2500 under surplus is held at the floor.
+
+    With no Venus present the all-DC fair-share would otherwise leave the
+    B2500 commanded toward 0/charge, so its external inverter sleeps. The
+    floor lifts it to a steady ~25 W discharge instead.
+    """
+    b2500 = DCOnlyBattery("b2500", device_type="HMJ-1")
+    _, power = _run_floor_scenario(
+        [b2500], surplus_watts=600.0, ticks=80, global_min_dc=25
+    )
+    tail = power["b2500"][-20:]
+    assert all(abs(p - 25) <= 1 for p in tail), f"expected ~25 W, got {tail}"
+
+
+def test_floor_off_by_default_leaves_b2500_asleep() -> None:
+    """Default (MIN_DC_OUTPUT=0) is a no-op: behaviour unchanged."""
+    b2500 = DCOnlyBattery("b2500", device_type="HMJ-1")
+    _, power = _run_floor_scenario(
+        [b2500], surplus_watts=600.0, ticks=80, global_min_dc=0
+    )
+    assert max(abs(p) for p in power["b2500"][-20:]) < 1.0
+
+
+def test_mixed_floor_holds_b2500_while_venus_absorbs() -> None:
+    """DC + Venus under surplus: B2500 held at floor, Venus absorbs the rest."""
+    b2500 = DCOnlyBattery("b2500", device_type="HMJ-1")
+    venus = ACBatteryWithStartupThreshold("venus", device_type="HMG-50")
+    _, power = _run_floor_scenario(
+        [b2500, venus], surplus_watts=600.0, ticks=200, global_min_dc=25
+    )
+    assert all(abs(p - 25) <= 2 for p in power["b2500"][-20:]), power["b2500"][-20:]
+    assert min(power["venus"][-20:]) < -500
+
+
+def test_global_floor_does_not_touch_venus_or_jupiter() -> None:
+    """Global floor never wakes a Venus or Jupiter (they have a built-in inverter)."""
+    venus = ACBatteryWithStartupThreshold("venus", device_type="HMG-50")
+    jupiter = DCOnlyBattery("jupiter", device_type="HMN-1")
+    _, power = _run_floor_scenario(
+        [venus, jupiter], surplus_watts=600.0, ticks=120, global_min_dc=25
+    )
+    # Jupiter is charge-blind here (not AC-chargeable) and excluded from the
+    # global floor, so it stays at 0 rather than being lifted to 25 W.
+    assert max(abs(p) for p in power["jupiter"][-20:]) < 1.0
+
+
+def test_per_device_override_floors_any_battery() -> None:
+    """An explicit override holds even a Venus at a minimum discharge."""
+    venus = ACBatteryWithStartupThreshold(
+        "venus", device_type="HMG-50", startup_min=0.0
+    )
+    _, power = _run_floor_scenario(
+        [venus], surplus_watts=600.0, ticks=120, overrides={"venus": 30.0}
+    )
+    assert all(abs(p - 30) <= 2 for p in power["venus"][-20:]), power["venus"][-20:]
+
+
+def test_weight_zero_battery_is_not_woken_by_floor() -> None:
+    """A B2500 parked via distribution_weight=0 stays at 0 despite the floor."""
+    b2500 = DCOnlyBattery("b2500", device_type="HMJ-1")
+    _, power = _run_floor_scenario(
+        [b2500],
+        surplus_watts=600.0,
+        ticks=80,
+        global_min_dc=25,
+        weights={"b2500": 0.0},
+    )
+    assert max(abs(p) for p in power["b2500"][-20:]) < 1.0
+
+
+def test_manual_and_inactive_b2500_not_floored() -> None:
+    """Manual (target 0) and inactive modes are deliberate 0 — not floored."""
+    manual_b = DCOnlyBattery("manual_b", device_type="HMJ-1")
+    _, power = _run_floor_scenario(
+        [manual_b],
+        surplus_watts=600.0,
+        ticks=60,
+        global_min_dc=25,
+        manual=frozenset({"manual_b"}),
+    )
+    assert max(abs(p) for p in power["manual_b"][-20:]) < 1.0
+
+    inactive_b = DCOnlyBattery("inactive_b", device_type="HMJ-1")
+    _, power = _run_floor_scenario(
+        [inactive_b],
+        surplus_watts=600.0,
+        ticks=60,
+        global_min_dc=25,
+        inactive=frozenset({"inactive_b"}),
+    )
+    assert max(abs(p) for p in power["inactive_b"][-20:]) < 1.0

--- a/tests/test_ct002_active_control.py
+++ b/tests/test_ct002_active_control.py
@@ -543,7 +543,8 @@ class TestEfficiencyOptimization:
         )
         # Use an AC-chargeable device_type so the efficiency-concentration
         # pipeline under test is not short-circuited by the DC-blind guard
-        # (see issue #338; AC_CHARGEABLE_DEVICE_PREFIXES in balancer.py).
+        # (see issue #338; device_capabilities() / _is_ac_chargeable in
+        # balancer.py).
         device._update_consumer_report("a", "A", 0, device_type="HMG-50")
         device._update_consumer_report("b", "A", 0, device_type="HMG-50")
         out_a = device._compute_smooth_target([-200, 0, 0], "a")

--- a/web/ts/app.ts
+++ b/web/ts/app.ts
@@ -11,6 +11,7 @@ import {
   CT_BASIC,
   CT_ACTIVE,
   CT_BALANCER,
+  CT_DC_KEEPALIVE,
   CT_EFFICIENCY,
   CT_SATURATION,
   MARSTEK_FIELDS,
@@ -476,6 +477,7 @@ function ctCard(): HTMLElement | null {
     el("div", { class: "field-grid" }, CT_BASIC.map((fl) => fieldControl(fl, f, {}))),
     group("Active control", CT_ACTIVE, true),
     group("Multi-battery balancing", CT_BALANCER),
+    group("DC battery keep-alive", CT_DC_KEEPALIVE),
     group("Efficiency optimization (AC batteries only)", CT_EFFICIENCY),
     group("Saturation handling", CT_SATURATION),
   ]);

--- a/web/ts/generate.ts
+++ b/web/ts/generate.ts
@@ -8,6 +8,7 @@ import {
   CT_BASIC,
   CT_ACTIVE,
   CT_BALANCER,
+  CT_DC_KEEPALIVE,
   CT_EFFICIENCY,
   CT_SATURATION,
   MARSTEK_FIELDS,
@@ -110,7 +111,14 @@ function ctSection(state: State, sectionName: string): string {
   const ct = state.ct || {};
   const f = ct.fields || {};
   const lines = [`[${sectionName}]`];
-  const groups = [CT_BASIC, CT_ACTIVE, CT_BALANCER, CT_EFFICIENCY, CT_SATURATION];
+  const groups = [
+    CT_BASIC,
+    CT_ACTIVE,
+    CT_BALANCER,
+    CT_DC_KEEPALIVE,
+    CT_EFFICIENCY,
+    CT_SATURATION,
+  ];
   for (const group of groups) {
     for (const field of group) {
       const line = iniLine(field, f[field.key]);
@@ -369,6 +377,11 @@ function ct002OptionalBlocks(ct: { fields: Fields } | undefined): string[] {
   pushBool(bal, "FAIR_DISTRIBUTION", "fair_distribution");
   for (const fld of CT_BALANCER) {
     if (fld.key === "FAIR_DISTRIBUTION") continue;
+    if (!isBlank(ctVal(fld.key))) bal.push(`${fld.ey}: ${ctVal(fld.key)}`);
+  }
+  // MIN_DC_OUTPUT is a per-battery knob in the UI, but its ESPHome key lives
+  // under the same `balancer:` block.
+  for (const fld of CT_DC_KEEPALIVE) {
     if (!isBlank(ctVal(fld.key))) bal.push(`${fld.ey}: ${ctVal(fld.key)}`);
   }
   for (const fld of CT_EFFICIENCY) {

--- a/web/ts/schema.ts
+++ b/web/ts/schema.ts
@@ -690,7 +690,12 @@ export const CT_BALANCER: Field[] = [
   { key: "ERROR_BOOST_MAX", ey: "error_boost_max", label: "Error boost max", help: "Maximum extra gain multiplier. Default 0.5.", type: "number", placeholder: "0.5" },
   { key: "ERROR_REDUCE_THRESHOLD", ey: "error_reduce_threshold", label: "Error reduce threshold (W)", help: "Below this imbalance, gain is scaled down. Default 20.", type: "number", placeholder: "20" },
   { key: "MAX_TARGET_STEP", ey: "max_target_step", label: "Max target step (W)", help: "Hard clamp on per-cycle target change. 0 = off.", type: "number", placeholder: "0" },
-  { key: "MIN_DC_OUTPUT", ey: "min_dc_output", label: "Min DC output (W)", help: "Minimum discharge to keep a DC battery's inverter (e.g. Marstek B2500) from switching off at 0 W and sleeping under high PV surplus. 0 = off. Only affects DC batteries; recommended >= 20.", type: "number", placeholder: "0" },
+];
+
+// Applies to each DC-only battery individually (also with a single battery,
+// independent of balancing). The ESPHome key lives under the `balancer:` block.
+export const CT_DC_KEEPALIVE: Field[] = [
+  { key: "MIN_DC_OUTPUT", ey: "min_dc_output", label: "Min DC output (W)", help: "Minimum discharge to keep a DC battery's inverter (e.g. Marstek B2500) from switching off at 0 W and sleeping under high PV surplus. Applied per DC-only battery; AC batteries (Venus) and Jupiter are unaffected. 0 = off; recommended >= 20.", type: "number", placeholder: "0" },
 ];
 
 export const CT_EFFICIENCY: Field[] = [

--- a/web/ts/schema.ts
+++ b/web/ts/schema.ts
@@ -690,6 +690,7 @@ export const CT_BALANCER: Field[] = [
   { key: "ERROR_BOOST_MAX", ey: "error_boost_max", label: "Error boost max", help: "Maximum extra gain multiplier. Default 0.5.", type: "number", placeholder: "0.5" },
   { key: "ERROR_REDUCE_THRESHOLD", ey: "error_reduce_threshold", label: "Error reduce threshold (W)", help: "Below this imbalance, gain is scaled down. Default 20.", type: "number", placeholder: "20" },
   { key: "MAX_TARGET_STEP", ey: "max_target_step", label: "Max target step (W)", help: "Hard clamp on per-cycle target change. 0 = off.", type: "number", placeholder: "0" },
+  { key: "MIN_DC_OUTPUT", ey: "min_dc_output", label: "Min DC output (W)", help: "Minimum discharge to keep a DC battery's inverter (e.g. Marstek B2500) from switching off at 0 W and sleeping under high PV surplus. 0 = off. Only affects DC batteries; recommended >= 20.", type: "number", placeholder: "0" },
 ];
 
 export const CT_EFFICIENCY: Field[] = [


### PR DESCRIPTION
## Summary

Implements a configurable minimum discharge floor (`MIN_DC_OUTPUT`) to prevent DC batteries with external inverters (Marstek B2500 family) from sleeping at 0 W under high PV surplus. This solves issue #425 where a lone B2500 would deadlock the grid at full feed-in because its inverter would switch off.

## Key Changes

- **Device capabilities model**: Replaces ad-hoc prefix checks with a unified `DeviceCapabilities` dataclass that classifies batteries into three independent capabilities (built-in inverter, AC input, DC input). This is the single source of truth for all device-type decisions.

- **AC-charge eligibility reclassified**: Unknown/empty `device_type` strings are now assumed to be modern AC-coupled batteries (issue #425), intentionally dropping the former fail-closed-to-DC default (issue #338). This prevents deadlock when device types can't be identified.

- **MIN_DC_OUTPUT floor**: New global `min_dc_output` config option (default 0 = disabled) that holds B2500-family batteries at a minimum discharge to keep their external inverter awake. Also supports per-device overrides via MQTT.

- **Floor eligibility**: Only applies to batteries with no built-in inverter and no AC input (B2500 family: `HMA*`, `HMJ*`, `HMK*`). Venus and Jupiter are unaffected because they have built-in inverters.

- **Respects user intent**: The floor does not override explicit user choices—batteries parked via `distribution_weight=0`, manual mode, or inactive mode stay at 0.

- **Home Assistant integration**: New "Min DC Output" number entity in MQTT discovery, only shown for B2500-family batteries where it has an effect.

## Implementation Details

- Python and C++ implementations are kept in parity (both `src/astrameter/ct002/balancer.py` and `esphome/components/ct002/balancer.cpp`).
- The floor is applied after the auto-path target computation, wrapping the result to enforce the minimum while preserving phase distribution.
- Configuration validation warns if `MIN_DC_OUTPUT` is set below the saturation `min_target`, which would prevent saturation detection on floored units.
- Comprehensive test coverage including parity tests between Python and C++ implementations, and scenario tests for mixed Venus/B2500 setups.

https://claude.ai/code/session_01BE7uMJDKMJNRPZTquxuTyM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global and per-battery configurable Min DC Output to keep DC-only batteries awake during high PV surplus.
  * Home Assistant gained a per-battery Min DC Output control that overrides the global setting for DC batteries.

* **Bug Fixes**
  * Fixed an MQTT/Home Assistant phantom "Unnamed Device" by publishing a properly grouped AstraMeter device.

* **Documentation**
  * Updated README, examples, and UI docs for DC battery keep-alive and HA controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->