### PR TITLE
Clarify config.ini file creation requirement in Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,11 @@ The AstraMeter project can be installed and run in several ways depending on you
 
 #### Installation Steps
 1. Create a directory for the project
-2. Create your `config.ini` file
+2. Create your `config.ini` file **before** starting the container. The compose
+   file bind-mounts `config.ini` as a single file, and Docker will create an
+   empty **directory** named `config.ini` if the file doesn't exist yet. (If you
+   prefer a directory mount, mount a folder to `/app/config` and point the
+   container at it with `command: ["astrameter", "-c", "config/config.ini"]`.)
 3. Use the provided `docker-compose.yaml` to start the container:
    ```bash
    docker-compose up -d


### PR DESCRIPTION
## Summary
Updated the Docker installation documentation to clarify that `config.ini` must be created **before** starting the container, and explain why this matters for Docker's bind-mount behavior.

## Changes
- Expanded step 2 of the installation instructions with a detailed explanation of Docker's bind-mount behavior
- Added a note explaining that Docker will create an empty **directory** named `config.ini` if the file doesn't exist, which breaks the setup
- Included an alternative approach for users who prefer directory-based mounts

## Details
This is a documentation-only change that addresses a common Docker gotcha: when using `docker-compose` with a bind-mount for a single file, if that file doesn't exist on the host, Docker creates a directory instead. This prevents the application from reading the configuration file. The updated documentation now makes this requirement explicit and provides guidance for both standard and alternative mounting strategies.

https://claude.ai/code/session_01WmMzjUTh9EpQLo4LjXCzMT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker installation instructions to clarify configuration file setup. Now explicitly requires creating `config.ini` before starting the container and provides alternative mounting approaches for improved setup flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->