### PR TITLE
Add steering-quality evaluation harness + CI metrics comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,109 @@ jobs:
           name: coverage-${{ matrix.python-version }}
           path: coverage.xml
 
+  # Steering-quality evaluation (issue #458): runs the deterministic
+  # active-control simulation suite (src/astrameter/simulator/evaluation.py)
+  # on the PR base and head and posts the before/after metrics as a sticky
+  # PR comment. Purely informational — thresholds that must hold live in
+  # pytest regressions, not here.
+  steering-eval:
+    needs: [ lint ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Run evaluation (head)
+        run: uv run python -m astrameter.simulator.evaluation --json head.json
+
+      # The base run uses the base commit's own harness + controller. Until
+      # the harness exists on the base branch this produces an empty
+      # baseline and the comment shows head-only numbers.
+      - name: Run evaluation (base)
+        if: github.event_name == 'pull_request'
+        run: |
+          git worktree add /tmp/steering-base "${{ github.event.pull_request.base.sha }}"
+          if [ -f /tmp/steering-base/src/astrameter/simulator/evaluation.py ]; then
+            (cd /tmp/steering-base \
+              && uv sync --frozen --extra dev \
+              && uv run python -m astrameter.simulator.evaluation --json "$GITHUB_WORKSPACE/base.json")
+          else
+            echo "[]" > "$GITHUB_WORKSPACE/base.json"
+          fi
+
+      - name: Render comparison
+        if: github.event_name == 'pull_request'
+        run: |
+          uv run python -m astrameter.simulator.evaluation \
+            --input head.json --compare base.json > steering-eval-comment.md
+          cat steering-eval-comment.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload metrics artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: steering-eval
+          path: |
+            head.json
+            base.json
+            steering-eval-comment.md
+          if-no-files-found: ignore
+
+      # Forks get a read-only token; they still see the table in the job
+      # summary above.
+      - name: Post sticky PR comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- steering-eval -->';
+            const body = marker + '\n' +
+              fs.readFileSync('steering-eval-comment.md', 'utf8');
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(
+              c => c.body && c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
   build:
     needs: [ validate ]
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,17 @@ CI runs the same steps (see `.github/workflows/ci.yml`).
 
 `esphome/components/ct002/` is a C++ mirror of the Python CT002 stack. Any change to shared behavior must land on **both** sides in the same change. See `CONTRIBUTING.md` for the file mapping and what has no C++ counterpart. Verify with `uv run pytest tests/components/ct002/`.
 
+## Steering-quality evaluation (run when touching balancer behavior)
+
+`uv run python -m astrameter.simulator.evaluation` simulates hours of
+realistic household activity against the firmware-accurate battery plant and
+reports reaction/oscillation/energy metrics per scenario. When changing
+`src/astrameter/ct002/balancer.py` (or anything else in the active-control
+loop), capture a baseline first (`--json base.json` on the unchanged code),
+re-run after the change, and compare with `--input head.json --compare
+base.json`. CI runs the same suite on PR base + head (job `steering-eval`)
+and posts the comparison as a sticky PR comment.
+
 ## Changelog
 
 For user-facing work on a branch, keep **one bullet under `## Next`** that summarizes the **overall** outcome of that branch. **Add** it when you first document the change; on **later iterations** on the same branch, **edit that same bullet** if the scope or wording shifts—do **not** append extra bullets for each follow-up. Skip `CHANGELOG.md` entirely when nothing users would notice changes (refactors, tests-only, etc.).

--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -1,0 +1,823 @@
+"""Steering-quality evaluation harness for the active-control loop.
+
+Wires the full closed loop — :class:`~astrameter.ct002.ct002.CT002` (active
+control) → :class:`~astrameter.simulator.battery.BatterySimulator` (real
+firmware steering laws) → :class:`~astrameter.simulator.load_model.LoadModel`
+→ :class:`~astrameter.simulator.powermeter_sim.PowermeterSimulator` — under a
+mock clock, so hours of simulated household activity (load spikes, solar,
+single / multiple / mixed batteries) run in seconds of wall time.
+
+Each scenario produces metrics answering three questions (issue #458):
+
+* **Reaction** — how fast does the loop settle after a load/solar step?
+* **Oscillation** — how much does it overshoot and hunt around the null?
+* **Energy** — how many Wh leak to/from the grid that a battery with
+  headroom could have covered?
+
+Run the suite (from the repo root, with dev deps)::
+
+    uv run python -m astrameter.simulator.evaluation
+    uv run python -m astrameter.simulator.evaluation --scenario two_venus/fair \\
+        --set balance_deadband=25 --json head.json
+    uv run python -m astrameter.simulator.evaluation --compare base.json \\
+        --input head.json
+
+``--compare`` renders a Markdown before/after table; CI runs the suite on
+the PR base and head and posts that comparison as a sticky PR comment (see
+``.github/workflows/ci.yml``, job ``steering-eval``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import itertools
+import json
+import math
+import random
+import socket
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+
+from astrameter.ct002.balancer import device_capabilities
+from astrameter.ct002.ct002 import CT002
+
+from .battery import BatterySimulator
+from .load_model import Load, LoadModel
+from .powermeter_sim import PowermeterSimulator
+
+# Mock-time epoch all scenarios start from (any fixed value works; using a
+# constant keeps runs bit-for-bit reproducible across machines).
+_EPOCH = 1_750_000_000.0
+
+# |grid| below this counts as "settled" (just above the battery's own
+# ±20 W deadband, matching the main e2e convergence assertion).
+SETTLE_BAND_W = 25.0
+# The grid must stay inside SETTLE_BAND_W for this long to count as settled.
+SETTLE_HOLD_S = 10.0
+# Settling/overshoot are measured in a window after each labeled event,
+# truncated by the next labeled event.
+EVENT_WINDOW_S = 600.0
+# Oscillation counting uses the battery's deadband as hysteresis band.
+OSC_BAND_W = 20.0
+# Samples within this long after a labeled event are excluded from the
+# steady-state RMS (they're legitimate transients, not hunting).
+STEADY_EXCLUDE_S = 120.0
+# Headroom margin when deciding whether grid exchange was "avoidable".
+HEADROOM_MARGIN_W = 5.0
+SOC_EMPTY = 0.02
+SOC_FULL = 0.98
+
+
+# ---------------------------------------------------------------------------
+# Scenario definition
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BatterySpec:
+    """Static description of one simulated battery in a scenario."""
+
+    device_type: str = "HMG-50"
+    phase: str = "A"
+    max_charge_power: int = 2500
+    max_discharge_power: int = 2500
+    capacity_wh: float = 5120.0
+    initial_soc: float = 0.6
+    ramp_rate: float = 400.0
+    poll_interval: float = 1.0
+    startup_delay: float = 2.0
+    min_power_threshold: float = 5.0
+    max_dc_input: int = 0
+
+    @property
+    def ac_chargeable(self) -> bool:
+        return device_capabilities(self.device_type).has_ac_input
+
+
+@dataclass(frozen=True)
+class Event:
+    """A scheduled world mutation.
+
+    A non-empty *label* marks a step disturbance whose settling/overshoot is
+    measured; unlabeled events (e.g. the per-minute solar curve) only mutate
+    the world.
+    """
+
+    at: float
+    apply: Callable[[EvalWorld], None]
+    label: str = ""
+
+
+@dataclass
+class Scenario:
+    name: str
+    description: str
+    batteries: list[BatterySpec]
+    duration_s: float
+    build_events: Callable[[random.Random], list[Event]]
+    base_load: list[float] = field(default_factory=lambda: [300.0, 0.0, 0.0])
+    base_noise: float = 10.0
+    loads: list[Load] = field(default_factory=list)
+    ct_kwargs: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class EvalWorld:
+    """Mutable world handle passed to scenario events."""
+
+    load_model: LoadModel
+    batteries: list[BatterySimulator]
+
+    def set_load(self, name: str, active: bool) -> None:
+        for ld in self.load_model.loads:
+            if ld.name == name:
+                ld.active = active
+                return
+        raise KeyError(f"no load named {name!r}")
+
+    def set_solar(self, watts: float) -> None:
+        self.load_model.set_solar(watts)
+
+    def set_dc_input(self, battery_index: int, watts: float) -> None:
+        self.batteries[battery_index].dc_input_power = watts
+
+
+class _EvalClock:
+    """Monotonic settable mock clock (same shape as the e2e HarnessClock)."""
+
+    def __init__(self, start: float) -> None:
+        self._now = start
+
+    def __call__(self) -> float:
+        return self._now
+
+    def set(self, value: float) -> None:
+        if value > self._now:
+            self._now = value
+
+
+# ---------------------------------------------------------------------------
+# Scenario runner
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Sample:
+    t: float  # seconds since scenario start
+    grid: float  # grid total W as seen by the controller (before_send)
+    powers: tuple[float, ...]
+    socs: tuple[float, ...]
+
+
+def _free_udp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+async def run_scenario(
+    scenario: Scenario,
+    seed: int = 1,
+    overrides: dict[str, float] | None = None,
+) -> dict:
+    """Run *scenario* deterministically and return its metrics dict."""
+    # The LoadModel draws noise from the global ``random``; seed it so each
+    # run is reproducible.  Event schedules use an independent stream so
+    # adding noise samples never shifts the scripted timeline.
+    random.seed(seed)
+    rng = random.Random(seed + 1)
+    events = sorted(scenario.build_events(rng), key=lambda e: e.at)
+
+    clock = _EvalClock(_EPOCH)
+    load_model = LoadModel(
+        base_load=list(scenario.base_load),
+        base_noise=scenario.base_noise,
+        loads=[Load(ld.name, ld.power, ld.phase) for ld in scenario.loads],
+    )
+    ct_mac = "112233445566"
+    ct_port = _free_udp_port()
+    batteries = [
+        BatterySimulator(
+            mac=f"02B250{i + 1:06X}",
+            phase=spec.phase,
+            ct_mac=ct_mac,
+            ct_host="127.0.0.1",
+            ct_port=ct_port,
+            meter_dev_type=spec.device_type,
+            max_charge_power=spec.max_charge_power,
+            max_discharge_power=spec.max_discharge_power,
+            capacity_wh=spec.capacity_wh,
+            initial_soc=spec.initial_soc,
+            ramp_rate=spec.ramp_rate,
+            poll_interval=spec.poll_interval,
+            min_power_threshold=spec.min_power_threshold,
+            startup_delay=spec.startup_delay,
+            max_dc_input=spec.max_dc_input,
+        )
+        for i, spec in enumerate(scenario.batteries)
+    ]
+    powermeter = PowermeterSimulator(batteries=batteries, load_model=load_model, port=0)
+    world = EvalWorld(load_model=load_model, batteries=batteries)
+
+    ct_kwargs: dict[str, float] = dict(scenario.ct_kwargs)
+    ct_kwargs.update(overrides or {})
+    ct002 = CT002(
+        udp_port=ct_port,
+        ct_mac=ct_mac,
+        active_control=True,
+        clock=clock,
+        consumer_ttl=10_000_000,  # mock time spans hours; never evict
+        dedupe_time_window=0.0,
+        **ct_kwargs,
+    )
+
+    samples: list[_Sample] = []
+
+    async def before_send(_addr, _fields=None, _consumer_id=None):
+        grid = powermeter.compute_grid()
+        total = grid["phase_a"] + grid["phase_b"] + grid["phase_c"]
+        samples.append(
+            _Sample(
+                t=clock() - _EPOCH,
+                grid=total,
+                powers=tuple(b.current_power for b in batteries),
+                socs=tuple(b.soc for b in batteries),
+            )
+        )
+        return [grid["phase_a"], grid["phase_b"], grid["phase_c"]]
+
+    ct002.before_send = before_send
+    await ct002.start()
+    try:
+        # Event-driven schedule: each battery polls on its own cadence
+        # (staggered starts), scripted events fire in between.
+        next_poll = [0.5 + i * 0.131 for i in range(len(batteries))]
+        marks: list[tuple[float, str]] = []
+        event_idx = 0
+        while True:
+            i = min(range(len(batteries)), key=lambda k: next_poll[k])
+            t_next = next_poll[i]
+            if t_next > scenario.duration_s:
+                break
+            while event_idx < len(events) and events[event_idx].at <= t_next:
+                ev = events[event_idx]
+                clock.set(_EPOCH + ev.at)
+                ev.apply(world)
+                if ev.label:
+                    marks.append((ev.at, ev.label))
+                event_idx += 1
+            clock.set(_EPOCH + t_next)
+            await batteries[i].step(batteries[i].poll_interval)
+            next_poll[i] = t_next + batteries[i].poll_interval
+    finally:
+        await ct002.stop()
+
+    return _compute_metrics(scenario, seed, samples, marks)
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+def _percentile(values: Sequence[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    k = (len(ordered) - 1) * pct
+    lo = math.floor(k)
+    hi = math.ceil(k)
+    if lo == hi:
+        return ordered[lo]
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * (k - lo)
+
+
+def _settle_time(samples: list[_Sample], start: float, end: float) -> float | None:
+    """Seconds from *start* until |grid| stays inside SETTLE_BAND_W for
+    SETTLE_HOLD_S, or ``None`` if it never settles inside the window."""
+    window = [s for s in samples if start <= s.t <= end]
+    candidate: float | None = None
+    for s in window:
+        if abs(s.grid) < SETTLE_BAND_W:
+            if candidate is None:
+                candidate = s.t
+            if s.t - candidate >= SETTLE_HOLD_S:
+                return candidate - start
+        else:
+            candidate = None
+    # A quiet tail shorter than the hold still counts when the window ends.
+    if candidate is not None and window and window[-1].t - candidate >= SETTLE_HOLD_S:
+        return candidate - start
+    return None
+
+
+def _compute_metrics(
+    scenario: Scenario,
+    seed: int,
+    samples: list[_Sample],
+    marks: list[tuple[float, str]],
+) -> dict:
+    duration_h = scenario.duration_s / 3600.0
+    specs = scenario.batteries
+
+    # --- per-event settling & overshoot ---
+    settle_times: list[float] = []
+    overshoots: list[float] = []
+    unsettled = 0
+    events_measured = 0
+    for idx, (t0, _label) in enumerate(marks):
+        t_end = min(
+            scenario.duration_s,
+            t0 + EVENT_WINDOW_S,
+            marks[idx + 1][0] if idx + 1 < len(marks) else float("inf"),
+        )
+        window = [s for s in samples if t0 <= s.t <= t_end]
+        if not window:
+            continue
+        e0 = window[0].grid
+        if abs(e0) < SETTLE_BAND_W:
+            continue  # disturbance too small to measure against the band
+        events_measured += 1
+        sign = 1.0 if e0 > 0 else -1.0
+        settle = _settle_time(samples, t0, t_end)
+        if settle is None:
+            unsettled += 1
+            settle_times.append(t_end - t0)
+        else:
+            settle_times.append(settle)
+        overshoots.append(max(0.0, max(-sign * s.grid for s in window)))
+
+    # --- oscillation: hysteresis band crossings ---
+    crossings = 0
+    state = 0
+    for s in samples:
+        if s.grid > OSC_BAND_W:
+            if state == -1:
+                crossings += 1
+            state = 1
+        elif s.grid < -OSC_BAND_W:
+            if state == 1:
+                crossings += 1
+            state = -1
+
+    # --- steady-state RMS (outside post-event transients) ---
+    def in_transient(t: float) -> bool:
+        return any(t0 <= t < t0 + STEADY_EXCLUDE_S for t0, _ in marks)
+
+    steady = [s.grid for s in samples if not in_transient(s.t)]
+    steady_rms = math.sqrt(sum(g * g for g in steady) / len(steady)) if steady else 0.0
+    mean_abs = sum(abs(s.grid) for s in samples) / len(samples) if samples else 0.0
+
+    # --- energy & battery travel ---
+    import_wh = export_wh = avoid_import_wh = avoid_export_wh = 0.0
+    travel_w = 0.0
+    for prev, cur in itertools.pairwise(samples):
+        dt = min(cur.t - prev.t, 5.0)
+        if dt <= 0:
+            continue
+        wh = prev.grid * dt / 3600.0
+        if wh > 0:
+            import_wh += wh
+            # Import is avoidable while any battery still has discharge
+            # headroom and charge in the pack.
+            if any(
+                prev.socs[i] > SOC_EMPTY
+                and prev.powers[i] < specs[i].max_discharge_power - HEADROOM_MARGIN_W
+                for i in range(len(specs))
+            ):
+                avoid_import_wh += wh
+        else:
+            export_wh += -wh
+            # Export is avoidable while any AC-chargeable battery has charge
+            # headroom and room in the pack.
+            if any(
+                specs[i].ac_chargeable
+                and prev.socs[i] < SOC_FULL
+                and prev.powers[i] > -specs[i].max_charge_power + HEADROOM_MARGIN_W
+                for i in range(len(specs))
+            ):
+                avoid_export_wh += -wh
+        travel_w += sum(abs(cur.powers[i] - prev.powers[i]) for i in range(len(specs)))
+
+    return {
+        "scenario": scenario.name,
+        "seed": seed,
+        "duration_h": round(duration_h, 3),
+        "samples": len(samples),
+        "events_measured": events_measured,
+        "unsettled_events": unsettled,
+        "settle_mean_s": round(sum(settle_times) / len(settle_times), 1)
+        if settle_times
+        else 0.0,
+        "settle_p95_s": round(_percentile(settle_times, 0.95), 1),
+        "overshoot_mean_w": round(sum(overshoots) / len(overshoots), 1)
+        if overshoots
+        else 0.0,
+        "overshoot_max_w": round(max(overshoots), 1) if overshoots else 0.0,
+        "band_crossings_per_h": round(crossings / duration_h, 2),
+        "steady_rms_w": round(steady_rms, 1),
+        "mean_abs_grid_w": round(mean_abs, 1),
+        "import_wh": round(import_wh, 1),
+        "export_wh": round(export_wh, 1),
+        "avoidable_import_wh": round(avoid_import_wh, 1),
+        "avoidable_export_wh": round(avoid_export_wh, 1),
+        "battery_travel_w_per_h": round(travel_w / duration_h, 0),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+_VENUS = BatterySpec()  # HMG-50 (V2-class), 1 s poll
+_VENUS_V3 = BatterySpec(device_type="VNSE3-0", poll_interval=0.45)
+_VENUS_V2_SLOW = BatterySpec(poll_interval=3.1)
+_B2500 = BatterySpec(
+    device_type="HMA-1",
+    max_charge_power=0,
+    max_discharge_power=800,
+    capacity_wh=2240.0,
+    max_dc_input=1000,
+    initial_soc=0.5,
+)
+
+# Efficiency-optimization mode knobs (mirrors a typical multi-battery setup).
+_EFF_MODE: dict[str, float] = {
+    "min_efficient_power": 150.0,
+    "efficiency_rotation_interval": 900.0,
+}
+
+
+# Typed closure factories for event actions (a plain lambda with extra
+# defaulted parameters doesn't type-check against ``Callable[[EvalWorld], None]``).
+
+
+def _set_load(name: str, active: bool) -> Callable[[EvalWorld], None]:
+    def apply(w: EvalWorld) -> None:
+        w.set_load(name, active)
+
+    return apply
+
+
+def _set_solar(watts: float) -> Callable[[EvalWorld], None]:
+    def apply(w: EvalWorld) -> None:
+        w.set_solar(watts)
+
+    return apply
+
+
+def _set_dc_input(battery_index: int, watts: float) -> Callable[[EvalWorld], None]:
+    def apply(w: EvalWorld) -> None:
+        w.set_dc_input(battery_index, watts)
+
+    return apply
+
+
+def _household_steps(rng: random.Random, duration: float) -> list[Event]:
+    """Scripted appliance schedule: kettle spikes, oven cycling, dishwasher.
+
+    Times get a deterministic per-seed jitter so different seeds exercise
+    different alignments against the poll cadence.
+    """
+
+    def jitter(t: float, spread: float = 20.0) -> float:
+        return max(1.0, t + rng.uniform(-spread, spread))
+
+    events: list[Event] = []
+
+    def load_event(t: float, name: str, active: bool) -> None:
+        state = "on" if active else "off"
+        events.append(
+            Event(at=jitter(t), label=f"{name}_{state}", apply=_set_load(name, active))
+        )
+
+    # Kettle: two 2 kW bursts of ~3 minutes.
+    for burst, t0 in enumerate((600.0, duration * 0.7)):
+        load_event(t0, "kettle", True)
+        load_event(t0 + 180.0, "kettle", False)
+        del burst
+    # Oven: thermostat cycling between 30% and 60% of the run.
+    t = duration * 0.3
+    on = True
+    while t < duration * 0.6:
+        load_event(t, "oven", on)
+        t += 240.0 if on else 180.0
+        on = not on
+    # Dishwasher: one long block in the second half.
+    load_event(duration * 0.8, "dishwasher", True)
+    load_event(duration * 0.8 + 600.0, "dishwasher", False)
+    return events
+
+
+_HOUSEHOLD_LOADS = [
+    Load("kettle", 2000.0, "A"),
+    Load("oven", 1500.0, "A"),
+    Load("dishwasher", 1100.0, "A"),
+]
+
+
+def _solar_curve(duration: float, peak: float) -> list[Event]:
+    """Unlabeled per-minute half-sine solar day curve."""
+    events: list[Event] = []
+    for t in range(0, int(duration), 60):
+        watts = peak * math.sin(math.pi * t / duration)
+        events.append(Event(at=float(t), apply=_set_solar(watts)))
+    return events
+
+
+def _cloud_dips(rng: random.Random, duration: float, peak: float) -> list[Event]:
+    """Labeled cloud transients: solar collapses to 20% for ~2 minutes."""
+    events: list[Event] = []
+    for frac in (0.4, 0.55):
+        t0 = duration * frac + rng.uniform(-60.0, 60.0)
+        dip = peak * math.sin(math.pi * t0 / duration) * 0.2
+        restore = peak * math.sin(math.pi * (t0 + 120.0) / duration)
+        events.append(Event(at=t0, label="cloud_on", apply=_set_solar(dip)))
+        events.append(
+            Event(at=t0 + 120.0, label="cloud_off", apply=_set_solar(restore))
+        )
+    return events
+
+
+def _dc_solar_curve(duration: float, peak: float, battery_index: int) -> list[Event]:
+    """Unlabeled per-minute DC-input solar curve for a B2500-style battery."""
+    events: list[Event] = []
+    for t in range(0, int(duration), 60):
+        watts = peak * math.sin(math.pi * t / duration)
+        events.append(Event(at=float(t), apply=_set_dc_input(battery_index, watts)))
+    return events
+
+
+def build_scenarios() -> dict[str, Scenario]:
+    """All evaluation scenarios, keyed by name.
+
+    Multi-battery scenarios come in two balancer modes: plain fair-share
+    (``…/fair``) and efficiency optimization (``…/eff``, exercising
+    deprioritization, rotation, saturation swaps and probe handoffs).
+    """
+    scenarios: dict[str, Scenario] = {}
+
+    def add(s: Scenario) -> None:
+        scenarios[s.name] = s
+
+    dur_steps = 3600.0
+    add(
+        Scenario(
+            name="single_venus_steps",
+            description="One Venus, stepped house load (kettle/oven/dishwasher)",
+            batteries=[_VENUS],
+            duration_s=dur_steps,
+            loads=list(_HOUSEHOLD_LOADS),
+            build_events=lambda rng: _household_steps(rng, dur_steps),
+        )
+    )
+
+    dur_solar = 5400.0
+    solar_peak = 1800.0
+    add(
+        Scenario(
+            name="single_venus_solar",
+            description="One Venus, solar day curve crossing into export + clouds",
+            batteries=[BatterySpec(initial_soc=0.4)],
+            duration_s=dur_solar,
+            base_load=[400.0, 0.0, 0.0],
+            build_events=lambda rng: (
+                _solar_curve(dur_solar, solar_peak)
+                + _cloud_dips(rng, dur_solar, solar_peak)
+            ),
+        )
+    )
+
+    for mode, kwargs in (("fair", {}), ("eff", _EFF_MODE)):
+        add(
+            Scenario(
+                name=f"two_venus/{mode}",
+                description="Two identical Venus sharing one phase",
+                batteries=[_VENUS, _VENUS],
+                duration_s=dur_steps,
+                loads=list(_HOUSEHOLD_LOADS),
+                build_events=lambda rng: _household_steps(rng, dur_steps),
+                ct_kwargs=dict(kwargs),
+            )
+        )
+
+    dur_mixed = 5400.0
+    for mode, kwargs in (("fair", {}), ("eff", _EFF_MODE)):
+        add(
+            Scenario(
+                name=f"mixed_venus_b2500/{mode}",
+                description="Two Venus + one DC-only B2500 with PV input",
+                batteries=[_VENUS, _VENUS, _B2500],
+                duration_s=dur_mixed,
+                loads=list(_HOUSEHOLD_LOADS),
+                build_events=lambda rng: (
+                    _household_steps(rng, dur_mixed)
+                    + _dc_solar_curve(dur_mixed, 700.0, battery_index=2)
+                ),
+                ct_kwargs=dict(kwargs),
+            )
+        )
+
+    for mode, kwargs in (("fair", {}), ("eff", _EFF_MODE)):
+        add(
+            Scenario(
+                name=f"mixed_cadence/{mode}",
+                description="Slow-polling V2 (3.1 s) + fast V3 (0.45 s)",
+                batteries=[_VENUS_V2_SLOW, _VENUS_V3],
+                duration_s=dur_steps,
+                loads=list(_HOUSEHOLD_LOADS),
+                build_events=lambda rng: _household_steps(rng, dur_steps),
+                ct_kwargs=dict(kwargs),
+            )
+        )
+
+    return scenarios
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+# Metrics shown in tables, in order, with "lower is better" direction (all
+# current metrics improve downward).
+_REPORT_METRICS = [
+    "settle_mean_s",
+    "settle_p95_s",
+    "unsettled_events",
+    "overshoot_mean_w",
+    "overshoot_max_w",
+    "band_crossings_per_h",
+    "steady_rms_w",
+    "mean_abs_grid_w",
+    "avoidable_import_wh",
+    "avoidable_export_wh",
+    "battery_travel_w_per_h",
+]
+
+
+def render_text(results: list[dict]) -> str:
+    lines = []
+    for res in results:
+        lines.append(
+            f"== {res['scenario']} (seed {res['seed']}, "
+            f"{res['duration_h']}h, {res['events_measured']} events)"
+        )
+        for key in _REPORT_METRICS:
+            lines.append(f"  {key:<24} {res[key]}")
+    return "\n".join(lines)
+
+
+def _fmt_delta(base: float, head: float) -> str:
+    if base == head:
+        return "="
+    if base == 0:
+        return f"{head - base:+g}"
+    return f"{(head - base) / abs(base) * 100.0:+.0f}%"
+
+
+def render_markdown_compare(base: list[dict], head: list[dict]) -> str:
+    """Markdown before/after table for the CI PR comment."""
+    base_by = {r["scenario"]: r for r in base}
+    out = [
+        "### Steering evaluation (base vs head)",
+        "",
+        "Lower is better for every metric. See "
+        "`src/astrameter/simulator/evaluation.py` for definitions.",
+        "",
+    ]
+    for res in head:
+        b = base_by.get(res["scenario"])
+        out.append(
+            f"<details><summary><b>{res['scenario']}</b> — "
+            f"{_summary_line(b, res)}</summary>"
+        )
+        out.append("")
+        out.append("| Metric | Base | Head | Δ |")
+        out.append("|---|---:|---:|---:|")
+        for key in _REPORT_METRICS:
+            bv = b[key] if b else "—"
+            delta = _fmt_delta(float(b[key]), float(res[key])) if b else "—"
+            out.append(f"| {key} | {bv} | {res[key]} | {delta} |")
+        out.append("")
+        out.append("</details>")
+    missing = [
+        r["scenario"]
+        for r in base
+        if r["scenario"] not in {h["scenario"] for h in head}
+    ]
+    if missing:
+        out.append("")
+        out.append(f"_Scenarios only in base: {', '.join(missing)}_")
+    return "\n".join(out)
+
+
+def _summary_line(base: dict | None, head: dict) -> str:
+    parts = [
+        f"settle {head['settle_mean_s']}s",
+        f"overshoot {head['overshoot_max_w']}W",
+        f"RMS {head['steady_rms_w']}W",
+    ]
+    if base:
+        parts = [
+            f"settle {base['settle_mean_s']}→{head['settle_mean_s']}s",
+            f"overshoot {base['overshoot_max_w']}→{head['overshoot_max_w']}W",
+            f"RMS {base['steady_rms_w']}→{head['steady_rms_w']}W",
+        ]
+    return ", ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_overrides(pairs: list[str]) -> dict[str, float]:
+    overrides: dict[str, float] = {}
+    for pair in pairs:
+        key, sep, value = pair.partition("=")
+        if not sep or not key:
+            raise SystemExit(f"--set expects KEY=VALUE, got {pair!r}")
+        overrides[key.strip()] = float(value)
+    return overrides
+
+
+async def _run_all(
+    names: list[str], seed: int, overrides: dict[str, float]
+) -> list[dict]:
+    scenarios = build_scenarios()
+    unknown = [n for n in names if n not in scenarios]
+    if unknown:
+        raise SystemExit(
+            f"unknown scenario(s): {', '.join(unknown)}; "
+            f"available: {', '.join(sorted(scenarios))}"
+        )
+    results = []
+    for name in names or sorted(scenarios):
+        res = await run_scenario(scenarios[name], seed=seed, overrides=overrides)
+        print(render_text([res]), file=sys.stderr, flush=True)
+        results.append(res)
+    return results
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        prog="python -m astrameter.simulator.evaluation",
+        description="Steering-quality evaluation for the active-control loop.",
+    )
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        default=[],
+        help="run only this scenario (repeatable; default: all)",
+    )
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument(
+        "--set",
+        dest="overrides",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="override a CT002/balancer config knob, e.g. balance_deadband=25",
+    )
+    parser.add_argument("--json", metavar="PATH", help="write results JSON to PATH")
+    parser.add_argument(
+        "--input",
+        metavar="PATH",
+        help="load results from PATH instead of running scenarios",
+    )
+    parser.add_argument(
+        "--compare",
+        metavar="BASELINE_JSON",
+        help="compare results against a baseline JSON",
+    )
+    parser.add_argument("--list", action="store_true", help="list scenarios and exit")
+    args = parser.parse_args(argv)
+
+    if args.list:
+        for name, sc in sorted(build_scenarios().items()):
+            print(f"{name:<28} {sc.description}")
+        return
+
+    if args.input:
+        with open(args.input) as fh:
+            results = json.load(fh)
+    else:
+        overrides = _parse_overrides(args.overrides)
+        results = asyncio.run(_run_all(args.scenario, args.seed, overrides))
+
+    if args.json:
+        with open(args.json, "w") as fh:
+            json.dump(results, fh, indent=2)
+
+    if args.compare:
+        with open(args.compare) as fh:
+            base = json.load(fh)
+        print(render_markdown_compare(base, results))
+    elif not args.input:
+        print(render_text(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -121,6 +121,10 @@ class Scenario:
     base_noise: float = 10.0
     loads: list[Load] = field(default_factory=list)
     ct_kwargs: dict[str, float] = field(default_factory=dict)
+    # Real grid meters report with latency; the controller acts on a reading
+    # refreshed at this cadence (matching a typical ~1 s powermeter poll /
+    # THROTTLE_INTERVAL) while the metrics see the true instantaneous grid.
+    meter_interval_s: float = 1.0
 
 
 @dataclass
@@ -129,6 +133,10 @@ class EvalWorld:
 
     load_model: LoadModel
     batteries: list[BatterySimulator]
+    # Solar is curve x factor so labeled transients (cloud dips) compose with
+    # the unlabeled day curve instead of being overwritten by its next tick.
+    solar_curve_w: float = 0.0
+    solar_factor: float = 1.0
 
     def set_load(self, name: str, active: bool) -> None:
         for ld in self.load_model.loads:
@@ -137,8 +145,16 @@ class EvalWorld:
                 return
         raise KeyError(f"no load named {name!r}")
 
-    def set_solar(self, watts: float) -> None:
-        self.load_model.set_solar(watts)
+    def set_solar_curve(self, watts: float) -> None:
+        self.solar_curve_w = watts
+        self._apply_solar()
+
+    def set_solar_factor(self, factor: float) -> None:
+        self.solar_factor = factor
+        self._apply_solar()
+
+    def _apply_solar(self) -> None:
+        self.load_model.set_solar(self.solar_curve_w * self.solar_factor)
 
     def set_dc_input(self, battery_index: int, watts: float) -> None:
         self.batteries[battery_index].dc_input_power = watts
@@ -234,19 +250,31 @@ async def run_scenario(
     )
 
     samples: list[_Sample] = []
+    # The controller reads the meter at the meter's own cadence (stale in
+    # between, like a real powermeter poll); metrics record the true grid.
+    meter_cache: dict[str, float] = {}
+    meter_read_at = [-math.inf]
 
     async def before_send(_addr, _fields=None, _consumer_id=None):
-        grid = powermeter.compute_grid()
-        total = grid["phase_a"] + grid["phase_b"] + grid["phase_c"]
+        now = clock() - _EPOCH
+        true_grid = powermeter.compute_grid()
+        if now - meter_read_at[0] >= scenario.meter_interval_s:
+            meter_cache.clear()
+            meter_cache.update(true_grid)
+            meter_read_at[0] = now
         samples.append(
             _Sample(
-                t=clock() - _EPOCH,
-                grid=total,
+                t=now,
+                grid=true_grid["phase_a"] + true_grid["phase_b"] + true_grid["phase_c"],
                 powers=tuple(b.current_power for b in batteries),
                 socs=tuple(b.soc for b in batteries),
             )
         )
-        return [grid["phase_a"], grid["phase_b"], grid["phase_c"]]
+        return [
+            meter_cache["phase_a"],
+            meter_cache["phase_b"],
+            meter_cache["phase_c"],
+        ]
 
     ct002.before_send = before_send
     await ct002.start()
@@ -461,9 +489,16 @@ def _set_load(name: str, active: bool) -> Callable[[EvalWorld], None]:
     return apply
 
 
-def _set_solar(watts: float) -> Callable[[EvalWorld], None]:
+def _set_solar_curve(watts: float) -> Callable[[EvalWorld], None]:
     def apply(w: EvalWorld) -> None:
-        w.set_solar(watts)
+        w.set_solar_curve(watts)
+
+    return apply
+
+
+def _set_solar_factor(factor: float) -> Callable[[EvalWorld], None]:
+    def apply(w: EvalWorld) -> None:
+        w.set_solar_factor(factor)
 
     return apply
 
@@ -498,13 +533,15 @@ def _household_steps(rng: random.Random, duration: float) -> list[Event]:
         load_event(t0, "kettle", True)
         load_event(t0 + 180.0, "kettle", False)
         del burst
-    # Oven: thermostat cycling between 30% and 60% of the run.
+    # Oven: thermostat cycling between 30% and 60% of the run.  Cycles are
+    # emitted as on/off pairs so the oven never stays on past its block
+    # (an unpaired trailing "on" would stack loads beyond the battery's
+    # ceiling for the rest of the run).
     t = duration * 0.3
-    on = True
-    while t < duration * 0.6:
-        load_event(t, "oven", on)
-        t += 240.0 if on else 180.0
-        on = not on
+    while t + 240.0 < duration * 0.6:
+        load_event(t, "oven", True)
+        load_event(t + 240.0, "oven", False)
+        t += 240.0 + 180.0
     # Dishwasher: one long block in the second half.
     load_event(duration * 0.8, "dishwasher", True)
     load_event(duration * 0.8 + 600.0, "dishwasher", False)
@@ -523,20 +560,22 @@ def _solar_curve(duration: float, peak: float) -> list[Event]:
     events: list[Event] = []
     for t in range(0, int(duration), 60):
         watts = peak * math.sin(math.pi * t / duration)
-        events.append(Event(at=float(t), apply=_set_solar(watts)))
+        events.append(Event(at=float(t), apply=_set_solar_curve(watts)))
     return events
 
 
-def _cloud_dips(rng: random.Random, duration: float, peak: float) -> list[Event]:
-    """Labeled cloud transients: solar collapses to 20% for ~2 minutes."""
+def _cloud_dips(rng: random.Random, duration: float) -> list[Event]:
+    """Labeled cloud transients: solar collapses to 20% for ~2 minutes.
+
+    Implemented as a multiplicative factor so the per-minute day curve keeps
+    ticking underneath without cancelling the dip.
+    """
     events: list[Event] = []
     for frac in (0.4, 0.55):
         t0 = duration * frac + rng.uniform(-60.0, 60.0)
-        dip = peak * math.sin(math.pi * t0 / duration) * 0.2
-        restore = peak * math.sin(math.pi * (t0 + 120.0) / duration)
-        events.append(Event(at=t0, label="cloud_on", apply=_set_solar(dip)))
+        events.append(Event(at=t0, label="cloud_on", apply=_set_solar_factor(0.2)))
         events.append(
-            Event(at=t0 + 120.0, label="cloud_off", apply=_set_solar(restore))
+            Event(at=t0 + 120.0, label="cloud_off", apply=_set_solar_factor(1.0))
         )
     return events
 
@@ -584,8 +623,7 @@ def build_scenarios() -> dict[str, Scenario]:
             duration_s=dur_solar,
             base_load=[400.0, 0.0, 0.0],
             build_events=lambda rng: (
-                _solar_curve(dur_solar, solar_peak)
-                + _cloud_dips(rng, dur_solar, solar_peak)
+                _solar_curve(dur_solar, solar_peak) + _cloud_dips(rng, dur_solar)
             ),
         )
     )

--- a/tests/test_steering_eval.py
+++ b/tests/test_steering_eval.py
@@ -1,0 +1,115 @@
+"""Smoke tests for the steering-quality evaluation harness.
+
+The full suite (``python -m astrameter.simulator.evaluation``) simulates
+hours per scenario; here we run a tiny inline scenario end-to-end to keep
+the harness itself covered by CI's pytest run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from astrameter.simulator.evaluation import (
+    BatterySpec,
+    Event,
+    Scenario,
+    build_scenarios,
+    render_markdown_compare,
+    run_scenario,
+)
+
+
+def _tiny_scenario() -> Scenario:
+    duration = 240.0
+
+    def events(_rng) -> list[Event]:
+        return [
+            Event(
+                at=60.0,
+                label="step_on",
+                apply=lambda w: w.load_model.base_load.__setitem__(0, 800.0),
+            ),
+            Event(
+                at=150.0,
+                label="step_off",
+                apply=lambda w: w.load_model.base_load.__setitem__(0, 200.0),
+            ),
+        ]
+
+    return Scenario(
+        name="tiny",
+        description="smoke",
+        batteries=[BatterySpec(poll_interval=1.0)],
+        duration_s=duration,
+        base_load=[200.0, 0.0, 0.0],
+        base_noise=0.0,
+        build_events=events,
+    )
+
+
+def test_run_scenario_produces_metrics():
+    res = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
+    assert res["scenario"] == "tiny"
+    assert res["samples"] > 200
+    # Both scripted steps are large enough to measure.
+    assert res["events_measured"] == 2
+    for key in (
+        "settle_mean_s",
+        "overshoot_max_w",
+        "band_crossings_per_h",
+        "steady_rms_w",
+        "import_wh",
+        "export_wh",
+        "avoidable_import_wh",
+        "avoidable_export_wh",
+        "battery_travel_w_per_h",
+    ):
+        assert res[key] >= 0, key
+    # The battery covers the initial 200 W base load well before the end.
+    assert res["settle_mean_s"] < res["duration_h"] * 3600
+
+
+def test_run_scenario_is_deterministic():
+    a = asyncio.run(run_scenario(_tiny_scenario(), seed=7))
+    b = asyncio.run(run_scenario(_tiny_scenario(), seed=7))
+    assert a == b
+
+
+def test_overrides_reach_the_balancer():
+    # An absurd deadband makes the balance-correction path inert; the run
+    # must still complete and produce metrics (knob plumbed through CT002).
+    res = asyncio.run(
+        run_scenario(_tiny_scenario(), seed=3, overrides={"balance_deadband": 500.0})
+    )
+    assert res["samples"] > 200
+
+
+def test_scenario_registry_shape():
+    scenarios = build_scenarios()
+    # Multi-battery scenarios exist in both balancer modes.
+    assert "two_venus/fair" in scenarios
+    assert "two_venus/eff" in scenarios
+    assert "mixed_venus_b2500/fair" in scenarios
+    assert "mixed_venus_b2500/eff" in scenarios
+    assert scenarios["two_venus/eff"].ct_kwargs["min_efficient_power"] > 0
+    for sc in scenarios.values():
+        assert sc.duration_s > 0 and sc.batteries
+
+
+def test_markdown_compare_renders():
+    res = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
+    base = dict(res, overshoot_max_w=res["overshoot_max_w"] + 100.0)
+    md = render_markdown_compare([base], [res])
+    assert "| overshoot_max_w |" in md
+    assert "tiny" in md
+
+
+@pytest.mark.parametrize("name", ["single_venus_steps"])
+def test_full_scenario_definitions_build(name):
+    import random
+
+    sc = build_scenarios()[name]
+    events = sc.build_events(random.Random(1))
+    assert events and all(e.at >= 0 for e in events)


### PR DESCRIPTION
## Summary

Adds a deterministic **steering-quality evaluation harness** for the active-control loop, plus a CI job that reports its metrics on every PR. This is the measurement groundwork for the #458 active-control redesign — the controller changes themselves stack on top in a follow-up PR, so this PR establishes the baseline they're compared against.

### Evaluation harness (`src/astrameter/simulator/evaluation.py`)

- Wires the full closed loop — `CT002` (active control) → `BatterySimulator` (the firmware-accurate Venus ramp / B2500 hysteresis controllers) → `LoadModel` → `PowermeterSimulator` — under a mock clock, so hours of simulated household activity run in seconds (full suite ~22 s).
- **Scenarios** (seeded, deterministic event schedules): single Venus with stepped appliance loads (kettle/oven/dishwasher), single Venus with a solar day-curve crossing into export plus cloud dips, two identical Venus, two Venus + one DC-only B2500 with PV input, and mixed poll cadences (V2 ≈3.1 s + V3 ≈0.45 s). Every multi-battery scenario runs in **both balancer modes**: plain fair-share and efficiency optimization (deprioritization/rotation/probes).
- The controller reads the meter at a realistic ~1 s cadence (stale in between) while metrics see the true instantaneous grid.
- **Metrics** per scenario: settling time (mean/p95) after each scripted step, opposite-direction overshoot, band crossings per hour, steady-state RMS, avoidable import/export Wh (grid exchange a battery with headroom could have covered), and battery power travel (churn).
- CLI: `--scenario`, `--seed`, `--set KEY=VALUE` config overrides, `--json` output, and `--compare base.json --input head.json` to render a Markdown before/after table.

```bash
uv run python -m astrameter.simulator.evaluation
```

### CI integration (`.github/workflows/ci.yml`, job `steering-eval`)

Runs the suite on the PR **base and head** and upserts the comparison as a sticky PR comment (informational only — thresholds live in pytest). On this PR the comment shows head-only numbers since the base has no harness yet; once merged, follow-up PRs (starting with the #458 controller changes) get a real before/after table. Fork PRs skip the comment (read-only token) but still get the table in the job summary; JSONs are uploaded as artifacts.

### Tests

`tests/test_steering_eval.py` runs a tiny inline scenario end-to-end (determinism, metric shape, config-override plumbing, registry shape, Markdown rendering) so the harness itself stays covered by the normal pytest run.

Part of #458.

https://claude.ai/code/session_01SeKwnaH74tzQoZEPhmhBu8

---
_Generated by [Claude Code](https://claude.ai/code/session_01SeKwnaH74tzQoZEPhmhBu8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a steering-quality evaluation framework with scenarios and metrics (settling time, overshoot, oscillation, steady-state RMS, energy).
  * CI integration that runs evaluations, uploads results/artifacts, and posts an auto-updating PR comment with a comparison.

* **Tests**
  * Added end-to-end smoke and regression tests ensuring determinism, metric production, and scenario coverage.

* **Documentation**
  * Added guidance for running steering evaluations locally and using baseline comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->