### PR TITLE
Add noisy house baseline scenarios for noise-rejection testing

### DIFF
--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -729,6 +729,27 @@ def _washer_cycle(rng: random.Random, duration: float) -> list[Event]:
     return events
 
 
+# "Pretty noisy" house baseline: a net draw that jitters hard sample-to-sample
+# (many small switching loads — fridge, electronics, pumps, chargers — with no
+# single dominant appliance). The ±_NOISY_BASE_NOISE W uniform jitter on every
+# meter read is the only disturbance: there are no scripted load steps, so (like
+# the washer scenario) this is scored on the sustained-oscillation aggregates
+# (grid_p2p_w, band_crossings_per_h, steady_rms_w, mean_abs_grid_w,
+# battery_travel_w_per_h) rather than per-step settling — a balancer that ignores
+# the noise (spike filter / deadband / damping) holds grid swing and battery
+# travel down instead of chasing every wiggle.
+_NOISY_BASE_LOAD = [400.0, 0.0, 0.0]
+_NOISY_BASE_NOISE = 150.0
+
+
+def _no_events(_rng: random.Random) -> list[Event]:
+    """A scenario with no scripted events: only the base load and its noise (plus
+    any solar) drive the loop, so the loop is exercised purely on noise rejection
+    and scored on the sustained-oscillation aggregates (the step-response metrics
+    read 0 with no labeled events)."""
+    return []
+
+
 def _solar_curve(duration: float, peak: float) -> list[Event]:
     """Unlabeled half-sine solar day curve.
 
@@ -834,6 +855,22 @@ def build_scenarios() -> dict[str, Scenario]:
         )
     )
 
+    add(
+        Scenario(
+            name="single_venus_noisy",
+            description=(
+                "One Venus, pretty noisy house baseline "
+                f"(±{_NOISY_BASE_NOISE:g} W jitter, no discrete appliance steps) "
+                "— noise-rejection stress"
+            ),
+            batteries=[_VENUS],
+            duration_s=dur_steps,
+            base_load=list(_NOISY_BASE_LOAD),
+            base_noise=_NOISY_BASE_NOISE,
+            build_events=_no_events,
+        )
+    )
+
     dur_solar = 5400.0
     solar_peak = 1800.0
     add(
@@ -915,6 +952,23 @@ def build_scenarios() -> dict[str, Scenario]:
                 duration_s=dur_steps,
                 loads=list(_HOUSEHOLD_LOADS),
                 build_events=lambda rng: _household_steps(rng, dur_steps),
+                ct_kwargs=dict(kwargs),
+            )
+        )
+
+    for mode, kwargs in (("fair", {}), ("eff", _EFF_MODE)):
+        add(
+            Scenario(
+                name=f"two_venus_noisy/{mode}",
+                description=(
+                    "Two Venus sharing one phase, pretty noisy house baseline "
+                    f"(±{_NOISY_BASE_NOISE:g} W jitter, no discrete appliance steps)"
+                ),
+                batteries=[_VENUS, _VENUS],
+                duration_s=dur_steps,
+                base_load=list(_NOISY_BASE_LOAD),
+                base_noise=_NOISY_BASE_NOISE,
+                build_events=_no_events,
                 ct_kwargs=dict(kwargs),
             )
         )
@@ -1446,6 +1500,14 @@ def render_markdown_compare(
     out.append("")
     out.append("</details>")
     out.append("")
+    # Collapse every per-scenario table behind one outer section so the comment
+    # leads with the aggregate roll-up and verdicts; reviewers expand this only
+    # to drill into individual scenarios (each still its own nested collapsible).
+    out.append(
+        f"<details><summary><b>Per-scenario tables</b> "
+        f"({len(head)} scenarios)</summary>"
+    )
+    out.append("")
     for res in head:
         b = base_by.get(res["scenario"])
         out.append(
@@ -1456,6 +1518,8 @@ def render_markdown_compare(
         out.extend(_md_metric_rows(b, res))
         out.append("")
         out.append("</details>")
+    out.append("")
+    out.append("</details>")
     missing = [
         r["scenario"]
         for r in base

--- a/tests/test_steering_eval.py
+++ b/tests/test_steering_eval.py
@@ -116,6 +116,15 @@ def test_scenario_registry_shape():
     assert "mixed_cadence_solar/eff" in scenarios
     # Washing-machine spike-absorption stress (issue #473).
     assert "single_venus_washer" in scenarios
+    # Pretty-noisy house baseline (noise-rejection stress), single and two Venus.
+    assert "single_venus_noisy" in scenarios
+    assert "two_venus_noisy/fair" in scenarios
+    assert "two_venus_noisy/eff" in scenarios
+    # The noisy variant carries a markedly louder baseline than the stepped one.
+    assert (
+        scenarios["single_venus_noisy"].base_noise
+        > scenarios["single_venus_steps"].base_noise
+    )
     # Venus D (VNSD-0 integer loop) variants, including a heterogeneous phase
     # sharing with a Venus C (HMG float ramp).
     assert "single_venus_d_steps" in scenarios
@@ -135,6 +144,9 @@ def test_markdown_compare_renders():
     md = render_markdown_compare([base], [res])
     assert "| overshoot_max_w |" in md
     assert "tiny" in md
+    # Every per-scenario table is collapsed behind one outer section so the
+    # comment leads with the aggregate roll-up.
+    assert "Per-scenario tables" in md
     # The collapsible metric glossary is included with a row per metric.
     assert "What do these metrics mean?" in md
     for key in _REPORT_METRICS:
@@ -500,6 +512,22 @@ def test_washer_scenario_reproduces_sustained_oscillation():
     assert res["band_crossings_per_h"] > 0
     assert res["mean_abs_grid_w"] > 0
     # All reported metrics are populated and non-negative.
+    for key in _REPORT_METRICS:
+        assert res[key] >= 0, key
+
+
+def test_noisy_scenario_has_no_labeled_events_but_scores_aggregates():
+    """The pretty-noisy house baseline has no scripted load steps (so the
+    step-response metrics read 0), and the loud baseline noise drives the loop:
+    it is scored on the sustained-oscillation aggregates, all of which stay
+    populated and non-negative."""
+    sc = build_scenarios()["single_venus_noisy"]
+    assert sc.build_events(__import__("random").Random(1)) == []
+    res = asyncio.run(run_scenario(sc, seed=1))
+    assert res["events_measured"] == 0
+    # The noise keeps the grid moving, so the oscillation aggregates are live.
+    assert res["grid_p2p_w"] > 0
+    assert res["mean_abs_grid_w"] > 0
     for key in _REPORT_METRICS:
         assert res[key] >= 0, key
 


### PR DESCRIPTION
## Summary

Adds new evaluation scenarios with a "pretty noisy" house baseline to stress-test noise rejection in the balancer. These scenarios have no scripted load steps—only a base load with ±150 W uniform jitter—and are scored on sustained-oscillation aggregates rather than step-response metrics.

## Changes

- **New scenario constants**: `_NOISY_BASE_LOAD` (400 W) and `_NOISY_BASE_NOISE` (±150 W) define the noisy baseline
- **New event builder**: `_no_events()` returns an empty event list, allowing the loop to be exercised purely on noise rejection
- **New scenarios**:
  - `single_venus_noisy`: One Venus with noisy baseline
  - `two_venus_noisy/fair` and `two_venus_noisy/eff`: Two Venus sharing one phase, in fair and efficiency modes
- **Improved markdown output**: Per-scenario tables are now collapsed behind a single outer `<details>` section so the aggregate roll-up and verdicts appear first; reviewers expand only to drill into individual scenarios
- **Test coverage**: Added assertions verifying the new scenarios exist, that noisy variants have higher baseline noise than stepped variants, and that the noisy scenario produces no labeled events but populates sustained-oscillation metrics

## Implementation Details

The noisy scenarios differ from the existing `single_venus_steps` and `two_venus_steps` scenarios by:
- Using `_no_events()` instead of `_step_events()`, so `events_measured` reads 0
- Carrying a much louder baseline noise (150 W vs. ~20 W), making noise rejection the primary challenge
- Being scored on `grid_p2p_w`, `band_crossings_per_h`, `steady_rms_w`, `mean_abs_grid_w`, and `battery_travel_w_per_h` rather than per-step settling metrics

The markdown rendering change wraps all per-scenario tables in a collapsible section, improving readability of comparison reports by leading with the aggregate summary.

https://claude.ai/code/session_01NncsRrfdSXTFtJyThwdc8r

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added noisy baseline test scenarios for single and multi-battery configurations to enhance noise rejection evaluation
  * Enhanced markdown reporting with collapsible per-scenario sections for improved readability

* **Tests**
  * Expanded coverage for new noisy baseline scenarios and noise metrics validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->