### PR TITLE
Seed-averaged metrics and aggregate roll-up in steering eval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,8 @@ reports reaction/oscillation/energy metrics per scenario. Each scenario is run
 over several seeds (`--seeds`, default 5) **in parallel across CPU cores**, and
 every metric is the mean over those seeds — so the figures are the
 seed-averaged signal, not one noisy draw (use `--seeds 1` for a quick
-single-seed run). When changing `src/astrameter/ct002/balancer.py` (or anything
+single-seed run, and `--seed N` to set the starting seed — seeds run are
+`N..N+seeds-1`). When changing `src/astrameter/ct002/balancer.py` (or anything
 else in the active-control loop), capture a baseline first (`--json base.json`
 on the unchanged code), re-run after the change, and compare with `--input
 head.json --compare base.json`. CI runs the same suite on PR base + head (job

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,11 @@ reports reaction/oscillation/energy metrics per scenario. When changing
 loop), capture a baseline first (`--json base.json` on the unchanged code),
 re-run after the change, and compare with `--input head.json --compare
 base.json`. CI runs the same suite on PR base + head (job `steering-eval`)
-and posts the comparison as a sticky PR comment.
+and posts the comparison as a sticky PR comment. The comparison leads with an
+**aggregate roll-up** (per-metric mean across all scenarios plus a one-line
+overall verdict — how many metrics improved/regressed and the mean relative
+change), so an across-the-board improvement or regression is visible without
+reading every scenario table.
 
 ## Changelog
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,16 +27,19 @@ CI runs the same steps (see `.github/workflows/ci.yml`).
 
 `uv run python -m astrameter.simulator.evaluation` simulates hours of
 realistic household activity against the firmware-accurate battery plant and
-reports reaction/oscillation/energy metrics per scenario. When changing
-`src/astrameter/ct002/balancer.py` (or anything else in the active-control
-loop), capture a baseline first (`--json base.json` on the unchanged code),
-re-run after the change, and compare with `--input head.json --compare
-base.json`. CI runs the same suite on PR base + head (job `steering-eval`)
-and posts the comparison as a sticky PR comment. The comparison leads with an
-**aggregate roll-up** (per-metric mean across all scenarios plus a one-line
-overall verdict — how many metrics improved/regressed and the mean relative
-change), so an across-the-board improvement or regression is visible without
-reading every scenario table.
+reports reaction/oscillation/energy metrics per scenario. Each scenario is run
+over several seeds (`--seeds`, default 5) **in parallel across CPU cores**, and
+every metric is the mean over those seeds — so the figures are the
+seed-averaged signal, not one noisy draw (use `--seeds 1` for a quick
+single-seed run). When changing `src/astrameter/ct002/balancer.py` (or anything
+else in the active-control loop), capture a baseline first (`--json base.json`
+on the unchanged code), re-run after the change, and compare with `--input
+head.json --compare base.json`. CI runs the same suite on PR base + head (job
+`steering-eval`) and posts the comparison as a sticky PR comment. The
+comparison leads with an **aggregate roll-up** (per-metric mean across all
+scenarios plus a one-line overall verdict — how many metrics
+improved/regressed and the mean relative change), so an across-the-board
+improvement or regression is visible without reading every scenario table.
 
 ## Changelog
 

--- a/src/astrameter/simulator/eval_report.py
+++ b/src/astrameter/simulator/eval_report.py
@@ -112,6 +112,7 @@ def render_html_report(
     fmt_delta: Callable[[float, float], str],
     aggregate: tuple[dict | None, dict] | None = None,
     aggregate_summary: str = "",
+    note: str = "",
 ) -> str:
     """Return a self-contained HTML report comparing *base* and *head*.
 
@@ -122,6 +123,8 @@ def render_html_report(
     roll-up rows (means across scenarios). It renders as a leading "Aggregate"
     section so the overall direction of a change is visible before any
     per-scenario table; *aggregate_summary* is a one-line verdict shown with it.
+    *note* is an optional caption (e.g. how many seeds were averaged) shown
+    under the page heading.
     """
     base_by = {r["scenario"]: r for r in (base or [])}
 
@@ -208,6 +211,7 @@ def render_html_report(
         if base_by
         else f'<span class="key" style="color:{COLOR_HEAD}">&#9632; head</span>'
     )
