### PR TITLE
Add Min DC Output configuration option to Home Assistant add-on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - **Added** the AVM **FRITZ!Smart Energy 250** smart-meter read head as a power source (`[FRITZ]`). AstraMeter logs into the FRITZ!Box over the AHA-HTTP-Interface (`login_sid.lua` + `getdevicelistinfos`) and reads the read head's signed grid power by AIN — positive = import, negative = feed-in. See [docs/powermeters.md](docs/powermeters.md#fritzsmart-energy-250).
+- **Added** the **Min DC Output** option to the Home Assistant add-on's Configuration tab, so it no longer requires a custom config file or MQTT to set. The web config generator's add-on target now emits it too ([#446](https://github.com/tomquist/astrameter/issues/446)).
 - **Fixed** the HomeWizard powermeter's MQTT Insights **Online** sensor flapping on/off while the P1 meter is in a broken state. A stalled dongle keeps accepting the WebSocket and replays a single cached reading on every watchdog reconnect, which briefly reset the freshness window; AstraMeter now treats the source as online only while readings flow as a continuous stream, so the sensor stays off until live data resumes ([#427](https://github.com/tomquist/astrameter/issues/427)).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next
 
 - **Added** the AVM **FRITZ!Smart Energy 250** smart-meter read head as a power source (`[FRITZ]`). AstraMeter logs into the FRITZ!Box over the AHA-HTTP-Interface (`login_sid.lua` + `getdevicelistinfos`) and reads the read head's signed grid power by AIN — positive = import, negative = feed-in. See [docs/powermeters.md](docs/powermeters.md#fritzsmart-energy-250).
-- **Added** the **Min DC Output** option to the Home Assistant add-on's Configuration tab, so it no longer requires a custom config file or MQTT to set. The web config generator's add-on target now emits it too ([#446](https://github.com/tomquist/astrameter/issues/446)).
+- **Added** the **Min DC Output** option to the Home Assistant add-on's Configuration tab, so it no longer requires a custom config file to set. The web config generator's add-on target now emits it too ([#446](https://github.com/tomquist/astrameter/issues/446)).
 - **Fixed** the HomeWizard powermeter's MQTT Insights **Online** sensor flapping on/off while the P1 meter is in a broken state. A stalled dongle keeps accepting the WebSocket and replays a single cached reading on every watchdog reconnect, which briefly reset the freshness window; AstraMeter now treats the source as online only while readings flow as a continuous stream, so the sensor stays off until live data resumes ([#427](https://github.com/tomquist/astrameter/issues/427)).
 
 

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -40,6 +40,7 @@ options:
   marstek_password: ""
   min_efficient_power: 0
   efficiency_rotation_interval: 900
+  min_dc_output: 0
   log_level: "info"
 schema:
   power_input_alias: str
@@ -53,6 +54,7 @@ schema:
   marstek_password: password?
   min_efficient_power: int(0,)?
   efficiency_rotation_interval: int(1,)?
+  min_dc_output: float(0,)?
   log_level: list(critical|error|warning|info|debug)
   power_offset: str?
   power_multiplier: str?

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -80,6 +80,11 @@ else
         efficiency_rotation_interval="$(bashio::config 'efficiency_rotation_interval')"
     fi
 
+    min_dc_output=""
+    if bashio::config.has_value 'min_dc_output'; then
+        min_dc_output="$(bashio::config 'min_dc_output')"
+    fi
+
     # Generate default config
     {
         echo "[GENERAL]"
@@ -95,17 +100,20 @@ else
             echo "CT_MAC=$ct_mac"
             [ -n "$min_efficient_power" ] && echo "MIN_EFFICIENT_POWER=$min_efficient_power"
             [ -n "$efficiency_rotation_interval" ] && echo "EFFICIENCY_ROTATION_INTERVAL=$efficiency_rotation_interval"
+            [ -n "$min_dc_output" ] && echo "MIN_DC_OUTPUT=$min_dc_output"
             echo ""
             echo "[CT003]"
             echo "CT_MAC=$ct_mac"
             [ -n "$min_efficient_power" ] && echo "MIN_EFFICIENT_POWER=$min_efficient_power"
             [ -n "$efficiency_rotation_interval" ] && echo "EFFICIENCY_ROTATION_INTERVAL=$efficiency_rotation_interval"
+            [ -n "$min_dc_output" ] && echo "MIN_DC_OUTPUT=$min_dc_output"
             echo ""
         else
             echo "[$ct_section]"
             echo "CT_MAC=$ct_mac"
             [ -n "$min_efficient_power" ] && echo "MIN_EFFICIENT_POWER=$min_efficient_power"
             [ -n "$efficiency_rotation_interval" ] && echo "EFFICIENCY_ROTATION_INTERVAL=$efficiency_rotation_interval"
+            [ -n "$min_dc_output" ] && echo "MIN_DC_OUTPUT=$min_dc_output"
             echo ""
         fi
 

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -32,6 +32,9 @@ configuration:
   efficiency_rotation_interval:
     name: Efficiency Rotation Interval
     description: "Seconds between rotating which battery has priority when Min Efficient Power is active (default 900). Ensures fair wear across batteries by periodically swapping which batteries are active and which are idled. Minimum value is 1. Only applies to CT002/CT003 device types."
+  min_dc_output:
+    name: Min DC Output
+    description: "Minimum discharge (in watts) to keep a DC battery's inverter (e.g. Marstek B2500) from switching off at 0 W and falling asleep under high PV surplus. Applies per battery and only affects DC-only batteries without their own inverter (Venus and Jupiter are unaffected). Set to 0 to disable (default); recommended >= 20. Only applies to CT002/CT003 device types."
   marstek_auto_register_ct_device:
     name: Auto-register Managed CT Device (Marstek)
     description: "If enabled, the app signs in to your Marstek account at startup and ensures one managed fake CT device exists for each emulated CT type (ct002 -> HME-4, ct003 -> HME-3). Existing matching devices are reused to avoid duplicates."

--- a/web/ts/generate.test.ts
+++ b/web/ts/generate.test.ts
@@ -257,13 +257,14 @@ const haOpts = generateHomeAssistant({
       },
     },
   ],
-  ct: { fields: { CT_MAC: "abc123" } },
+  ct: { fields: { CT_MAC: "abc123", MIN_DC_OUTPUT: "30" } },
 });
 has(haOpts, "power_input_alias: \"sensor.grid_power\"", "ha-opts: power input alias");
 has(haOpts, "device_types: \"ct002\"", "ha-opts: device types");
 has(haOpts, "throttle_interval: 2", "ha-opts: throttle interval");
 has(haOpts, "wait_for_next_message: false", "ha-opts: wait for next message");
 has(haOpts, "ct_mac: \"abc123\"", "ha-opts: ct mac");
+has(haOpts, "min_dc_output: 30", "ha-opts: min dc output");
 has(haOpts, 'power_offset: "-20"', "ha-opts: power offset (quoted str)");
 has(haOpts, "smooth_target_alpha: 0.3", "ha-opts: smoothing alpha");
 has(haOpts, "deadband: 5", "ha-opts: deadband");
@@ -285,6 +286,7 @@ const haMin = generateHomeAssistant({
 lacks(haMin, "hampel_window", "ha-opts: omits unset hampel");
 lacks(haMin, "pid_kp", "ha-opts: omits unset pid");
 lacks(haMin, "deadband", "ha-opts: omits unset deadband");
+lacks(haMin, "min_dc_output", "ha-opts: omits unset min dc output");
 
 // ── Home Assistant add-on options: calculate from in/out ─────────────────────
 const haCalc = generateHomeAssistant({

--- a/web/ts/generate.ts
+++ b/web/ts/generate.ts
@@ -639,11 +639,12 @@ export function generateHomeAssistant(state: State): string {
   add("wait_for_next_message", !isBlank(g.waitForNextMessage) ? g.waitForNextMessage : tuning.WAIT_FOR_NEXT_MESSAGE);
   add("dedupe_time_window", g.dedupeTimeWindow);
 
-  // CT identity / efficiency options.
+  // CT identity / efficiency / DC keep-alive options.
   const ctf = (state.ct && state.ct.fields) || {};
   add("ct_mac", ctf.CT_MAC);
   add("min_efficient_power", ctf.MIN_EFFICIENT_POWER);
   add("efficiency_rotation_interval", ctf.EFFICIENCY_ROTATION_INTERVAL);
+  add("min_dc_output", ctf.MIN_DC_OUTPUT);
 
   // Signal-conditioning filters (transform, smoothing, deadband, hampel, pid).
   // Option names are the lower-cased INI keys; throttle/wait handled above.


### PR DESCRIPTION
## Summary
Adds the **Min DC Output** configuration option to the Home Assistant add-on, allowing users to set a minimum discharge threshold for DC battery inverters directly from the add-on's Configuration tab, rather than requiring manual config file edits.

## Changes
- **ha_addon/config.yaml**: Added `min_dc_output` option (default 0, accepts float ≥ 0) and schema validation
- **ha_addon/run.sh**: Reads `min_dc_output` from config and emits `MIN_DC_OUTPUT` to all CT sections (CT002, CT003, and custom)
- **ha_addon/translations/en.yaml**: Added user-facing name and description explaining the option's purpose (prevents inverter sleep under high PV surplus, applies to DC-only batteries)
- **web/ts/generate.ts**: Updated config generator to emit `min_dc_output` from CT field data
- **web/ts/generate.test.ts**: Added test coverage for the new option (presence when set, absence when unset)
- **CHANGELOG.md**: Documented the feature addition with issue reference

## Implementation Details
- The option is only applied to CT002/CT003 device types (as noted in the description)
- Follows the same conditional emission pattern as existing CT options (`min_efficient_power`, `efficiency_rotation_interval`)
- Web config generator correctly omits the option when not set, maintaining backward compatibility

https://claude.ai/code/session_01HgT63b6YakwGcgBwFYD2eE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * "Min DC Output" configuration option is now available directly in the Home Assistant add-on Configuration tab, allowing per-battery discharge threshold control for DC-only device types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->