### PR TITLE
Fix HomeWizard Online sensor flapping on broken P1 dongle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Fixed** the HomeWizard powermeter's MQTT Insights **Online** sensor flapping on/off while the P1 meter is in a broken state. A stalled dongle keeps accepting the WebSocket and replays a single cached reading on every watchdog reconnect, which briefly reset the freshness window; AstraMeter now treats the source as online only while readings flow as a continuous stream, so the sensor stays off until live data resumes ([#427](https://github.com/tomquist/astrameter/issues/427)).
+
 
 ## 2.1.2
 

--- a/src/astrameter/powermeter/homewizard.py
+++ b/src/astrameter/powermeter/homewizard.py
@@ -59,6 +59,12 @@ class HomeWizardPowermeter(Powermeter):
         # Read-only health flag for stream_online(): set once the WebSocket is
         # up and subscribed, cleared whenever the connection drops.
         self._connected = False
+        # True only while measurements arrive as a *continuous* stream (each one
+        # before the previous goes stale).  A broken P1 dongle still accepts the
+        # WebSocket and replays a single cached value every time the watchdog
+        # force-reconnects; that lone sample would otherwise reset the freshness
+        # window and flap the "Online" sensor on/off.  See stream_online().
+        self._stream_healthy = False
         self._session: aiohttp.ClientSession | None = None
         self._ws_task: asyncio.Task[None] | None = None
         self._message_event = asyncio.Event()
@@ -89,6 +95,7 @@ class HomeWizardPowermeter(Powermeter):
         self.values = None
         self._last_measurement_time = None
         self._connected = False
+        self._stream_healthy = False
         self._message_event = asyncio.Event()
         self._fresh_measurement_event = asyncio.Event()
         self._session = aiohttp.ClientSession()
@@ -222,14 +229,33 @@ class HomeWizardPowermeter(Powermeter):
         else:
             return
 
+        now = self._clock()
+        max_age = self._max_measurement_age_seconds
+        prev = self._last_measurement_time
+        if max_age <= 0:
+            # Staleness check disabled: treat every sample as a live stream.
+            self._stream_healthy = True
+        else:
+            # Healthy only if this sample arrived before the previous one went
+            # stale.  A lone sample after a longer gap (e.g. the single cached
+            # value a broken dongle replays on each reconnect) is not a live
+            # stream, so it must not flip stream_online() back on.
+            self._stream_healthy = prev is not None and (now - prev) <= max_age
+
         self.values = values
-        self._last_measurement_time = self._clock()
+        self._last_measurement_time = now
         self._message_event.set()
         self._fresh_measurement_event.set()
 
     def stream_online(self) -> bool | None:
