### PR TITLE
test: tighten probe-coverage grid bounds to measured headroom

### DIFF
--- a/tests/test_efficiency_e2e.py
+++ b/tests/test_efficiency_e2e.py
@@ -391,7 +391,9 @@ class TestEfficiencyE2E:
                 f"Max probe power={max_probe_power:.0f}W"
             )
             max_grid = max(grid_errors)
-            assert max_grid < 50, (
+            # Measured headroom (both backends, paced and unpaced): <10 W.
+            # 30 matches the settle convention used elsewhere in this suite.
+            assert max_grid < 30, (
                 f"Grid should stay near zero during probe, max={max_grid:.0f}W. "
                 f"Powers: {h.battery_powers()}"
             )
@@ -590,7 +592,9 @@ class TestEfficiencyE2E:
                 f"max_grid={max(grid_errors):.0f}W powers={h.battery_powers()}"
             )
             max_grid = max(grid_errors)
-            assert max_grid < 55, (
+            # Measured headroom (both backends, paced and unpaced): <1 W.
+            # 30 matches the settle convention used elsewhere in this suite.
+            assert max_grid < 30, (
                 f"Rejected probe should not leave a large grid gap; max={max_grid:.0f}W. "
                 f"Powers: {h.battery_powers()}"
             )


### PR DESCRIPTION
## Summary

Follow-up to #467 (merged): an audit of the efficiency-e2e grid/transient thresholds against **measured actuals** on both backends, with the goal of pinning behavior tighter now that the controller is ramp-paced.

## What the measurement showed

| test | bound | actual (python / esphome) | verdict |
|---|---|---|---|
| `test_probe_rotation_keeps_grid_stable` | <150 W | 120.2 / 120.2 | keep — snug |
| `test_probe_handles_mixed_poll_intervals` | <500 W | 0 / 439.6 | keep — snug |
| `test_smooth_transition_no_overshoot` | <500 W | 438.0 / 475.4 | keep — snug |
| `test_probe_with_min_inverter_power…` | <120 W | 81.5 / 82.5 | keep — modest margin |
| `test_probe_rejection_keeps_backup_covering_demand` | <55 W | **0.3 / 0.7** | **tighten → 30 W** |
| `test_probe_keeps_grid_near_zero_during_slow_rotation` | <50 W | **0.1 / 9.6** | **tighten → 30 W** |

Honest finding: the big transient bounds are **not** slack under pacing. This harness polls at 0.3 s with a zero-latency meter — the regime where pacing changes little; its gains show under the eval suite's realistic 1 s meter latency (see #467's `steering-eval` comparison). And the two bounds that *do* have slack had it **before pacing too** (verified by re-measuring with `pace_base_step=0`).

## Change

Tighten only the two genuinely slack coverage bounds to **30 W** (the settle convention used elsewhere in this suite): 3× the worst observed value for the slow-rotation case, ~40× for the rejected-probe case. A future probe-coverage regression now trips ~2x sooner. Comments record the measured headroom so the next audit doesn't have to re-derive it.

Test-only; both backends green (`pytest tests/test_efficiency_e2e.py` with the compiled ESPHome host binary: 34/34).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01SeKwnaH74tzQoZEPhmhBu8