### PR TITLE
docs: expand CT002/CT003 protocol notes + add Marstek MQTT/HTTP reference

### DIFF
--- a/docs/ct002-capture-analysis.md
+++ b/docs/ct002-capture-analysis.md
@@ -69,10 +69,14 @@ Likely (high confidence):
 - `v1..v3` are per-phase-like values
 - `v4` behaves like a total/aggregate value (often close to sum with small +/- drift)
 
-Partially confirmed (targeted experiments still useful for edge-cases):
+Now resolved (see [ct002-ct003-protocol.md](ct002-ct003-protocol.md#response-fields)):
 
-- later fields after `v4` are largely consistent with status/counter/energy-style telemetry.
-- remaining uncertainty is mainly field-by-field naming confidence under all operating states.
+- The numeric layout is fixed: 4 phase/total powers, 4 "active" counts, signed
+  RSSI, an 8‑bit wrapping `info_idx`, a 10‑value charge/discharge block (an
+  unassigned `x` bucket, phases A/B/C, and a combined `ABC` bucket), and (CT003
+  only) 4 trailing tariff energy registers.
+- `v1..v3` are the per‑phase powers and `v4` is the total — as suspected here.
+- The `chrg`/`dchrg` block is signed 16‑bit, so it saturates at ±32767 W.
 
 ## 4) Scenario comparison: single-active vs multi-active
 
@@ -166,9 +170,14 @@ Legend:
 
 - Newer traces with explicit discharge scenarios confirm the same aggregate logic as charge traces,
   but mapped to the `*_dchrg_power` block instead of `*_chrg_power`.
-- Field hypothesis update:
-  - `F25` and likely `F26` are plausible CT003 import/export counter-like values (scaling still unknown).
-  - `F27` and `F28` may also be meter-state/counter related, but semantics are still not fully confirmed.
+- Field hypothesis update — **now resolved** (see
+  [ct002-ct003-protocol.md](ct002-ct003-protocol.md#ct003-energy-fields-fields-2528)):
+  - `F25`–`F28` are four trailing unsigned‑32‑bit fields that **only CT003
+    (`HME-3`) carries** (CT002/`HME-4` stops at field 24). They are the cumulative
+    import/export energy registers CT003 reads from a P1/SML smart meter,
+    matching the four standard OBIS codes `1-0:1.8.1`, `1-0:1.8.2`, `1-0:2.8.1`,
+    `1-0:2.8.2`. Exact scaling (carried as kWh with three decimals) is the
+    remaining unknown.
 
 - Two devices (battery B and battery C) both report phase `B` in these captures.
   - So phase label is not guaranteed to be globally unique per device.
@@ -181,9 +190,11 @@ For emulator/protocol implementation:
 - Parse request tail strictly as:
   - `phase = fields[4]`
   - `power = int(fields[5])`
-- Accept phase `A`, `B`, `C` for normal aggregation; accept `0` or empty as inspection mode (respond
-  but do not aggregate). Reject other phase values.
-- Treat later response fields as implementation-defined unless verified with controlled experiments.
+- Accept phase `A`, `B`, `C`, `D` for normal aggregation; accept `0` or empty as inspection mode
+  (respond but do not aggregate).
+- The full response field layout (and per‑field types/widths) is now documented in
+  [ct002-ct003-protocol.md](ct002-ct003-protocol.md#response-fields). Controlled
+  experiments are now only needed for the CT003 energy‑register scaling.
 
 ## 9) Suggested follow-up experiments
 

--- a/docs/ct002-ct003-protocol.md
+++ b/docs/ct002-ct003-protocol.md
@@ -11,6 +11,9 @@ The CT002 and CT003 share the **same protocol**. The only difference is the CT t
 - **CT002:** `HME-4`
 - **CT003:** `HME-3`
 
+CT003 additionally reads a P1/SML smart meter, so it carries cumulative energy
+data that CT002 does not (see "CT003 energy fields" below).
+
 ## Transport
 
 - **Protocol:** UDP
@@ -32,11 +35,14 @@ ETX (0x03)
 
 ### Length
 `LENGTH` is the **total byte length** of the entire packet, including the length digits and checksum bytes.
-Because the length field is part of the packet, you must compute it iteratively until the digit count matches.
+Because the length field is part of the packet, you must compute it iteratively until the digit count matches
+(the CT does the same: it sizes the body, then adds the framing/checksum bytes and one extra byte once the
+length crosses from two to three digits).
 
 ### Checksum
-The checksum is a 2‑character ASCII hex string (lowercase in observed traffic). It is the XOR of all bytes from the
-**start of SOH up to and including ETX**.
+The checksum is a 2‑character ASCII hex string. It is the XOR of all bytes from the
+**start of SOH up to and including ETX**. Parse it case‑insensitively: the CT emits uppercase `A`–`F`
+for two‑digit values and may emit a leading space for small values.
 
 Pseudo‑code:
 
@@ -51,26 +57,36 @@ checksum = f"{xor:02x}".encode("ascii")
 
 Request payload fields (consumer → CT):
 
-1. **meter_dev_type** — device type of the requester (copied through into the response)
-2. **meter_mac_code** — battery MAC (12 hex chars, from Marstek app device management)
-3. **hhm_dev_type** — CT type (`HME-4` or `HME-3`)
-4. **hhm_mac_code** — CT MAC (12 hex chars, from Marstek app device management)
-5. **phase** — phase identifier (`A`, `B`, `C`) observed in real traffic; any other value (observed: `0`, empty, `D`) means inspection mode
-6. **phase_power** — signed integer watts for the phase in field 5
+| # | Field | Type / width | Notes |
+|---|-------|--------------|-------|
+| — | length | 16‑bit int | leading digits of the framed packet |
+| 1 | **meter_dev_type** | string ≤ 10 | requester type (e.g. `HMG-50`); copied into the response |
+| 2 | **meter_mac_code** | string ≤ 30 | battery MAC (12 hex chars in practice, from the Marstek app) |
+| 3 | **hhm_dev_type** | string ≤ 8 | CT type (`HME-4` or `HME-3`) |
+| 4 | **hhm_mac_code** | string ≤ 13 | CT MAC (12 hex chars) |
+| 5 | **phase** | single char | `A`/`B`/`C` = physical phase; `D` = **combined** (see "Phase selection"); `0`/empty = **unassigned / inspection** |
+| 6 | **phase_power** | 16‑bit signed | watts for the phase in field 5 (range −32768…32767) |
+| 7 | **participate** | unsigned byte | **optional**; `0` = do **not** aggregate this reporter, non‑zero = include. **Defaults to `1`** when the field is absent |
 
-This mapping is based on real packet captures. Older public scripts may show `0|0` placeholders,
-but observed live traffic carries `phase|power` in these two fields.
+Fields 1–6 appear in all observed traffic; field 7 is the newer "UDP protocol v4"
+addition and may be omitted by older senders (in which case the CT treats it as `1`).
+Whether it is sent is **model‑dependent**: the Venus class (HMG‑50, VNSE3‑0)
+builds only fields 1–6, while the B2500 class (HMJ) builds a 7th field (its
+request template carries an extra trailing integer). Power is sent as a 16‑bit
+value by the Venus class and a 32‑bit value by the B2500 class; both fit the
+same ASCII wire field.
 
-### Inspection mode (any phase other than `A`/`B`/`C`)
+### Phase handling and inspection mode
 
-When a device sends a phase that is not `A`, `B`, or `C` (observed markers
-include `0`, empty, and `D` from newer Marstek firmwares), it is in
-**inspection mode** — determining which
-phase it is connected to. The emulator:
-
-- **Responds** to the request (so the device can continue its phase detection)
-- **Does not** add the device's reported power to the per-phase aggregates (the device has not yet
-  committed to a phase)
+- The CT accepts `A`, `B`, `C` (physical phases) and `D` (combined / 合相 — see
+  [Phase selection](#phase-selection-and-the-combined-abc-mode)) as committed phase labels.
+- Any other value (observed: `0`, empty) is the **`'0'` unassigned bucket** — the
+  **inspection mode** a device uses while it is still determining which phase it is on.
+- The emulator:
+  - **Responds** to the request (so the device can continue its phase detection), and
+  - **Does not** add an unassigned/inspection reporter's power to a committed‑phase aggregate.
+- The `participate` flag (field 7) is an additional, explicit gate: even a fully phase‑committed reporter
+  is **excluded from aggregation** when it sends `0`.
 
 ### Example Request (human readable)
 
@@ -80,57 +96,291 @@ phase it is connected to. The emulator:
 
 ## Response Fields
 
-Response payload fields (CT → consumer):
+Response payload fields (CT → consumer). **Identity order differs from the
+request:** the response leads with the **CT/meter** type/MAC, then the **storage**
+type/MAC (`…|HME-3|<ct_mac>|HMG-50|<battery_mac>|…`) — the reverse of the request's
+storage‑then‑CT order. This is confirmed by the captures, the CT, and the storage
+side (which reads token 0 as its `meter_dev_type` = the CT type). It matches
+AstraMeter's `RESPONSE_LABELS`.
 
-1. **meter_dev_type** — echoes request field 1
-2. **meter_mac_code** — echoes request field 2
-3. **hhm_dev_type** — CT type (`HME-4` or `HME-3`)
-4. **hhm_mac_code** — CT MAC
-5. **A_phase_power** — integer watts for phase A
-6. **B_phase_power** — integer watts for phase B
-7. **C_phase_power** — integer watts for phase C
-8. **total_power** — integer watts (sum of phases)
-9. **A_chrg_nb** — set to `1` if phase A aggregate is non-zero, else `0`
-10. **B_chrg_nb** — set to `1` if phase B aggregate is non-zero, else `0`
-11. **C_chrg_nb** — set to `1` if phase C aggregate is non-zero, else `0`
-12. **ABC_chrg_nb** — currently always `0`
-13. **wifi_rssi** — configured RSSI value
-14. **info_idx** — incrementing response index (`0..255`, wraps)
-15. **x_chrg_power** — currently `0`
-16. **A_chrg_power** — phase A aggregate when negative, else `0`
-17. **B_chrg_power** — phase B aggregate when negative, else `0`
-18. **C_chrg_power** — phase C aggregate when negative, else `0`
-19. **ABC_chrg_power** — currently `0`
-20. **x_dchrg_power** — currently `0`
-21. **A_dchrg_power** — phase A aggregate when positive, else `0`
-22. **B_dchrg_power** — phase B aggregate when positive, else `0`
-23. **C_dchrg_power** — phase C aggregate when positive, else `0`
-24. **ABC_dchrg_power** — currently `0`
+The numeric section uses **four phase buckets plus one "unassigned" bucket**:
 
-This list describes current emulator behavior as implemented.
+- `x_*` — the **`'0'`/unassigned** bucket: reporters that have not committed to a phase (inspection).
+- `A_*` / `B_*` / `C_*` — the three **physical phases**.
+- `ABC_*` — the **combined / 合相** bucket: a reporter balancing against the **sum of all three phases** (see "Phase selection" below).
 
-## Multi‑consumer behavior
+| # | Field | Type / width | Meaning |
+|---|-------|--------------|---------|
+| 1 | **meter_dev_type** | string | CT/meter type (`HME-4` / `HME-3`) |
+| 2 | **meter_mac_code** | string | CT MAC |
+| 3 | **hhm_dev_type** | string | storage type (echoes request, e.g. `HMG-50`) |
+| 4 | **hhm_mac_code** | string | storage MAC (echoes request battery MAC) |
+| 5 | **A_phase_power** | int ¹ | watts, phase A |
+| 6 | **B_phase_power** | int ¹ | watts, phase B |
+| 7 | **C_phase_power** | int ¹ | watts, phase C |
+| 8 | **total_power** | 32‑bit int | watts, total |
+| 9 | **A_chrg_nb** | unsigned byte | count of reporters on phase A |
+| 10 | **B_chrg_nb** | unsigned byte | count of reporters on phase B |
+| 11 | **C_chrg_nb** | unsigned byte | count of reporters on phase C |
+| 12 | **ABC_chrg_nb** | unsigned byte | count of reporters in the combined (`ABC`) bucket |
+| 13 | **wifi_rssi** | **signed** byte | RSSI (negative dBm) |
+| 14 | **info_idx** | unsigned byte | response index, `0..255`, wraps; the consumer uses it to drop duplicate responses |
+| 15 | **x_chrg_power** | 16‑bit signed ² | unassigned‑bucket charge sum (negative powers) |
+| 16 | **A_chrg_power** | 16‑bit signed ² | phase A charge sum (negative powers) |
+| 17 | **B_chrg_power** | 16‑bit signed ² | phase B charge sum |
+| 18 | **C_chrg_power** | 16‑bit signed ² | phase C charge sum |
+| 19 | **ABC_chrg_power** | 16‑bit signed ² | combined‑bucket charge sum |
+| 20 | **x_dchrg_power** | 16‑bit signed ² | unassigned‑bucket discharge sum (positive powers) |
+| 21 | **A_dchrg_power** | 16‑bit signed ² | phase A discharge sum (positive powers) |
+| 22 | **B_dchrg_power** | 16‑bit signed ² | phase B discharge sum |
+| 23 | **C_dchrg_power** | 16‑bit signed ² | phase C discharge sum |
+| 24 | **ABC_dchrg_power** | 16‑bit signed ² | combined‑bucket discharge sum |
+| 25 | **low_price_ele_in** | 32‑bit unsigned | (CT003 only) off‑peak import energy |
+| 26 | **normal_price_ele_in** | 32‑bit unsigned | (CT003 only) peak import energy |
+| 27 | **low_price_ele_out** | 32‑bit unsigned | (CT003 only) off‑peak export energy |
+| 28 | **normal_price_ele_out** | 32‑bit unsigned | (CT003 only) peak export energy |
 
-The emulator tracks per‑consumer `phase` + `phase_power` from the request fields (only when phase is
-`A`, `B`, or `C`; inspection-mode requests carrying any other phase value — observed: `0`, empty, `D` — are responded to but not aggregated).
-If a consumer stops sending updates for a while, its reported values are evicted after a configurable
-TTL (`CONSUMER_TTL`).
+¹ **Field‑width difference between models:** on **CT002 (`HME-4`)** the three
+per‑phase powers (fields 5–7) are **16‑bit signed** (±32767 W); the total
+(field 8) is 32‑bit. On **CT003 (`HME-3`)** all four are 32‑bit.
+
+² The charge/discharge breakdown (fields 15–24) is **16‑bit signed on both
+models**, so each value saturates at ±32767 W.
+
+These names match `RESPONSE_LABELS` in `src/astrameter/ct002/protocol.py`. In
+ordinary single/three‑phase traffic the `x_*` and `ABC_*` buckets are usually
+`0` (nobody is mid‑inspection or in combined mode), which is why earlier capture
+analysis saw the 4th slot as "always 0".
+
+### Phase selection and the combined (`ABC`) mode
+
+The storage device picks the request **phase** character from a `phase_t`
+configuration value:
+
+| `phase_t` | request phase char | response bucket used |
+|-----------|--------------------|----------------------|
+| 0 | `'0'` | `x_*` (unassigned / still detecting) |
+| 1 | `A` | `A_*` |
+| 2 | `B` | `B_*` |
+| 3 | `C` | `C_*` |
+| 4 | `D` | `ABC_*` (combined) |
+
+So **phase `D` on the wire is not a fourth physical phase** — it selects the
+**combined / 合相** aggregation. A consumer in `phase_t = 4` tells the CT to lump
+it into the `ABC` bucket and reads back `ABC_chrg_power` / `ABC_dchrg_power`,
+i.e. it balances against the **sum of all three phases** (whole‑home net grid
+power) rather than its own phase. This is the mode behind a B2500 reporting
+phase `D`: the meter is wired across a 3‑phase supply and the battery is set to
+compensate the **total** grid exchange, not a single phase. The `x` bucket is
+the transient state while a device is still detecting its phase (`phase_t = 0`).
+
+> The AstraMeter emulator models phases `A`/`B`/`C` and folds `D` and any
+> non‑`A/B/C` value into the unassigned/inspection path; it does not yet
+> implement the combined (`ABC`) control mode.
+
+### CT003 energy fields (fields 25–28)
+
+CT003 (`HME-3`) — but **not** CT002 (`HME-4`) — appends **four** trailing
+unsigned‑32‑bit fields, making the CT003 response **28 fields** vs. CT002's 24.
+They are the cumulative import/export energy registers CT003 reads from a
+connected P1/SML smart meter, split by tariff, named
+`low_price_ele_in`, `normal_price_ele_in`, `low_price_ele_out`,
+`normal_price_ele_out` — i.e. off‑peak/peak import and off‑peak/peak export,
+corresponding to the standard DSMR/SML registers `1-0:1.8.x` (import) and
+`1-0:2.8.x` (export). The exact scaling (the OBIS values are carried as `kWh`
+with three decimals) is the remaining unknown. The AstraMeter emulator (a
+clamp‑style CT002) does not source a smart meter and does not emit these fields.
+
+## Aggregation, eviction and response cadence
+
+The CT keeps a table of up to **9 consumer slots**, keyed by battery MAC. Each
+incoming request updates the matching slot (or allocates a free one), storing
+the reporter's IP, type, phase, signed power, and `participate` flag.
+
+Per response cycle the CT:
+
+1. **Evicts stale slots** — a slot not refreshed within ~1–2 cycles is cleared.
+2. **Builds per‑bucket aggregates** over the live slots, but only for a slot that
+   is occupied **and** has `participate != 0`:
+   - bucket by phase (`A`/`B`/`C`, the combined `ABC` bucket for phase `D`, or
+     the `x` bucket for the `'0'`/unassigned phase), and
+   - **sign‑split** the power: negative → that bucket's `*_chrg_power`,
+     positive → its `*_dchrg_power`; bump the bucket's `*_chrg_nb` count.
+3. **Replies to one slave per cycle**, round‑robin across the active slots
+   (each requester receives its own unicast response).
+
+The storage side validates each response (checksum, length, and `info_idx`
+de‑duplication) before applying it. This aggregate + sign‑split model matches
+the observed captures.
+
+## How the storage side consumes the response
+
+The battery — not the CT — drives the exchange: it is the **UDP master** and
+polls the CT on a timer (open socket → send request → parse reply). The same
+poll loop also speaks the Shelly EM / Pro JSON API when the configured meter
+type (`ct_t`) is a Shelly rather than a CT002/CT003, so the CT response is one
+of several interchangeable grid‑power sources feeding the same controller.
+
+Once a response passes validation, the storage turns it into a charge/discharge
+command in three steps:
+
+1. **Parse** the 28 fields into a record. Two kinds of numbers are kept: the
+   measured per‑phase grid power (`A/B/C_phase_power`, `total_power`) and the
+   sign‑split activity buckets (`x` / `A` / `B` / `C` / `ABC`, each with a
+   `*_chrg_power` and `*_dchrg_power`).
+2. **Select the bucket for this device** using the `phase_t` setting:
+   - `phase_t` 1/2/3 → the `A`/`B`/`C` bucket,
+   - `phase_t` 4 (and the default) → the combined **`ABC`** bucket,
+   - a separate "sum all phases" config flag overrides this to add
+     `A + B + C + ABC` (whole‑home total).
+
+   The `x`/unassigned bucket is always carried alongside so the device still
+   reacts while it is still detecting its phase. This is the consumer side of
+   the [phase selection](#phase-selection-and-the-combined-abc-mode): phase `D`
+   is exactly "read the combined bucket".
+3. **Regulate** with a closed loop (detailed below). The storage keeps an
+   inverter power **setpoint** and, each step, nudges it toward driving the
+   selected grid value to zero (self‑consumption) — it does **not** copy the
+   reading straight to the inverter.
+
+So a CT reading is an **input to an integral‑style self‑consumption controller**,
+not a direct power command. The per‑phase `*_chrg_power` / `*_dchrg_power`
+buckets additionally let several batteries on the same phase divide the load
+rather than all chasing the same target.
+
+### Steering / ramp logic (simulator‑grade)
+
+This is the exact control law the storage runs on the selected grid value. It is
+enough to reproduce the device's behavior bit‑for‑bit. Powers are in **watts**;
+the constants below are the literal values used.
+
+> **Model scope.** The float controller documented here is the **Venus class**
+> (HMG‑50, VNSE3‑0). It is **not** universal: the **B2500 class** (HMJ) runs an
+> **integer‑only** controller (its firmware has no floating‑point unit and no
+> float gain table), so while the higher‑level behavior is the same — poll the
+> meter, select the phase/combined bucket via `phase_t`, divide by the per‑phase
+> device count, and slew an inverter setpoint — its step sizing, deadband and
+> clamps use different (integer) values and are **not** the table below. The
+> B2500 also has a smaller power envelope than the Venus's ±2500 W. Treat the
+> numbers below as Venus‑class; model a B2500 with the same structure but its
+> own limits.
+
+**Per‑device persistent state**
+
+| name | meaning |
+|------|---------|
+| `setpoint` | commanded inverter power (float W); sign is the charge/discharge direction (follows the bucket convention — + discharge / − charge; the inverter‑side polarity was not independently confirmed) |
+| `ramp` | direction/acceleration counter, integer, clamped to **−5…+5** |
+| `last` | the previous step's `g` (grid value) |
+| `ref` | a reference reading captured the last time the error grew |
+| `out_min` | running minimum of `g` since the last reset |
+| `prev_g`, `prev_out` | previous grid value / own output, for the spike filter |
+
+**Inputs each step**
+
+- `g` — the selected bucket value (this phase, or the combined `ABC` bucket for
+  phase `D`; or `A+B+C+ABC` when the "sum all phases" flag is set).
+- `nb` — the `*_chrg_nb` count for that bucket (number of batteries sharing it).
+- `out` — the battery's own measured output power.
+- `hi`, `lo` — the current upper/lower **power limits** (runtime values, e.g.
+  derived from the configured max charge/discharge power and SOC headroom).
+
+**Cadence.** A regulation step is gated by a timer (~**3000 ticks**); the steps
+below run once per gate, which is why the response visibly ramps rather than
+snapping.
+
+```text
+# 1. share split across batteries on the same phase/bucket
+g = g / nb                         # nb >= 1
+
+# 2. validity / direction debounce
+#    - require the meter to be active, else reset the setpoint
+#    - a 10-tick debounce rejects a charge<->discharge sign flip until it persists
+
+# 3. deadband + spike filter
+if abs(g) < 20 and out < 1:        # +/-20 W deadband
+    return                         # hold setpoint, do nothing
+if abs(g - prev_g) > 50 and abs(out_as_int - prev_out) < 20:
+    skip_one_step()                # transient load step: act on the next sample
+prev_g = g; prev_out = out_as_int
+
+# 4. keep the setpoint inside the dynamic power window
+if setpoint > hi:                  # above the upper power limit
+    setpoint = hi - 100; ramp = -1; goto CLAMP
+if setpoint < lo:                  # below the lower power limit
+    setpoint = lo + 100; ramp =  0; goto CLAMP
+
+# 5. ramp / direction accumulator
+out_min = min(out_min, g)
+if g > last:                       # error grew since last step
+    ramp = -1 if ramp > 0 else 0   # brake / flip toward decreasing
+    ref = out_min; out_min = g
+else:                              # error steady or shrinking
+    if ramp > 0: ramp = min(ramp + 1, +5)   # accelerate same direction
+    else:        ramp = max(ramp - 1, -5)
+
+# 6. step size
+step = sqrt(abs(g*g - ref*ref)) + 10
+step = min(step, GAIN[ramp])       # gain table below
+step = min(step, abs(g))           # never overshoot the remaining error
+if ramp > 0: setpoint += step
+else:        setpoint -= step
+
+# 7. (only in work mode 5) remap setpoint through a per-step calibration table
+
+CLAMP:
+setpoint = clamp(setpoint, -2500, +2500)   # hard limit, ±2500 W (Venus E)
+apply_to_inverter(setpoint)
+last = g
+```
+
+**`GAIN[ramp]` — maximum step per cadence, in watts**
+
+| `ramp` | −5 | −4 | −3 | −2 | −1 | 0 | +1 | +2 | +3 | +4 | +5 |
+|--------|----|----|----|----|----|---|----|----|----|----|----|
+| W | 410.35 | 350.41 | 180.30 | 60.02 | 50.12 | 50.23 | 50.10 | 50.21 | 100.01 | 200.02 | 400.40 |
+
+Notes for an implementer:
+- The cap is ~50 W while `ramp` is near 0 and grows toward ~400 W at `ramp = ±5`,
+  so the longer the error persists in one direction the larger each correction —
+  a coarse acceleration curve, not a linear gain. The curve is slightly
+  asymmetric (charge vs discharge).
+- `ramp` only reaches ±5 after several consecutive steps without the error
+  growing; any step where `g` increases versus `last` brakes it back toward 0.
+- `step` is additionally bounded by `sqrt(|g² − ref²|)+10` and by `|g|`, so near
+  convergence the per‑step change collapses to a few watts.
+- The `±2500 W` clamp is the absolute hardware limit; the softer `hi`/`lo` window
+  (step 4) is what enforces the configured max charge / max discharge power (the
+  same limits the BLE/MQTT "set max charge/discharge power" commands write — e.g.
+  the discharge cap that rejects values over 800 W).
+- The final `apply_to_inverter` hands the setpoint to the power‑stage controller
+  across the inverter‑MCU boundary.
+
+> AstraMeter does not implement this storage‑side controller — when AstraMeter is
+> the active‑control authority it computes per‑battery targets itself (see below).
+> This section documents what a *real* Marstek battery does with the response so a
+> faithful battery simulator can be built.
+
+> Sign convention: in the buckets, **negative** power is charging (grid surplus
+> to absorb) and **positive** is discharging (load to cover); the controller
+> drives the selected phase's net toward zero.
+
+## Active vs. relay control (AstraMeter)
+
+The sections above describe the CT/emulator wire behavior. AstraMeter adds two
+operating modes on top:
 
 ### Relay mode (ACTIVE_CONTROL = False)
 
-When active control is disabled, the emulator behaves like a passive relay:
-- Forwards per-phase aggregates based on the latest known reports from all known consumers,
-  grouped by their reported phase.
-- Uses sign split for forwarded aggregates:
-  - negative phase sums -> `A/B/C_chrg_power` (fields 16-18)
-  - positive phase sums -> `A/B/C_dchrg_power` (fields 21-23)
+The emulator behaves like a passive relay:
+- Forwards per-phase aggregates from the latest known reports, grouped by phase.
+- Uses the sign split above (negative → `*_chrg_power`, positive → `*_dchrg_power`).
 
-Capture analysis shows this aggregate + sign-split model matches observed traffic closely. In this
-mode, each battery decides its own charge/discharge based on the relayed aggregates.
+Each battery then decides its own charge/discharge from the relayed aggregates.
 
 ### Active control mode (ACTIVE_CONTROL = True, default)
 
-When active control is enabled, the emulator becomes the control authority:
+The emulator becomes the control authority:
 - Reads grid/meter power from a configured powermeter (Tasmota, Shelly, etc.).
 - Smooths the raw reading (EMA) and splits the target across consumers.
 - Sends per-consumer targets in the response fields (`A/B/C_phase_power`, `*_chrg_power`, `*_dchrg_power`).
@@ -144,8 +394,72 @@ Additional options refine the control:
 
 In this mode, the emulator computes what each battery should do; the batteries follow the targets.
 
+## MQTT runtime‑info frame
+
+> The full MQTT protocol (connection/TLS, topics, the complete `cd` command set,
+> every payload) and the CT003 HTTP cloud reporting are documented separately in
+> [marstek-mqtt-http.md](marstek-mqtt-http.md). This section is just the
+> `cd=1`/`cd=4` frames the AstraMeter responder emulates.
+
+The same CTs also answer the Marstek app over MQTT (this is what the
+`mqtt_insights:` Marstek subsection emulates). The CT subscribes to the App
+control topic and publishes to the device control topic:
+
+```text
+subscribe: marstek_energy/<ct_type>/App/<mac>/ctrl
+publish:   marstek_energy/<ct_type>/device/<mac>/ctrl
+```
+
+Newer devices use the **`marstek_energy/…`** prefix; the older
+**`hame_energy/…`** prefix (after the `hamedata.com` cloud) is used by earlier
+devices. AstraMeter subscribes/answers on **both** prefixes.
+
+A poll arrives as a CSV `k=v` body. `cd=1` requests aggregate runtime info;
+`cd=4` (+`p1=<id>`) requests the slave list. (The App control channel carries a
+wider command set too — e.g. reset, debug‑stream toggles, error clears — but
+those are outside the scope of the meter emulator.) The reply omits any `cd=`
+echo. The aggregate (`cd=1`) field set **differs between models**:
+
+```text
+CT002 (HME-4):
+  pwr_a,pwr_b,pwr_c,pwr_t,ble_s,wif_r,fc4_v,ver_v,wif_s,slv_n,cur_d
+
+CT003 (HME-3):
+  pwr_a,pwr_b,pwr_c,pwr_t,ble_s,wif_r,fc4_v,ver_v,eng_t,wif_s,slv_n,
+  com_t,com_b,ptl_t,smt_n,har_f,sof_f,irs_f,pwr_f,frm_c,upd_t,udp_v
+```
+
+- Both start with `pwr_a/pwr_b/pwr_c/pwr_t` (per‑phase + total power) then
+  `ble_s` (BLE state), `wif_r` (Wi‑Fi RSSI), `fc4_v` (Wi‑Fi module firmware
+  string), `ver_v` (device version).
+- CT002 then carries `wif_s` (Wi‑Fi state), `slv_n` (connected slave count) and
+  `cur_d`, and stops.
+- CT003 inserts `eng_t` (cumulative energy, 64‑bit) after `ver_v`, and after
+  `wif_s,slv_n` adds a diagnostics block: `com_t/com_b` (comms), `ptl_t`
+  (protocol type), `smt_n` (smart‑meter count), `har_f/sof_f/irs_f/pwr_f`
+  (fault flags), `frm_c` (frame counter), `upd_t` (update time), `udp_v`
+  (UDP protocol version).
+
+The slave list (`cd=4`) reply uses repeated `;`‑terminated tokens, **capped at
+5 entries** and only for occupied slots:
+
+```text
+slv_ip=<ip>,slv_t=<type>,slv_p=<phase>,slv_id=<mac>;
+```
+
+> **AstraMeter responder vs. a real CT:** the AstraMeter MQTT responder
+> (`src/astrameter/mqtt_insights/marstek_mqtt.py`) does **not** reproduce these
+> layouts byte‑for‑byte — it emits a tolerant `k=v` superset in a different key
+> order, adds `kwh/n_kwh/used_kwh/fed_kwh` placeholders, and formats `cd=4` rows
+> as comma‑joined `slv_t,slv_id,slv_ip,slv_p` (no `;` terminator). The app's
+> parser (`replaceAll(' ','')` → split) is order‑independent and tolerant of
+> extra keys, so this works in practice; the layouts above are the reference for
+> what a *real* CT sends, not a spec the responder must match.
+
 ## CT MAC behavior
 
-If `CT_MAC` is configured, the CT only responds when the request `hhm_mac_code` matches `CT_MAC`.
-If `CT_MAC` is empty, the emulator accepts requests for any CT MAC and echoes the request CT MAC
-back in responses.
+The CT responds when the request `hhm_mac_code` is the wildcard `000000000000`
+**or** matches the CT's own MAC. In AstraMeter: if `CT_MAC` is configured, the
+emulator only responds when the request `hhm_mac_code` matches `CT_MAC`; if
+`CT_MAC` is empty, it accepts requests for any CT MAC and echoes the request CT
+MAC back in responses.

--- a/docs/marstek-mqtt-http.md
+++ b/docs/marstek-mqtt-http.md
@@ -1,0 +1,249 @@
+# Marstek CT002 / CT003 MQTT & HTTP (cloud / app) protocol
+
+This documents how a CT002 (`HME-4`) / CT003 (`HME-3`) talks to the Marstek
+mobile app over MQTT and to the Marstek cloud over HTTP. It is a reference for
+**replicating** that side (the `mqtt_insights:` Marstek responder emulates part
+of it). The UDP control protocol between the CT and the batteries is separate —
+see [ct002-ct003-protocol.md](ct002-ct003-protocol.md).
+
+Both models speak the same MQTT protocol. **Only the CT003 (`HME-4` = CT002 does
+not) reports to the HTTP cloud**, because only the CT003 reads a P1/SML smart
+meter with energy data worth reporting.
+
+## 1. MQTT connection
+
+| parameter | value |
+|-----------|-------|
+| transport | TLS, **port 8883** |
+| MQTT version | 3.1.1 (protocol level 4) |
+| keepalive | 30 s |
+| clean session | yes |
+| client id | **`mst_<mac>`** where `<mac>` is the 12‑hex lowercase device MAC |
+| username / password | **none** — the device authenticates with a **client certificate** |
+| broker host | **provisioned at runtime** (not hard‑coded in the image); the cloud side lives under `hamedata.com` (the HTTP host is `eu.hamedata.com` for the EU region) |
+
+TLS is **mutual**: the device is provisioned with a **CA certificate, a client
+certificate, and a client private key** (all carried on the device) and presents
+the client cert to the broker. Certificate verification of the server is
+configured permissively (the connect proceeds on the client cert). To replicate
+the device you need its provisioned client cert/key for that broker; a stand‑in
+broker that doesn't require the client cert can be used for local testing (this
+is what the AstraMeter responder + [hame‑relay](https://github.com/tomquist/hame-relay)
+rely on).
+
+Connection bring‑up sequence (the device drives a Quectel Wi‑Fi module over `AT`):
+load the three certs, configure TLS (`verify` permissive, all ciphersuites,
+TLS 1.2), then `QMTOPEN` (host, 8883) → `QMTCONN` (`mst_<mac>`) → `QMTSUB` the
+App topic. On Wi‑Fi loss it `QMTCLOSE`/`QMTDISC` and retries with backoff.
+
+## 2. Topics
+
+The device **subscribes** to the App control topic and **publishes** to the
+device control topic:
+
+```text
+subscribe (app → device):  <prefix>/<ct_type>/App/<mac>/ctrl
+publish   (device → app):  <prefix>/<ct_type>/device/<mac>/ctrl
+```
+
+- `<prefix>` is **`marstek_energy`** on current firmware; older firmware used
+  **`hame_energy`** (after the `hamedata.com` cloud). Replicas should accept both.
+- `<ct_type>` is the model string `HME-4` (CT002) or `HME-3` (CT003).
+- `<mac>` is the 12‑hex device MAC.
+
+## 3. Message framing
+
+Payloads are UTF‑8 CSV `key=value` text. The app's parser strips spaces, splits
+on `,`, then splits each token on `=` expecting exactly one `=`. Lists of repeated
+records use `;` between records.
+
+**App → device** commands are a single `cd=<NN>` token (zero‑padded, e.g.
+`cd=01`), optionally followed by parameters (`,p1=<n>` etc.). The device parses
+the `cd` number, latches it as the pending response type plus any parameter, and
+the publish task then emits the matching frame on the device topic. **Replies do
+not echo a `cd=` key** — the app already knows what it asked for.
+
+## 4. Command reference (`cd` codes)
+
+Confirmed handlers (app sends `cd=<NN>` on the App topic; device answers on the
+device topic):
+
+| `cd` | direction / action | device reply payload |
+|------|--------------------|----------------------|
+| `1` | poll runtime info | `pwr_a=…` aggregate frame (see §5.1) |
+| `4` | poll slave list (page 1, slaves 0–4) | repeated `slv_ip=…;` (see §5.2) |
+| `7` | (takes a parameter) | — |
+| `8` | **reset_ct** — device replies `reset_ct` then reboots | `reset_ct` |
+| `9` | **start_debug** (parameter) — enable raw‑UDP debug stream | `start_debug`, then `sCtn=…` frames (§5.4) |
+| `10` | **clear_Err** (parameter) — clear / read error counters | `clear_Err` or `Err=…` (§5.5) |
+| `11` | slave list (page 2, slaves 5–8) | repeated `slv_ip=…;` |
+| `29` | poll detail record `N` (param `1..30`) | `PP=…` power‑detail frame (§5.6) |
+| `30` | poll detail record `N` (param `1..30`) | detail frame |
+| `33` | (command) | — |
+| `41` | slave list (page, slaves 0–4) | repeated `slv_ip=…;` |
+| `42` | slave list (page, slaves 5–8) | repeated `slv_ip=…;` |
+
+`cd` `1`–`7` are the core read polls; `1` (runtime info) and `4` (slave list)
+are the two the app uses most and the two the AstraMeter responder implements. The other low codes return the auxiliary frames
+in §5 (network, identity, smart‑meter, etc.); their exact `cd` numbers beyond the
+table above were not all pinned down.
+
+## 5. Device → app payloads
+
+All numeric fields are decimal ASCII. Strings are bare (no quoting).
+
+### 5.1 Runtime info (`cd=1`)
+
+**CT002 (`HME-4`):**
+```text
+pwr_a=%d,pwr_b=%d,pwr_c=%d,pwr_t=%d,ble_s=%d,wif_r=%d,fc4_v=%s,ver_v=%d,wif_s=%d,slv_n=%d,cur_d=%d
+```
+**CT003 (`HME-3`):**
+```text
+pwr_a=%d,pwr_b=%d,pwr_c=%d,pwr_t=%d,ble_s=%d,wif_r=%d,fc4_v=%s,ver_v=%d,eng_t=%lld,wif_s=%d,slv_n=%d,
+com_t=%d,com_b=%d,ptl_t=%d,smt_n=%d,har_f=%d,sof_f=%d,irs_f=%d,pwr_f=%d,frm_c=%d,upd_t=%d,udp_v=%d
+```
+
+| field | meaning |
+|-------|---------|
+| `pwr_a/b/c` | per‑phase grid power (W) |
+| `pwr_t` | total grid power (W) |
+| `ble_s` | BLE state |
+| `wif_r` | Wi‑Fi RSSI (dBm) |
+| `fc4_v` | Wi‑Fi module (FC41D) firmware string |
+| `ver_v` | device firmware version |
+| `wif_s` | Wi‑Fi state |
+| `slv_n` | number of connected batteries (slaves) |
+| `cur_d` | *(CT002 only)* current‑direction/day field |
+| `eng_t` | *(CT003 only)* cumulative energy, 64‑bit |
+| `com_t,com_b` | *(CT003)* comms counters |
+| `ptl_t` | *(CT003)* smart‑meter protocol type |
+| `smt_n` | *(CT003)* smart‑meter count |
+| `har_f,sof_f,irs_f,pwr_f` | *(CT003)* hardware / software / interrupt / power fault flags |
+| `frm_c` | *(CT003)* frame counter |
+| `upd_t` | *(CT003)* update time |
+| `udp_v` | *(CT003)* UDP protocol version (`4`) |
+
+### 5.2 Slave list (`cd=4` / `11` / `41` / `42`)
+
+Repeated, `;`‑terminated, **max 5 records per message** (hence the page codes):
+```text
+slv_ip=%s,slv_t=%s,slv_p=%c,slv_id=%s;
+```
+`slv_ip` = battery IP, `slv_t` = battery type, `slv_p` = its phase char
+(`A`/`B`/`C`/`D`/`0`), `slv_id` = battery MAC. A second compact slave/device form
+also exists: `type=%s,sid=%s,ip=%s,phpos=%c;`.
+
+### 5.3 Network / identity
+
+```text
+wif_n=%s,ip_ad=%s,udp_f=%d,gate=%s,mask=%s,dns=%s
+type=%s,id=%s,mac=%s,dev_ver=%d,fc_ver=%s
+```
+Wi‑Fi SSID, IP, UDP flag, gateway, netmask, DNS; and device type / id / MAC /
+device version / Wi‑Fi‑module version.
+
+### 5.4 Debug stream (`cd=9`)
+
+```text
+sCtn=%d,rCtn=%d,udpData=%s
+```
+Send count, receive count, and a raw UDP frame (the on‑wire CT packet) — a live
+tap of the UDP control traffic, used for diagnostics.
+
+### 5.5 Error counters (`cd=10`)
+
+```text
+Err=%d,%d,%d,%d,%d,%d,%d,%d,Urt_e=%d,Urt_s=%d
+```
+Eight error counters plus UART error / success counters.
+
+### 5.6 Power / meter detail (`cd=29` / `30`)
+
+```text
+PP=%d,NP=%d,aPP=%d,bPP=%d,cPP=%d,aNP=%d,bNP=%d,cNP=%d
+sm_t=%d,sm_b=%d,sm_p=%d,sm_n=%d,rec_l=%d,sm_dctn=%d,sm_p1iscon=%d,sm_p=%d,sm_wl=%d,e1=%d,rst=%d,isr=%d,urt_e=%d,urt_s=%d,isThr=%d
+```
+`PP`/`NP` = total positive (import) / negative (export) power; `aPP/bPP/cPP` and
+`aNP/bNP/cNP` = the per‑phase positive/negative split. The `sm_*` frame is CT003
+smart‑meter diagnostics (type, baud, protocol, count, record length, direction,
+phase‑1 connected, wiring, etc.).
+
+## 6. HTTP cloud reporting (CT003 only)
+
+The CT003 also reports to the Marstek cloud over plain **HTTP GET** (via the
+Wi‑Fi module: configure URL → GET → read response). Two endpoints, both under
+`eu.hamedata.com` (EU region host):
+
+### 6.1 Status report — `setCtReporting`
+
+```text
+GET http://eu.hamedata.com/prod/api/v1/setCtReporting
+    ?id=<mac>&eled=<lld>&elet=<lld>
+    &ap=<d>&bp=<d>&cp=<d>&dp=<d>
+    &rssi=<d>&slv=<d>&udp=<d>&mqtt=<d>
+    &timeNo=<d>&date=<YYYY>-<MM>-<DD>
+    &cz=<d>&ca=<d>&cb=<d>&cc=<d>&cd=<d>
+    &dz=<d>&da=<d>&db=<d>&dc=<d>&dd=<d>
+```
+
+| field | meaning |
+|-------|---------|
+| `id` | device MAC |
+| `eled`, `elet` | cumulative energy values (64‑bit) — import/export style totals |
+| `ap`, `bp`, `cp`, `dp` | per‑phase power for phases A/B/C and **D** (the combined/合相 bucket) |
+| `rssi` | Wi‑Fi RSSI |
+| `slv` | connected battery count |
+| `udp`, `mqtt` | UDP / MQTT link state flags |
+| `timeNo` | monotonic sequence / time number |
+| `date` | `Y-M-D` |
+| `cz,ca,cb,cc,cd` | charge power: combined‑unassigned (`z`) + phases A/B/C/D |
+| `dz,da,db,dc,dd` | discharge power: combined‑unassigned (`z`) + phases A/B/C/D |
+
+The `cz/ca/cb/cc/cd` and `dz/da/db/dc/dd` groups mirror the UDP response's
+`x`/`A`/`B`/`C`/`ABC` charge/discharge buckets (`z`↔`x`, `d`↔`ABC`). It is the
+cloud's source of the per‑phase power and energy history shown in the app.
+
+**Cadence.** This is a **timer‑driven, repeating** push — each report carries an
+incrementing `timeNo` and a `date`, i.e. it is scheduled, not event‑driven. The
+exact interval between reports is **not documented here** — the known timers are
+per‑operation, not the report period: the HTTP GET steps time out at **5 s**
+(config/read) and **65 s** (response wait), and the MQTT reconnect backoffs are
+30 s / 50 s. To get the real cadence, **measure it from the device** — the gap
+between successive `setCtReporting` GETs to `eu.hamedata.com` in a DNS/HTTP
+capture is the ground truth.
+
+> Note: the on‑wire URL has a missing `&` between `slv=%d` and `udp=%d`
+> (`…&slv=%dudp=%d…`), so on the wire the slave count and udp flag run together as
+> one token. Replicas mimicking it byte‑for‑byte should reproduce that quirk;
+> a tolerant server should parse `slv` as everything up to `udp=`.
+
+### 6.2 Config / time fetch — `getDateInfoeu.php`
+
+```text
+GET http://eu.hamedata.com/app/neng/getDateInfoeu.php?uid=<mac>&fcv=<fw>&aid=<id>&sv=<d>
+```
+Used to fetch date / config / OTA info: `uid` = MAC, `fcv` = firmware version,
+`aid` = an account/app id, `sv` = a settings/schema version. (`hamedata.com` is
+also the OTA download host.)
+
+## 7. CT002 vs CT003 summary
+
+| | CT002 (`HME-4`) | CT003 (`HME-3`) |
+|---|---|---|
+| MQTT (8883, mutual TLS, both topic prefixes) | yes | yes |
+| `cd` command set | yes | yes |
+| runtime‑info frame | shorter, ends `…slv_n,cur_d` | longer, `eng_t` + `com_t…udp_v` diagnostics |
+| HTTP cloud reporting | **no** | **yes** (`setCtReporting`, `getDateInfoeu`) |
+
+## 8. Relation to AstraMeter
+
+The `mqtt_insights:` Marstek responder
+(`src/astrameter/mqtt_insights/marstek_mqtt.py`) emulates the **`cd=1`** runtime
+frame and the **`cd=4`** slave list against a local broker so the app shows live
+grid power via [hame‑relay](https://github.com/tomquist/hame-relay). It emits a
+tolerant superset rather than a byte‑exact copy (different key order, extra
+`kwh/...` keys, comma‑joined `cd=4` rows); see that module's note. AstraMeter does
+**not** implement the auxiliary `cd` frames (§5.3–§5.6), the mutual‑TLS cloud
+connection, or the HTTP cloud reporting in §6 — those are documented here for
+completeness and for anyone aiming to fully replicate a real CT.

--- a/src/astrameter/mqtt_insights/marstek_mqtt.py
+++ b/src/astrameter/mqtt_insights/marstek_mqtt.py
@@ -8,6 +8,15 @@ Wire format (UTF-8): the Marstek app typically parses payloads with
 expecting **exactly one** ``=`` per token. Replies to ``cd=1`` / ``cd=4`` polls
 omit a ``cd=`` echo; ``cd=4`` slave lists use flat ``slv_t/…/slv_p`` tokens only.
 Aggregate replies include power, ``slv_n``, optional extras, and kWh placeholders.
+
+This emulates - but does not byte-for-byte reproduce - what a real CT sends. A
+real CT's ``cd=1`` layout differs by model and key order (CT002:
+``...ble_s,wif_r,fc4_v,ver_v,wif_s,slv_n,cur_d``; CT003 adds ``eng_t`` plus a
+``com_t...udp_v`` diagnostics block), neither emits ``kwh/n_kwh/...`` keys, and a
+real ``cd=4`` row is ``slv_ip,slv_t,slv_p,slv_id`` terminated by ``;``. The
+app's tolerant, order-independent parser accepts our superset. See
+``docs/ct002-ct003-protocol.md`` ("MQTT runtime-info frame") for the reference
+layouts.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Documentation-only update that substantially deepens the Marstek CT002/CT003
protocol notes and adds a new reference for the app/cloud (MQTT + HTTP) side. No
runtime behavior changes.

## What changed

**`docs/ct002-ct003-protocol.md`** — corrected and greatly expanded:
- Request/response field tables with exact per-field types/widths; corrected
  response identity order (CT/meter first, then storage) and the authoritative
  field names (`meter_*`, `hhm_*`, `x_*`/`A`/`B`/`C`/`ABC` buckets).
- **Phase `D` explained**: it is not a 4th physical phase — `phase_t` 0/1/2/3/4
  selects `'0'`(unassigned) / A / B / C / **D = combined (合相)**, i.e. balancing
  against the sum of all three phases (the mode behind a B2500 reporting `D`).
- The optional 7th request field (`participate`), with a note that it's
  model-dependent (B2500/HMJ sends it; Venus/HMG-50 does not).
- CT003-only trailing energy registers (`low_price_ele_in/out`,
  `normal_price_ele_in/out`).
- Aggregation/eviction/round-robin behavior, and a new **"How the storage side
  consumes the response"** section.
- A **simulator-grade steering/ramp spec** (Venus-class) — setpoint state, ramp
  counter, deadband/spike filter, the gain table, and clamps — with an explicit
  **model-scope note** that the B2500/HMJ uses an integer-only controller
  instead.

**`docs/marstek-mqtt-http.md`** (new) — the app/cloud side, written for full
replication:
- MQTT connection (TLS 8883, MQTT 3.1.1, keepalive 30, clean session, client id
  `mst_<mac>`, mutual-TLS with provisioned CA/client cert/key), topics, and the
  `cd=` command framing.
- The `cd` command table and every device→app payload with field meanings.
- **HTTP cloud reporting (CT003 only)**: `setCtReporting` and `getDateInfoeu.php`
  with all fields. The report cadence is documented as timer-driven/scheduled
  (`timeNo`+`date`); the exact interval is noted as best measured from device
  traffic.

**`docs/ct002-capture-analysis.md`** — reconciled the earlier capture findings
with the above (F25–F28 resolved, bucket naming).

**`src/astrameter/mqtt_insights/marstek_mqtt.py`** — docstring-only note (no code
change) pointing to the reference layouts.

## Notes
- No code/behavior changes; the one `.py` edit is a docstring.
- Follow-up (not in this PR): if useful, fold any of these findings into the
  emulator (e.g. phase-`D`/combined handling, the `participate` gate).

https://claude.ai/code/session_01FxfiScQCthNzzPsCAMZzjc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CT002/CT003 protocol specifications including UDP framing, response field layouts, and CT003-specific energy registers.
  * Added comprehensive Marstek MQTT/HTTP protocol documentation covering connection setup, message formatting, and device payload structures.
  * Updated protocol emulation documentation to distinguish real CT behavior from AstraMeter simulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->