### PR TITLE
eval: smooth the solar day curve

### DIFF
--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -73,6 +73,10 @@ SOC_FULL = 0.98
 # interactive charts in the HTML report. Base and head share this fixed count
 # so the two lines align by index regardless of poll cadence.
 GRAPH_POINTS = 1800
+# Resolution of the half-sine solar day curve (s).  Fine enough that each step
+# is a few watts (vs ~50 W per minute at the steepest part of the sine), so the
+# controller sees a smooth ramp rather than a minutely staircase of load steps.
+SOLAR_CURVE_STEP_S = 2
 
 
 # ---------------------------------------------------------------------------
@@ -701,9 +705,14 @@ def _washer_cycle(rng: random.Random, duration: float) -> list[Event]:
 
 
 def _solar_curve(duration: float, peak: float) -> list[Event]:
-    """Unlabeled per-minute half-sine solar day curve."""
+    """Unlabeled half-sine solar day curve.
+
+    Updated every ``SOLAR_CURVE_STEP_S`` so the curve is smooth: a coarse
+    per-minute step jumps ~50 W per tick where the sine is steepest (sunrise /
+    sunset), which the controller would chase as a series of small load steps.
+    """
     events: list[Event] = []
-    for t in range(0, int(duration), 60):
+    for t in range(0, int(duration), SOLAR_CURVE_STEP_S):
         watts = peak * math.sin(math.pi * t / duration)
         events.append(Event(at=float(t), apply=_set_solar_curve(watts)))
     return events
@@ -712,8 +721,8 @@ def _solar_curve(duration: float, peak: float) -> list[Event]:
 def _cloud_dips(rng: random.Random, duration: float) -> list[Event]:
     """Labeled cloud transients: solar collapses to 20% for ~2 minutes.
 
-    Implemented as a multiplicative factor so the per-minute day curve keeps
-    ticking underneath without cancelling the dip.
+    Implemented as a multiplicative factor so the day curve keeps ticking
+    underneath without cancelling the dip.
     """
     events: list[Event] = []
     for frac in (0.4, 0.55):
@@ -726,9 +735,10 @@ def _cloud_dips(rng: random.Random, duration: float) -> list[Event]:
 
 
 def _dc_solar_curve(duration: float, peak: float, battery_index: int) -> list[Event]:
-    """Unlabeled per-minute DC-input solar curve for a B2500-style battery."""
+    """Unlabeled DC-input solar curve for a B2500-style battery (smooth — see
+    :func:`_solar_curve`)."""
     events: list[Event] = []
-    for t in range(0, int(duration), 60):
+    for t in range(0, int(duration), SOLAR_CURVE_STEP_S):
         watts = peak * math.sin(math.pi * t / duration)
         events.append(Event(at=float(t), apply=_set_dc_input(battery_index, watts)))
     return events


### PR DESCRIPTION
## What

The steering-eval half-sine **solar day curve was updated only once a minute**, so near sunrise/sunset — where the sine is steepest — it stepped by ~50–60 W per tick (`peak · π/duration · 60 s`). The controller chased each jump as a small load step, so the "solar" scenarios carried an artificial minutely staircase of disturbances rather than a smooth ramp.

## Fix

Update the curve (and the DC-input variant `_dc_solar_curve`) every `SOLAR_CURVE_STEP_S = 2 s` instead of 60 s. Each step is now a few watts:

```
max step: ~3.5 W  (was ~63 W/min);  2700 events over a 5400 s day (was 90)
```

That's finer than both the 1 s meter cadence and the chart's 3 s/point resolution, so it renders as a smooth line and the controller no longer reacts to a fake staircase.

## Why a separate PR

This is an independent eval-harness/scenario change. Keeping it out of the oscillation-damping PR (#475) avoids conflating a scenario change with a balancer change in that PR's base-vs-head steering-eval comparison. Once this merges, #475 can rebase so both sides use the smooth curve.

## Notes

- Simulator/eval is **Python-only** — no ESPHome counterpart, parity rule N/A.
- No `CHANGELOG.md` entry — internal tooling, nothing user-visible.
- `ruff` / `mypy` / `pytest tests/test_steering_eval.py` green; solar scenarios run unchanged in shape (e.g. `single_venus_solar` grid_p2p/band/settle steady).

https://claude.ai/code/session_01V6PWDgijfH7nmniL47A2qy

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6PWDgijfH7nmniL47A2qy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Solar curve simulation now updates at finer intervals for smoother behavior during cloud events and transient environmental variations, ensuring more accurate representation throughout simulation runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->