+    note_html = f"<p class='summary'>{_esc(note)}</p>" if note else ""
     body = (
         "<div class='wrap'>"
         "<h1>Steering evaluation &mdash; base vs head</h1>"
@@ -215,6 +219,7 @@ def render_html_report(
         "(base vs head) and the head run's per-battery output. Drag on a chart "
         "to zoom, double-click to reset, click a series in the legend to toggle "
         "it. Lower is better for every metric.</p>"
+        f"{note_html}"
         "<details><summary><b>What do these metrics mean?</b></summary>"
         f"<table><thead><tr><th>Metric</th><th>Meaning</th></tr></thead>"
         f"<tbody>{glossary_rows}</tbody></table></details>"

--- a/src/astrameter/simulator/eval_report.py
+++ b/src/astrameter/simulator/eval_report.py
@@ -110,11 +110,18 @@ def render_html_report(
     report_metrics: Sequence[str],
     metric_glossary: Sequence[tuple[str, str]],
     fmt_delta: Callable[[float, float], str],
+    aggregate: tuple[dict | None, dict] | None = None,
+    aggregate_summary: str = "",
 ) -> str:
     """Return a self-contained HTML report comparing *base* and *head*.
 
     *base* may be ``None`` / empty (no baseline on the PR base branch), in which
     case each scenario renders head-only.
+
+    *aggregate*, when given, is a ``(base_agg, head_agg)`` pair of synthetic
+    roll-up rows (means across scenarios). It renders as a leading "Aggregate"
+    section so the overall direction of a change is visible before any
+    per-scenario table; *aggregate_summary* is a one-line verdict shown with it.
     """
     base_by = {r["scenario"]: r for r in (base or [])}
 
@@ -124,6 +131,14 @@ def render_html_report(
     )
 
     sections: list[str] = []
+    if aggregate is not None:
+        agg_base, agg_head = aggregate
+        n = agg_head.get("n_scenarios", len(head))
+        agg_parts = [f"<h2>Aggregate &mdash; mean across {_esc(n)} scenarios</h2>"]
+        if aggregate_summary:
+            agg_parts.append(f'<p class="summary">{_esc(aggregate_summary)}</p>')
+        agg_parts.append(_metrics_table(agg_base, agg_head, report_metrics, fmt_delta))
+        sections.append(f"<section>{''.join(agg_parts)}</section>")
     # Each chart is a generic {durationMin, series:[{label,color,data}, ...]}
     # so the same JS builder draws both the grid (base vs head) and the
     # per-battery output overlays.

--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -14,18 +14,28 @@ Each scenario produces metrics answering three questions (issue #458):
 * **Energy** — how many Wh leak to/from the grid that a battery with
   headroom could have covered?
 
+Each scenario is run over several seeds (``--seeds``, default 5) **in parallel
+across CPU cores** and every metric is reported as the mean over those seeds,
+so the figures reflect the seed-averaged signal rather than one noisy draw.
+Process isolation (not asyncio) is what parallelizes the CPU-bound sim and, as
+a bonus, gives each seed its own global ``random`` state so runs stay
+deterministic. Per-scenario rows are then rolled up into a single cross-scenario
+``AGGREGATE`` so an across-the-board win or regression is visible at a glance.
+
 Run the suite (from the repo root, with dev deps)::
 
     uv run python -m astrameter.simulator.evaluation
     uv run python -m astrameter.simulator.evaluation --scenario two_venus/fair \\
-        --set balance_deadband=25 --json head.json
+        --set balance_deadband=25 --seeds 10 --json head.json
     uv run python -m astrameter.simulator.evaluation --compare base.json \\
         --input head.json
 
-``--compare`` renders a Markdown before/after table — including a Mermaid
-chart of each scenario's grid-power trace (base vs head) — and CI runs the
-suite on the PR base and head and posts that comparison as a sticky PR
-comment (see ``.github/workflows/ci.yml``, job ``steering-eval``).
+``--compare`` renders a Markdown before/after table — leading with the
+seed-averaged ``AGGREGATE`` roll-up — and CI runs the suite on the PR base and
+head and posts that comparison as a sticky PR comment (see
+``.github/workflows/ci.yml``, job ``steering-eval``). The interactive
+grid-power charts live in the self-contained HTML report CI uploads as the
+``steering-eval`` artifact.
 """
 
 from __future__ import annotations
@@ -35,10 +45,12 @@ import asyncio
 import itertools
 import json
 import math
+import os
 import random
 import socket
 import sys
 from collections.abc import Callable, Sequence
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
 
 from astrameter.ct002.balancer import device_capabilities
@@ -1056,6 +1068,46 @@ _METRIC_GLOSSARY = [
 ]
 
 
+def _mean_value(values: list):
+    """Average a homogeneous list of result values across seeds.
+
+    Recurses into nested lists (a battery's trace, the list of per-battery
+    traces) so traces average element-by-element; string lists (battery
+    labels, identical across seeds) pass through as the first value."""
+    v0 = values[0]
+    if isinstance(v0, bool):
+        return v0
+    if isinstance(v0, (int, float)):
+        return round(sum(float(v) for v in values) / len(values), 1)
+    if isinstance(v0, list):
+        if v0 and isinstance(v0[0], str):
+            return v0  # labels are identical across seeds
+        return [_mean_value([v[i] for v in values]) for i in range(len(v0))]
+    return v0  # strings / anything else: identical across seeds
+
+
+def _merge_seeds(per_seed: list[dict]) -> dict:
+    """Collapse one scenario's per-seed results into a single averaged row.
+
+    Every numeric metric (and every trace, element-wise) becomes the mean over
+    the seeds, so the reported figure is the seed-averaged signal rather than
+    one noisy draw. A lone seed is returned unchanged (no averaging, keeps the
+    original ``seed`` field). The merged row carries ``seeds`` / ``n_seeds``
+    instead of a single ``seed``."""
+    if len(per_seed) == 1:
+        return per_seed[0]
+    merged: dict = {
+        "scenario": per_seed[0]["scenario"],
+        "seeds": [r["seed"] for r in per_seed],
+        "n_seeds": len(per_seed),
+    }
+    for key in per_seed[0]:
+        if key in ("scenario", "seed"):
+            continue
+        merged[key] = _mean_value([r[key] for r in per_seed])
+    return merged
+
+
 def _aggregate(results: list[dict]) -> dict:
     """Collapse a result list into one synthetic "AGGREGATE" row.
 
@@ -1137,12 +1189,20 @@ def render_text(results: list[dict]) -> str:
         lines.append("")
     for res in results:
         lines.append(
-            f"== {res['scenario']} (seed {res['seed']}, "
+            f"== {res['scenario']} ({_seed_label(res)}, "
             f"{res['duration_h']}h, {res['events_measured']} events)"
         )
         for key in _REPORT_METRICS:
             lines.append(f"  {key:<24} {res[key]}")
     return "\n".join(lines)
+
+
+def _seed_label(res: dict) -> str:
+    """How a result's seed provenance reads in a header: a single ``seed N`` or
+    ``mean of N seeds`` once per-seed results have been merged."""
+    if res.get("n_seeds"):
+        return f"mean of {res['n_seeds']} seeds"
+    return f"seed {res.get('seed', '?')}"
 
 
 def _fmt_delta(base: float, head: float) -> str:
@@ -1170,6 +1230,31 @@ def _md_metric_rows(base: dict | None, head: dict) -> list[str]:
             delta = "—"
         rows.append(f"| {key} | {bv} | {hv} | {delta} |")
     return rows
+
+
+def _seeds_phrase(results: list[dict]) -> str:
+    """`mean of N seeds` / `single seed` describing how a result set was run."""
+    n = max((int(r.get("n_seeds", 1)) for r in results), default=1)
+    return f"mean of {n} seeds" if n > 1 else "single seed"
+
+
+def _seeds_caption(base: list[dict] | None, head: list[dict]) -> str:
+    """One sentence on the seed count behind each side, or ``""`` when both ran a
+    single seed (so the note only appears once figures are seed-averaged)."""
+    hp = _seeds_phrase(head)
+    bp = _seeds_phrase(base) if base else None
+    if hp == "single seed" and (bp is None or bp == "single seed"):
+        return ""
+    if bp is None or bp == hp:
+        return f"Metrics are the per-scenario {hp}."
+    return f"Metrics are the per-scenario mean over seeds (base: {bp}, head: {hp})."
+
+
+def _seeds_note(base: list[dict], head: list[dict]) -> list[str]:
+    """The :func:`_seeds_caption` sentence as italic Markdown lines (empty when
+    there's nothing to note)."""
+    caption = _seeds_caption(base, head)
+    return [f"_{caption}_", ""] if caption else []
 
 
 def render_markdown_compare(
@@ -1204,6 +1289,9 @@ def render_markdown_compare(
         "Lower is better for every metric. See "
         "`src/astrameter/simulator/evaluation.py` for definitions.",
         "",
+    ]
+    out += _seeds_note(base, head)
+    out += [
         f"#### Aggregate — mean across {head_agg['n_scenarios']} scenarios",
         "",
     ]
@@ -1277,9 +1365,45 @@ def _parse_overrides(pairs: list[str]) -> dict[str, float]:
     return overrides
 
 
-async def _run_all(
-    names: list[str], seed: int, overrides: dict[str, float]
+def _run_one(name: str, seed: int, overrides: dict[str, float]) -> dict:
+    """Run one (scenario, seed) to completion in its own process.
+
+    A process-pool worker: it rebuilds the scenario registry from *name*
+    (closures in ``Scenario.build_events`` aren't picklable, so we ship the
+    name, not the object) and drives the async scenario under a fresh event
+    loop. Process isolation also gives each seed its own global ``random``
+    state, so concurrent runs stay bit-for-bit deterministic — which a single
+    interpreter (asyncio interleaving the shared global RNG) could not."""
+    scenarios = build_scenarios()
+    return asyncio.run(run_scenario(scenarios[name], seed=seed, overrides=overrides))
+
+
+def _run_tasks(
+    tasks: list[tuple[str, int]], overrides: dict[str, float]
+) -> dict[tuple[str, int], dict]:
+    """Run every (scenario, seed) task, in parallel across CPU cores.
+
+    The simulation is CPU-bound, so processes (not asyncio) are what actually
+    parallelize it; one task runs inline to avoid pool overhead."""
+    if len(tasks) <= 1:
+        return {t: _run_one(t[0], t[1], overrides) for t in tasks}
+    workers = min(len(tasks), os.cpu_count() or 1)
+    out: dict[tuple[str, int], dict] = {}
+    with ProcessPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(_run_one, name, seed, overrides): (name, seed)
+            for name, seed in tasks
+        }
+        for fut in as_completed(futures):
+            out[futures[fut]] = fut.result()
+    return out
+
+
+def _run_all(
+    names: list[str], seeds: list[int], overrides: dict[str, float]
 ) -> list[dict]:
+    """Run the selected scenarios across all *seeds* concurrently, then collapse
+    each scenario's per-seed results into one seed-averaged row."""
     scenarios = build_scenarios()
     unknown = [n for n in names if n not in scenarios]
     if unknown:
@@ -1287,11 +1411,13 @@ async def _run_all(
             f"unknown scenario(s): {', '.join(unknown)}; "
             f"available: {', '.join(sorted(scenarios))}"
         )
+    selected = names or sorted(scenarios)
+    raw = _run_tasks([(name, seed) for name in selected for seed in seeds], overrides)
     results = []
-    for name in names or sorted(scenarios):
-        res = await run_scenario(scenarios[name], seed=seed, overrides=overrides)
-        print(render_text([res]), file=sys.stderr, flush=True)
-        results.append(res)
+    for name in selected:
+        merged = _merge_seeds([raw[(name, seed)] for seed in seeds])
+        print(render_text([merged]), file=sys.stderr, flush=True)
+        results.append(merged)
     return results
 
 
@@ -1306,7 +1432,20 @@ def main(argv: list[str] | None = None) -> None:
         default=[],
         help="run only this scenario (repeatable; default: all)",
     )
-    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=1,
+        help="first seed (default: 1); with --seeds N, runs seed..seed+N-1",
+    )
+    parser.add_argument(
+        "--seeds",
+        type=int,
+        default=5,
+        metavar="N",
+        help="number of seeds to run per scenario and average over, in "
+        "parallel across CPU cores (default: 5; 1 disables seed averaging)",
+    )
     parser.add_argument(
         "--set",
         dest="overrides",
@@ -1344,8 +1483,11 @@ def main(argv: list[str] | None = None) -> None:
         with open(args.input) as fh:
             results = json.load(fh)
     else:
+        if args.seeds < 1:
+            raise SystemExit("--seeds must be >= 1")
         overrides = _parse_overrides(args.overrides)
-        results = asyncio.run(_run_all(args.scenario, args.seed, overrides))
+        seeds = list(range(args.seed, args.seed + args.seeds))
+        results = _run_all(args.scenario, seeds, overrides)
 
     if args.json:
         with open(args.json, "w") as fh:
@@ -1374,6 +1516,7 @@ def main(argv: list[str] | None = None) -> None:
             aggregate_summary=(
                 _overall_summary(base_agg, head_agg) if base_agg is not None else ""
             ),
+            note=_seeds_caption(base, results),
         )
         with open(args.html, "w", encoding="utf-8") as fh:
             fh.write(report)

--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -1129,6 +1129,23 @@ def _aggregate(results: list[dict]) -> dict:
     return agg
 
 
+def _compare_aggregates(
+    base: list[dict] | None, head: list[dict]
+) -> tuple[dict | None, dict]:
+    """Aggregate base and head for a base-vs-head comparison.
+
+    With a baseline, both sides are aggregated over the **scenarios they share**
+    so the Overall verdict and aggregate table compare like for like even when
+    the two runs cover different scenario sets (e.g. a PR adds or drops a
+    scenario). Without a baseline, head is aggregated over all its scenarios."""
+    if not base:
+        return None, _aggregate(head)
+    shared = {r["scenario"] for r in base} & {r["scenario"] for r in head}
+    base_agg = _aggregate([r for r in base if r["scenario"] in shared])
+    head_agg = _aggregate([r for r in head if r["scenario"] in shared])
+    return base_agg, head_agg
+
+
 def _overall_change(
     base_agg: dict, head_agg: dict
 ) -> tuple[int, int, int, float | None]:
@@ -1171,7 +1188,7 @@ def _overall_summary(base_agg: dict, head_agg: dict) -> str:
         trend = "mean 0% (unchanged)"
     return (
         f"{improved} improved, {regressed} regressed, {unchanged} unchanged "
-        f"across {len(_REPORT_METRICS)} metrics — {trend}"
+        f"across {improved + regressed + unchanged} metrics — {trend}"
     )
 
 
@@ -1274,8 +1291,7 @@ def render_markdown_compare(
     doesn't exist.
     """
     base_by = {r["scenario"]: r for r in base}
-    head_agg = _aggregate(head)
-    base_agg = _aggregate(base) if base else None
+    base_agg, head_agg = _compare_aggregates(base, head)
     out = [
         "### Steering evaluation (base vs head)",
         "",
@@ -1504,8 +1520,7 @@ def main(argv: list[str] | None = None) -> None:
     if args.html:
         from .eval_report import render_html_report
 
-        head_agg = _aggregate(results)
-        base_agg = _aggregate(base) if base else None
+        base_agg, head_agg = _compare_aggregates(base, results)
         report = render_html_report(
             base,
             results,

--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -1056,8 +1056,85 @@ _METRIC_GLOSSARY = [
 ]
 
 
+def _aggregate(results: list[dict]) -> dict:
+    """Collapse a result list into one synthetic "AGGREGATE" row.
+
+    Each reported metric becomes its **unweighted mean across the scenarios**
+    that carry it (a base produced before a metric existed simply doesn't
+    contribute that key — it's omitted from the aggregate, mirroring the
+    per-scenario renderers' ``—`` handling). One row that answers "did this
+    change help *overall*?" at a glance, on top of the per-scenario tables.
+
+    Means are scale-mixing on purpose: they're a rough headline, while the
+    per-metric relative deltas (and :func:`_overall_summary`) are the
+    unit-independent read on direction.
+    """
+    agg: dict = {"scenario": "AGGREGATE", "n_scenarios": len(results)}
+    for key in _REPORT_METRICS:
+        vals = [float(r[key]) for r in results if key in r]
+        if vals:
+            agg[key] = round(sum(vals) / len(vals), 1)
+    return agg
+
+
+def _overall_change(
+    base_agg: dict, head_agg: dict
+) -> tuple[int, int, int, float | None]:
+    """Count improved / regressed / unchanged aggregate metrics and the mean
+    relative change across them (``None`` when nothing is comparable).
+
+    Every reported metric is lower-is-better, so a negative mean is an overall
+    improvement. The mean is over *relative* deltas (head vs base, per metric),
+    making it unit-independent; metrics whose base aggregate is 0 contribute to
+    the up/down counts but not the percentage (no defined relative change)."""
+    improved = regressed = unchanged = 0
+    deltas: list[float] = []
+    for key in _REPORT_METRICS:
+        if key not in base_agg or key not in head_agg:
+            continue
+        bv, hv = float(base_agg[key]), float(head_agg[key])
+        if hv < bv:
+            improved += 1
+        elif hv > bv:
+            regressed += 1
+        else:
+            unchanged += 1
+        if bv != 0:
+            deltas.append((hv - bv) / abs(bv))
+    mean_pct = sum(deltas) / len(deltas) * 100.0 if deltas else None
+    return improved, regressed, unchanged, mean_pct
+
+
+def _overall_summary(base_agg: dict, head_agg: dict) -> str:
+    """One-line verdict for the aggregate: how many metrics moved each way and
+    the mean relative change (lower is better)."""
+    improved, regressed, unchanged, mean_pct = _overall_change(base_agg, head_agg)
+    if mean_pct is None:
+        trend = "no comparable metrics"
+    elif mean_pct < 0:
+        trend = f"mean {mean_pct:.1f}% (better)"
+    elif mean_pct > 0:
+        trend = f"mean +{mean_pct:.1f}% (worse)"
+    else:
+        trend = "mean 0% (unchanged)"
+    return (
+        f"{improved} improved, {regressed} regressed, {unchanged} unchanged "
+        f"across {len(_REPORT_METRICS)} metrics — {trend}"
+    )
+
+
 def render_text(results: list[dict]) -> str:
     lines = []
+    # A single aggregate row up top makes an overall read possible without
+    # eyeballing every scenario (skipped for a lone scenario — it'd just echo
+    # that scenario's own numbers).
+    if len(results) > 1:
+        agg = _aggregate(results)
+        lines.append(f"== AGGREGATE (mean across {agg['n_scenarios']} scenarios)")
+        for key in _REPORT_METRICS:
+            if key in agg:
+                lines.append(f"  {key:<24} {agg[key]}")
+        lines.append("")
     for res in results:
         lines.append(
             f"== {res['scenario']} (seed {res['seed']}, "
@@ -1074,6 +1151,25 @@ def _fmt_delta(base: float, head: float) -> str:
     if base == 0:
         return f"{head - base:+g}"
     return f"{(head - base) / abs(base) * 100.0:+.0f}%"
+
+
+def _md_metric_rows(base: dict | None, head: dict) -> list[str]:
+    """A `| Metric | Base | Head | Δ |` table body for one result pair.
+
+    Shared by the aggregate roll-up and the per-scenario tables. A base
+    produced before a metric existed (newly added metric on the PR head) has
+    no value to compare against, so both Base and Δ degrade to ``—``."""
+    rows = ["| Metric | Base | Head | Δ |", "|---|---:|---:|---:|"]
+    for key in _REPORT_METRICS:
+        hv: object = head.get(key, "—")
+        if base is not None and key in base and key in head:
+            bv: object = base[key]
+            delta = _fmt_delta(float(base[key]), float(head[key]))
+        else:
+            bv = "—"
+            delta = "—"
+        rows.append(f"| {key} | {bv} | {hv} | {delta} |")
+    return rows
 
 
 def render_markdown_compare(
@@ -1093,13 +1189,26 @@ def render_markdown_compare(
     doesn't exist.
     """
     base_by = {r["scenario"]: r for r in base}
+    head_agg = _aggregate(head)
+    base_agg = _aggregate(base) if base else None
     out = [
         "### Steering evaluation (base vs head)",
         "",
+    ]
+    # Lead with the aggregate so a reviewer sees the overall direction before
+    # any per-scenario table — the whole point of the roll-up.
+    if base_agg is not None:
+        out.append(f"**Overall: {_overall_summary(base_agg, head_agg)}.**")
+        out.append("")
+    out += [
         "Lower is better for every metric. See "
         "`src/astrameter/simulator/evaluation.py` for definitions.",
         "",
+        f"#### Aggregate — mean across {head_agg['n_scenarios']} scenarios",
+        "",
     ]
+    out += _md_metric_rows(base_agg, head_agg)
+    out.append("")
     if report_available:
         out += [
             "📊 **Interactive grid-power charts** (zoom / hover / toggle series) "
@@ -1124,18 +1233,7 @@ def render_markdown_compare(
             f"{_summary_line(b, res)}</summary>"
         )
         out.append("")
-        out.append("| Metric | Base | Head | Δ |")
-        out.append("|---|---:|---:|---:|")
-        for key in _REPORT_METRICS:
-            # A base produced before this metric existed (e.g. a newly added
-            # metric on the PR head) simply has no value to compare against.
-            if b is not None and key in b:
-                bv: object = b[key]
-                delta = _fmt_delta(float(b[key]), float(res[key]))
-            else:
-                bv = "—"
-                delta = "—"
-            out.append(f"| {key} | {bv} | {res[key]} | {delta} |")
+        out.extend(_md_metric_rows(b, res))
         out.append("")
         out.append("</details>")
     missing = [
@@ -1264,12 +1362,18 @@ def main(argv: list[str] | None = None) -> None:
     if args.html:
         from .eval_report import render_html_report
 
+        head_agg = _aggregate(results)
+        base_agg = _aggregate(base) if base else None
         report = render_html_report(
             base,
             results,
             report_metrics=_REPORT_METRICS,
             metric_glossary=_METRIC_GLOSSARY,
             fmt_delta=_fmt_delta,
+            aggregate=(base_agg, head_agg),
+            aggregate_summary=(
+                _overall_summary(base_agg, head_agg) if base_agg is not None else ""
+            ),
         )
         with open(args.html, "w", encoding="utf-8") as fh:
             fh.write(report)

--- a/tests/test_steering_eval.py
+++ b/tests/test_steering_eval.py
@@ -20,6 +20,7 @@ from astrameter.simulator.evaluation import (
     Event,
     Scenario,
     _aggregate,
+    _compare_aggregates,
     _fmt_delta,
     _merge_seeds,
     _overall_summary,
@@ -283,6 +284,32 @@ def test_overall_summary_reports_direction():
     assert "(better)" in _overall_summary(base_agg, better)
     assert "improved" in _overall_summary(base_agg, better)
     assert "(worse)" in _overall_summary(base_agg, worse)
+
+
+def test_overall_summary_denominator_counts_only_compared_metrics():
+    # Base carries only 2 of the reported metrics (e.g. an older base from
+    # before others existed); the verdict's denominator must be the metrics
+    # actually compared, not the full list.
+    base = {"settle_mean_s": 10.0, "overshoot_max_w": 100.0}
+    head = {"settle_mean_s": 8.0, "overshoot_max_w": 90.0}
+    assert "across 2 metrics" in _overall_summary(base, head)
+
+
+def test_compare_aggregates_uses_only_shared_scenarios():
+    def mk(name: str, settle: float) -> dict:
+        return {"scenario": name, "seed": 1, "settle_mean_s": settle}
+
+    # 'z' is base-only, 'c' is head-only; both must be excluded so the two
+    # aggregates are computed over the same {a, b} population.
+    base = [mk("a", 10.0), mk("b", 20.0), mk("z", 999.0)]
+    head = [mk("a", 8.0), mk("b", 16.0), mk("c", 1.0)]
+    base_agg, head_agg = _compare_aggregates(base, head)
+    assert base_agg is not None
+    assert base_agg["n_scenarios"] == head_agg["n_scenarios"] == 2
+    assert base_agg["settle_mean_s"] == 15.0  # (10+20)/2, no 'z'
+    assert head_agg["settle_mean_s"] == 12.0  # (8+16)/2, no 'c'
+    # No baseline: head aggregates over all its scenarios, base side is None.
+    assert _compare_aggregates(None, head) == (None, _aggregate(head))
 
 
 def test_render_text_adds_aggregate_only_for_multiple_scenarios():

--- a/tests/test_steering_eval.py
+++ b/tests/test_steering_eval.py
@@ -19,9 +19,12 @@ from astrameter.simulator.evaluation import (
     BatterySpec,
     Event,
     Scenario,
+    _aggregate,
     _fmt_delta,
+    _overall_summary,
     build_scenarios,
     render_markdown_compare,
+    render_text,
     run_scenario,
 )
 
@@ -242,6 +245,77 @@ def test_consumption_trace_matches_grid_plus_battery_output():
     for k in range(GRAPH_POINTS):
         expected = grid[k] + sum(b[k] for b in bat)
         assert abs(cons[k] - expected) <= 1.0
+
+
+def _two_results() -> list[dict]:
+    a = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
+    b = dict(a, scenario="tiny2", settle_mean_s=a["settle_mean_s"] + 4.0)
+    return [a, b]
+
+
+def test_aggregate_is_per_metric_mean_across_scenarios():
+    results = _two_results()
+    agg = _aggregate(results)
+    assert agg["scenario"] == "AGGREGATE"
+    assert agg["n_scenarios"] == 2
+    # Every reported metric is the unweighted mean of the two scenarios.
+    for key in _REPORT_METRICS:
+        expected = (float(results[0][key]) + float(results[1][key])) / 2
+        assert agg[key] == round(expected, 1), key
+
+
+def test_aggregate_omits_metrics_absent_from_every_result():
+    res = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
+    old = {k: v for k, v in res.items() if k != "grid_p2p_w"}
+    # A base produced before grid_p2p_w existed contributes no value for it, so
+    # the aggregate simply omits the key (renderers then show '—').
+    assert "grid_p2p_w" not in _aggregate([old])
+    assert "grid_p2p_w" in _aggregate([res])
+
+
+def test_overall_summary_reports_direction():
+    base_agg = {"settle_mean_s": 10.0, "overshoot_max_w": 100.0}
+    better = {"settle_mean_s": 8.0, "overshoot_max_w": 90.0}
+    worse = {"settle_mean_s": 12.0, "overshoot_max_w": 110.0}
+    assert "(better)" in _overall_summary(base_agg, better)
+    assert "improved" in _overall_summary(base_agg, better)
+    assert "(worse)" in _overall_summary(base_agg, worse)
+
+
+def test_render_text_adds_aggregate_only_for_multiple_scenarios():
+    multi = render_text(_two_results())
+    assert "AGGREGATE (mean across 2 scenarios)" in multi
+    # A single scenario would just echo its own numbers, so no aggregate.
+    single = render_text([asyncio.run(run_scenario(_tiny_scenario(), seed=3))])
+    assert "AGGREGATE" not in single
+
+
+def test_markdown_compare_leads_with_aggregate_rollup():
+    results = _two_results()
+    base = [dict(r, overshoot_max_w=r["overshoot_max_w"] + 50.0) for r in results]
+    md = render_markdown_compare(base, results)
+    assert "**Overall:" in md
+    assert "Aggregate — mean across 2 scenarios" in md
+    # The overall verdict and the aggregate table both precede any per-scenario
+    # collapsible, so the roll-up is the first thing a reviewer sees.
+    assert md.index("Aggregate — mean across") < md.index("<details>")
+
+
+def test_html_report_renders_aggregate_section():
+    results = _two_results()
+    base = [dict(r, overshoot_max_w=r["overshoot_max_w"] + 50.0) for r in results]
+    base_agg, head_agg = _aggregate(base), _aggregate(results)
+    h = render_html_report(
+        base,
+        results,
+        report_metrics=_REPORT_METRICS,
+        metric_glossary=_METRIC_GLOSSARY,
+        fmt_delta=_fmt_delta,
+        aggregate=(base_agg, head_agg),
+        aggregate_summary=_overall_summary(base_agg, head_agg),
+    )
+    assert "Aggregate &mdash; mean across 2 scenarios" in h
+    assert "improved" in h  # the one-line verdict is rendered
 
 
 def test_metric_glossary_covers_every_reported_metric():

--- a/tests/test_steering_eval.py
+++ b/tests/test_steering_eval.py
@@ -21,7 +21,10 @@ from astrameter.simulator.evaluation import (
     Scenario,
     _aggregate,
     _fmt_delta,
+    _merge_seeds,
     _overall_summary,
+    _run_all,
+    _seed_label,
     build_scenarios,
     render_markdown_compare,
     render_text,
@@ -316,6 +319,69 @@ def test_html_report_renders_aggregate_section():
     )
     assert "Aggregate &mdash; mean across 2 scenarios" in h
     assert "improved" in h  # the one-line verdict is rendered
+
+
+def test_merge_seeds_averages_metrics_and_traces():
+    r1 = {
+        "scenario": "x",
+        "seed": 1,
+        "settle_mean_s": 10.0,
+        "unsettled_events": 0,
+        "grid_trace": [0.0, 10.0],
+        "battery_traces": [[1.0, 3.0]],
+        "battery_labels": ["B1 HMG-50"],
+    }
+    r2 = dict(
+        r1,
+        seed=2,
+        settle_mean_s=20.0,
+        unsettled_events=1,
+        grid_trace=[2.0, 20.0],
+        battery_traces=[[3.0, 5.0]],
+    )
+    merged = _merge_seeds([r1, r2])
+    assert merged["seeds"] == [1, 2] and merged["n_seeds"] == 2
+    assert "seed" not in merged  # the single-seed field is replaced
+    # Scalars and traces are the element-wise mean over seeds.
+    assert merged["settle_mean_s"] == 15.0
+    assert merged["unsettled_events"] == 0.5
+    assert merged["grid_trace"] == [1.0, 15.0]
+    assert merged["battery_traces"] == [[2.0, 4.0]]
+    # Labels (identical across seeds) pass through.
+    assert merged["battery_labels"] == ["B1 HMG-50"]
+
+
+def test_merge_seeds_single_seed_is_passthrough():
+    r = {"scenario": "x", "seed": 1, "settle_mean_s": 10.0}
+    # One seed: nothing to average, the original row (with its seed) is returned.
+    assert _merge_seeds([r]) is r
+
+
+def test_seed_label_reads_single_or_averaged():
+    assert _seed_label({"seed": 3}) == "seed 3"
+    assert _seed_label({"n_seeds": 4, "seeds": [1, 2, 3, 4]}) == "mean of 4 seeds"
+
+
+def test_markdown_compare_notes_seed_averaging():
+    res = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
+    head = [dict(res, n_seeds=3, seeds=[1, 2, 3])]
+    md = render_markdown_compare([res], head)
+    # The reader is told the head figures are seed-averaged (not a single draw).
+    assert "Metrics are the per-scenario" in md
+    assert "mean of 3 seeds" in md
+
+
+def test_run_all_runs_seeds_in_parallel_and_merges():
+    # End-to-end through the process pool: one real (short) scenario over two
+    # seeds collapses to a single seed-averaged row.
+    results = _run_all(["single_venus_washer"], [1, 2], {})
+    assert len(results) == 1
+    r = results[0]
+    assert r["scenario"] == "single_venus_washer"
+    assert r["n_seeds"] == 2 and r["seeds"] == [1, 2]
+    assert "seed" not in r
+    for key in _REPORT_METRICS:
+        assert key in r
 
 
 def test_metric_glossary_covers_every_reported_metric():


### PR DESCRIPTION
## Summary

The steering evaluation now runs each scenario over multiple seeds (default 5) in parallel across CPU cores, reports seed-averaged metrics instead of single noisy draws, and leads comparison reports with an aggregate roll-up showing overall direction at a glance.

## Key Changes

- **Parallel seed execution**: Scenarios run across multiple seeds concurrently using `ProcessPoolExecutor`. Each seed gets its own process and global `random` state, ensuring deterministic runs while achieving true parallelism on CPU-bound simulation.

- **Seed averaging**: Per-scenario results are merged via `_merge_seeds()`, which averages all numeric metrics and traces element-wise across seeds. Single-seed runs pass through unchanged for backward compatibility.

- **Aggregate roll-up**: New `_aggregate()` function computes per-metric means across all scenarios, providing a synthetic "AGGREGATE" row that answers "did this help overall?" at a glance. `_overall_summary()` adds a one-line verdict (improved/regressed/unchanged counts and mean relative change).

- **Report improvements**:
  - Text output now leads with AGGREGATE (when multiple scenarios) before per-scenario details
  - Markdown comparison leads with overall verdict and aggregate table before per-scenario collapsibles
  - HTML report renders aggregate section with summary and metrics table
  - New `_seeds_caption()` and `_seeds_note()` explain seed averaging to readers

- **CLI updates**:
  - `--seed` now specifies the first seed; `--seeds N` (default 5) runs N seeds in parallel
  - `--seeds 1` disables averaging for quick single-seed runs
  - Validation ensures `--seeds >= 1`

- **Helper functions**:
  - `_mean_value()`: Recursively averages homogeneous values (scalars, lists, nested traces)
  - `_seed_label()`: Formats seed provenance ("seed N" or "mean of N seeds")
  - `_md_metric_rows()`: Shared table-building logic for aggregate and per-scenario comparisons
  - `_run_one()`: Worker function for process pool (rebuilds scenario registry to avoid pickling closures)
  - `_run_tasks()`: Orchestrates parallel execution with fallback to inline for single task

## Implementation Details

- Process isolation (not asyncio) parallelizes the CPU-bound simulation and provides each seed its own RNG state for determinism
- Metrics absent from older baselines (newly added on PR head) degrade to "—" in comparisons, with aggregate omitting the key
- Relative delta calculations skip metrics with zero base values (undefined percentage change) but still count them in improvement/regression tallies
- Seed averaging is transparent to existing code paths; single-seed results behave identically to before

https://claude.ai/code/session_011dMKAuxEc72FUXkFK7ZQ5j

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluation now runs scenarios in parallel across multiple deterministic seeds and averages results (seed-averaged means).
  * Text, Markdown comparison, and HTML reports can include an aggregate roll-up with an overall improved/regressed/unchanged verdict and metric delta summary.
  * Added `--seed` and `--seeds` CLI options for seed configuration.
* **Documentation**
  * Updated steering-quality evaluation guidance to reflect parallel CPU execution, seed-averaged figures, and improved/baseline comparison reporting format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->