-        return self._connected and stream_fresh(
-            self._last_measurement_time, self._max_measurement_age_seconds, self._clock
+        return (
+            self._connected
+            and self._stream_healthy
+            and stream_fresh(
+                self._last_measurement_time,
+                self._max_measurement_age_seconds,
+                self._clock,
+            )
         )
 
     async def get_powermeter_watts(self) -> list[float]:

--- a/src/astrameter/powermeter/homewizard_test.py
+++ b/src/astrameter/powermeter/homewizard_test.py
@@ -250,19 +250,95 @@ async def test_stream_online_true_when_connected_and_fresh():
     clock = _FakeClock()
     pm = _create_powermeter(max_measurement_age_seconds=30.0, clock=clock)
     pm._connected = True
+    # A single sample is not yet a live stream; a second one arriving before
+    # the first goes stale establishes continuous flow.
     pm._handle_measurement({"power_w": 100})
+    clock.advance(1.0)
+    pm._handle_measurement({"power_w": 110})
     assert pm.stream_online() is True
     clock.advance(29.0)
     assert pm.stream_online() is True
+
+
+async def test_stream_online_false_after_single_sample():
+    """One sample alone is not a continuous stream — a broken dongle that
+    replays a single cached value on reconnect must not read as online."""
+    clock = _FakeClock()
+    pm = _create_powermeter(max_measurement_age_seconds=30.0, clock=clock)
+    pm._connected = True
+    pm._handle_measurement({"power_w": 100})
+    assert pm.stream_online() is False
 
 
 async def test_stream_online_false_when_connected_but_stale():
     clock = _FakeClock()
     pm = _create_powermeter(max_measurement_age_seconds=30.0, clock=clock)
     pm._connected = True
+    # Establish a live stream, then let it go stale.
     pm._handle_measurement({"power_w": 100})
+    clock.advance(1.0)
+    pm._handle_measurement({"power_w": 110})
     clock.advance(31.0)
     assert pm.stream_online() is False
+
+
+async def test_stream_online_does_not_flap_on_reconnect_replay():
+    """Regression for the flapping "Online" sensor (#427): a broken P1 dongle
+    keeps accepting the WebSocket and replays one cached value on every
+    watchdog-triggered reconnect.  Each lone sample resets the freshness
+    window, but it is not a live stream, so stream_online() must stay False
+    instead of flapping on/off — and recover only once samples flow again.
+    """
+    clock = _FakeClock()
+    pm = _create_powermeter(max_measurement_age_seconds=30.0, clock=clock)
+    pm._connected = True
+
+    # Healthy stream, then it stalls and goes stale → offline.
+    pm._handle_measurement({"power_w": 100})
+    clock.advance(1.0)
+    pm._handle_measurement({"power_w": 110})
+    assert pm.stream_online() is True
+
+    # Simulate three reconnect cycles, each delivering a single cached sample
+    # ~50s apart (watchdog 45s + reconnect).  Freshness resets each time, but
+    # the lone sample must never read as online.
+    for _ in range(3):
+        clock.advance(50.0)
+        pm._handle_measurement({"power_w": 110})
+        assert pm.stream_online() is False
+
+    # P1 recovers: samples resume at the normal ~1s cadence.  The first
+    # resumed sample still follows a long gap, the next establishes flow.
+    clock.advance(1.0)
+    pm._handle_measurement({"power_w": 120})
+    assert pm.stream_online() is True
+
+
+async def test_stream_online_stays_online_across_brief_reconnect():
+    """A short blip (reconnect well within the freshness window) keeps the
+    stream healthy — only gaps longer than max age break continuity."""
+    clock = _FakeClock()
+    pm = _create_powermeter(max_measurement_age_seconds=30.0, clock=clock)
+    pm._connected = True
+    pm._handle_measurement({"power_w": 100})
+    clock.advance(1.0)
+    pm._handle_measurement({"power_w": 110})
+    # ~6s gap (ws close + reconnect), still inside the 30s window.
+    clock.advance(6.0)
+    pm._handle_measurement({"power_w": 120})
+    assert pm.stream_online() is True
+
+
+async def test_stream_online_healthy_when_staleness_disabled():
+    """With max_age=0 the staleness check is disabled, so any sample on a
+    connected stream counts as online."""
+    clock = _FakeClock()
+    pm = _create_powermeter(max_measurement_age_seconds=0.0, clock=clock)
+    pm._connected = True
+    pm._handle_measurement({"power_w": 100})
+    assert pm.stream_online() is True
+    clock.advance(100000.0)
+    assert pm.stream_online() is True
 
 
 def test_stream_online_false_when_disconnected_even_if_fresh():


### PR DESCRIPTION
## Summary

Fixes the HomeWizard powermeter's MQTT Insights **Online** sensor flapping on/off when the P1 meter enters a broken state where the dongle keeps accepting the WebSocket but replays a single cached reading on every watchdog-triggered reconnect.

## Problem

A stalled P1 dongle would accept the WebSocket connection and replay one cached measurement value every time the watchdog force-reconnected (~50s intervals). Each lone sample would reset the freshness window, causing `stream_online()` to flap between `True` and `False` as the single value alternated between fresh and stale.

## Solution

Introduced a new `_stream_healthy` flag that tracks whether measurements are arriving as a **continuous stream** (each sample before the previous goes stale), rather than just checking if the last measurement is fresh:

- **Single sample alone** → not a live stream (`_stream_healthy = False`)
- **Two or more samples within the freshness window** → continuous flow (`_stream_healthy = True`)
- **Gap longer than max age** → stream breaks (`_stream_healthy = False`)
- **Staleness disabled (max_age ≤ 0)** → any connected sample counts as online

The `stream_online()` method now requires both `_connected` and `_stream_healthy` to be true, preventing false positives from lone cached replays.

## Changes

- **`homewizard.py`**: Added `_stream_healthy` flag; updated `_handle_measurement()` to detect continuous flow; modified `stream_online()` to require stream health
- **`homewizard_test.py`**: Added comprehensive test coverage for the new behavior:
  - Single sample is not online
  - Reconnect replays don't flap the sensor
  - Brief reconnects within freshness window stay online
  - Staleness-disabled mode treats any sample as online
  - Updated existing tests to establish continuous flow before asserting online
- **`CHANGELOG.md`**: Documented the fix for users

## Testing

All new tests pass and verify the fix handles the broken dongle scenario without false positives or flapping.

https://claude.ai/code/session_01BnddEX5mwZXQLuZmZ15Lxh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HomeWizard powermeter MQTT Insights Online sensor to accurately reflect connection status, staying offline during cached data replay and only coming online with continuous live data stream.

* **Tests**
  * Expanded test coverage for powermeter stream online behavior during reconnection and data replay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->