### PR TITLE
Add cost regret metric and perfect-foresight oracle benchmark

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ second **priority verdict** sits below it: a value-weighted score (`_METRIC_WEIG
 — import-heavy self-consumption energy, do-no-harm overshoot/hunting guardrails,
 cycle-life battery travel) plus a hard flag when any do-no-harm guardrail
 (`_GUARDRAIL_METRICS`: overshoot, band-crossings, grid p2p, and avoidable grid
-import — the retail-tariff money metric) regresses past 5% (or appears from a
-zero base). Read the flat mean for "did most numbers move down?" and the priority verdict
+import/export — the self-consumption money metrics) regresses past 5% (or
+appears from a zero base). Read the flat mean for "did most numbers move down?" and the priority verdict
 for "did it improve *where it matters*, and did it break a guardrail?".
 
 ## Changelog

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ second **priority verdict** sits below it: a value-weighted score (`_METRIC_WEIG
 — import-heavy self-consumption energy, do-no-harm overshoot/hunting guardrails,
 cycle-life battery travel) plus a hard flag when any do-no-harm guardrail
 (`_GUARDRAIL_METRICS`: overshoot, band-crossings, grid p2p, and avoidable grid
-import/export — the self-consumption money metrics) regresses past 5% (or
-appears from a zero base). Read the flat mean for "did most numbers move down?" and the priority verdict
+import — the retail-tariff money metric) regresses past 5% (or appears from a
+zero base). Read the flat mean for "did most numbers move down?" and the priority verdict
 for "did it improve *where it matters*, and did it break a guardrail?".
 
 ## Changelog

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,12 +42,25 @@ scenarios plus a one-line overall verdict — how many metrics
 improved/regressed and the mean relative change), so an across-the-board
 improvement or regression is visible without reading every scenario table. A
 second **priority verdict** sits below it: a value-weighted score (`_METRIC_WEIGHTS`
-— import-heavy self-consumption energy, do-no-harm overshoot/hunting guardrails,
-cycle-life battery travel) plus a hard flag when any do-no-harm guardrail
-(`_GUARDRAIL_METRICS`: overshoot, band-crossings, grid p2p, and avoidable grid
-import — the retail-tariff money metric) regresses past 5% (or appears from a
-zero base). Read the flat mean for "did most numbers move down?" and the priority verdict
-for "did it improve *where it matters*, and did it break a guardrail?".
+— `cost_regret_ct` money north-star, import-heavy self-consumption energy,
+do-no-harm overshoot/hunting guardrails, cycle-life battery travel) plus a hard
+flag when any do-no-harm guardrail (`_GUARDRAIL_METRICS`: overshoot,
+band-crossings, grid p2p, avoidable grid import, and cost regret) regresses past
+5% (or appears from a zero base). Read the flat mean for "did most numbers move
+down?" and the priority verdict for "did it improve *where it matters*, and did
+it break a guardrail?".
+
+The headline metric is **`cost_regret_ct`**: the controller's electricity bill
+(eurocents, asymmetric tariff — import @ `RETAIL_CT_PER_KWH`, export @
+`FEEDIN_CT_PER_KWH`) minus what a **perfect-foresight optimal battery** would
+have paid on the same load (`_oracle_cost_ct`, a lossless greedy aggregate
+battery — provably optimal under a flat tariff). It is the single ungameable
+"money the controller left on the table" number — 0 means it matched the
+optimum; the irreducible cost when the pack saturates is subtracted out, so
+regret is purely controllable loss. **`grid_rms_w`** is the whole-run L2 tracking
+error (control quality, transients included), pairing with
+`battery_travel_w_per_h` as the effort term (the two LQR terms are kept separate,
+not fused with an arbitrary weight).
 
 ## Changelog
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,9 @@ improvement or regression is visible without reading every scenario table. A
 second **priority verdict** sits below it: a value-weighted score (`_METRIC_WEIGHTS`
 — import-heavy self-consumption energy, do-no-harm overshoot/hunting guardrails,
 cycle-life battery travel) plus a hard flag when any do-no-harm guardrail
-(`_GUARDRAIL_METRICS`: overshoot, band-crossings, grid p2p) regresses past 5%.
-Read the flat mean for "did most numbers move down?" and the priority verdict
+(`_GUARDRAIL_METRICS`: overshoot, band-crossings, grid p2p, and avoidable grid
+import — the retail-tariff money metric) regresses past 5% (or appears from a
+zero base). Read the flat mean for "did most numbers move down?" and the priority verdict
 for "did it improve *where it matters*, and did it break a guardrail?".
 
 ## Changelog

--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -100,8 +100,10 @@ SOC_FULL = 0.98
 # (much lower) feed-in tariff.  These are the only value judgment in the cost
 # metric; the asymmetry (retail >> feed-in) is what makes a controller that
 # silently exports stored energy show up as money lost.  Costs are reported in
-# *eurocents* (not euros) because the report rounds metrics to one decimal —
-# euros would collapse a real difference to 0.0.
+# *eurocents* (not euros) and the cost keys are rounded to 2 dp everywhere
+# (per-scenario rows, seed-merge and the aggregate — see ``_metric_ndp``);
+# regret clusters at fractions of a cent, so the usual 1-dp metric rounding
+# would quantize the guardrail's 5% test into noise.
 RETAIL_CT_PER_KWH = 30.0
 FEEDIN_CT_PER_KWH = 8.0
 # Number of points each scenario's grid-power trace is downsampled to for the
@@ -488,10 +490,19 @@ def _oracle_cost_ct(scenario: Scenario, samples: list[_Sample]) -> float:
     empty or power-limited — so ``actual_cost - oracle_cost`` isolates the cost
     the *controller* could have avoided.
 
-    Approximations (documented, not exact): the fleet is treated as one AC
-    battery, so per-phase routing is ignored (slightly optimistic in the
-    three-phase scenario) and a DC-only B2500's PV-passthrough is not modelled
-    (it contributes 0 charge power, its discharge + capacity still count)."""
+    Two aggregation approximations bias the floor in *opposite* directions:
+      * **Phase routing is ignored** (the fleet is one battery): a real per-phase
+        controller can be forced to import on one phase while exporting on
+        another, which the netted aggregate avoids — so the oracle is *optimistic*
+        (a true lower bound) in the three-phase scenario.  Regret stays >= 0.
+      * **A DC-only B2500's PV-passthrough is not modelled** (it contributes 0
+        charge power; only its discharge + capacity count).  The real B2500 self-
+        consumes DC solar the aggregate — fed only by ``consumption`` — never sees
+        as chargeable, so here the oracle is *pessimistic* and a real controller
+        can beat it.  ``cost_regret_ct`` clamps at 0, so in ``mixed_venus_b2500``
+        scenarios regret is a conservative under-estimate of controller skill, not
+        a true lower bound.  (Feeding the DC-input trace into the oracle would fix
+        this; it is not in ``_Sample`` today.)"""
     specs = scenario.batteries
     cap_wh = sum(s.capacity_wh for s in specs)
     max_charge = sum(s.max_charge_power for s in specs)
@@ -505,12 +516,12 @@ def _oracle_cost_ct(scenario: Scenario, samples: list[_Sample]) -> float:
         h = dt / 3600.0
         net = prev.consumption  # >0 deficit (would import), <0 surplus (export)
         if net > 0:
-            discharge = min(net, max_discharge, energy_wh / h if h > 0 else net)
+            discharge = min(net, max_discharge, energy_wh / h)
             energy_wh -= discharge * h
             grid = net - discharge
         else:
             room_wh = cap_wh - energy_wh
-            charge = min(-net, max_charge, room_wh / h if h > 0 else -net)
+            charge = min(-net, max_charge, room_wh / h)
             energy_wh += charge * h
             grid = net + charge
         if grid > 0:
@@ -575,7 +586,6 @@ def _compute_metrics(
 
     steady = [s.grid for s in samples if not in_transient(s.t)]
     steady_rms = math.sqrt(sum(g * g for g in steady) / len(steady)) if steady else 0.0
-    mean_abs = sum(abs(s.grid) for s in samples) / len(samples) if samples else 0.0
 
     # --- sustained oscillation amplitude ---
     # The robust peak-to-peak grid swing (p95 - p5) over the whole run. Unlike
@@ -587,25 +597,26 @@ def _compute_metrics(
     all_grid = [s.grid for s in samples]
     grid_p2p = _percentile(all_grid, 0.95) - _percentile(all_grid, 0.05)
 
-    # --- whole-run L2 tracking error (control quality) ---
-    # RMS grid power over the *entire* run, transients included (unlike
-    # steady_rms_w, which excludes post-event windows). This is the L2 tracking
-    # term of the classic control objective: squaring punishes large excursions
-    # (overshoot, big swings) far harder than a small steady offset, so it reads
-    # "how cleanly did the loop hold zero?" as one number. Its effort partner is
-    # battery_travel_w_per_h; the two are kept separate rather than fused into a
-    # single weighted scalar so neither needs an arbitrary trade-off constant.
-    grid_rms = (
-        math.sqrt(sum(g * g for g in all_grid) / len(all_grid)) if all_grid else 0.0
-    )
-
-    # --- energy & battery travel ---
+    # --- energy, battery travel & whole-run L2 tracking error ---
+    # grid_rms is RMS grid power over the *entire* run, transients included
+    # (unlike steady_rms_w, which excludes post-event windows). It's the L2
+    # tracking term of the classic control objective: squaring punishes large
+    # excursions (overshoot, big swings) far harder than a small steady offset, so
+    # it reads "how cleanly did the loop hold zero?" as one number. Its effort
+    # partner is battery_travel_w_per_h; the two are kept separate rather than
+    # fused with an arbitrary trade-off constant. Both grid_rms and mean_abs are
+    # *time-weighted* (by dt) so they're true time-averages, not sample-averages
+    # skewed by uneven / staggered poll spacing (slow meters, multi-battery).
     import_wh = export_wh = avoid_import_wh = avoid_export_wh = 0.0
     travel_w = 0.0
+    grid_sq_dt = abs_grid_dt = total_dt = 0.0
     for prev, cur in itertools.pairwise(samples):
         dt = min(cur.t - prev.t, 5.0)
         if dt <= 0:
             continue
+        grid_sq_dt += prev.grid * prev.grid * dt
+        abs_grid_dt += abs(prev.grid) * dt
+        total_dt += dt
         wh = prev.grid * dt / 3600.0
         if wh > 0:
             import_wh += wh
@@ -630,14 +641,19 @@ def _compute_metrics(
                 avoid_export_wh += -wh
         travel_w += sum(abs(cur.powers[i] - prev.powers[i]) for i in range(len(specs)))
 
+    grid_rms = math.sqrt(grid_sq_dt / total_dt) if total_dt > 0 else 0.0
+    mean_abs = abs_grid_dt / total_dt if total_dt > 0 else 0.0
+
     # --- money: cost vs perfect-foresight oracle (the north-star metric) ---
     # The actual electricity bill (eurocents) for the residual grid this
     # controller left, minus what an ideal perfect-foresight battery would have
     # paid on the same load. The difference is the money the *controller* could
     # have saved — ungameable (both import and export cost), 0 = matched perfect
-    # foresight. Clamped at 0: the oracle is optimal by construction, so any
-    # negative is aggregate-model slack (phase routing / DC passthrough), not a
-    # controller beating perfect foresight.
+    # foresight. Clamped at 0 because the aggregate oracle is a true lower bound
+    # in every AC scenario (phase netting only makes it optimistic); the one case
+    # it can be *beaten* is a B2500 self-consuming DC solar the oracle doesn't
+    # model (see ``_oracle_cost_ct``), where the clamp deliberately reports the
+    # conservative 0 rather than a misleading "controller beat the optimum".
     grid_cost = _grid_cost_ct(import_wh, export_wh)
     oracle_cost = _oracle_cost_ct(scenario, samples)
     cost_regret = max(0.0, grid_cost - oracle_cost)
@@ -1718,21 +1734,30 @@ _METRIC_GLOSSARY = [
 ]
 
 
-def _mean_value(values: list):
+def _metric_ndp(key: str) -> int:
+    """Decimal places to round a metric to. Eurocent costs need 2: per-scenario
+    ``cost_regret_ct`` clusters at fractions of a cent, so rounding the
+    aggregate/seed-merge to 1 dp would quantize the guardrail's 5% test into
+    pure noise. Every other metric keeps the 1-dp report convention."""
+    return 2 if key.endswith("_ct") else 1
+
+
+def _mean_value(values: list, ndp: int = 1):
     """Average a homogeneous list of result values across seeds.
 
     Recurses into nested lists (a battery's trace, the list of per-battery
     traces) so traces average element-by-element; string lists (battery
-    labels, identical across seeds) pass through as the first value."""
+    labels, identical across seeds) pass through as the first value. *ndp* is
+    the rounding precision for numeric values (see :func:`_metric_ndp`)."""
     v0 = values[0]
     if isinstance(v0, bool):
         return v0
     if isinstance(v0, (int, float)):
-        return round(sum(float(v) for v in values) / len(values), 1)
+        return round(sum(float(v) for v in values) / len(values), ndp)
     if isinstance(v0, list):
         if v0 and isinstance(v0[0], str):
             return v0  # labels are identical across seeds
-        return [_mean_value([v[i] for v in values]) for i in range(len(v0))]
+        return [_mean_value([v[i] for v in values], ndp) for i in range(len(v0))]
     return v0  # strings / anything else: identical across seeds
 
 
@@ -1754,7 +1779,7 @@ def _merge_seeds(per_seed: list[dict]) -> dict:
     for key in per_seed[0]:
         if key in ("scenario", "seed"):
             continue
-        merged[key] = _mean_value([r[key] for r in per_seed])
+        merged[key] = _mean_value([r[key] for r in per_seed], _metric_ndp(key))
     return merged
 
 
@@ -1775,7 +1800,7 @@ def _aggregate(results: list[dict]) -> dict:
     for key in _REPORT_METRICS:
         vals = [float(r[key]) for r in results if key in r]
         if vals:
-            agg[key] = round(sum(vals) / len(vals), 1)
+            agg[key] = round(sum(vals) / len(vals), _metric_ndp(key))
     return agg
 
 

--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -93,6 +93,17 @@ STEADY_EXCLUDE_S = 120.0
 HEADROOM_MARGIN_W = 5.0
 SOC_EMPTY = 0.02
 SOC_FULL = 0.98
+
+# --- Cost / oracle metric (the money north-star) ---------------------------
+# Flat (time-invariant) EU-typical tariffs used to price the residual grid
+# exchange in eurocents.  Import is paid at the retail tariff, export earns the
+# (much lower) feed-in tariff.  These are the only value judgment in the cost
+# metric; the asymmetry (retail >> feed-in) is what makes a controller that
+# silently exports stored energy show up as money lost.  Costs are reported in
+# *eurocents* (not euros) because the report rounds metrics to one decimal —
+# euros would collapse a real difference to 0.0.
+RETAIL_CT_PER_KWH = 30.0
+FEEDIN_CT_PER_KWH = 8.0
 # Number of points each scenario's grid-power trace is downsampled to for the
 # interactive charts in the HTML report. Base and head share this fixed count
 # so the two lines align by index regardless of poll cadence.
@@ -451,6 +462,64 @@ def _battery_pick(i: int) -> Callable[[_Sample], float]:
     return lambda s: s.powers[i]
 
 
+def _grid_cost_ct(import_wh: float, export_wh: float) -> float:
+    """Electricity bill (eurocents) for a residual grid exchange: import paid at
+    the retail tariff, export credited at the (lower) feed-in tariff.  Can go
+    negative when feed-in credit exceeds import cost."""
+    return (RETAIL_CT_PER_KWH * import_wh - FEEDIN_CT_PER_KWH * export_wh) / 1000.0
+
+
+def _oracle_cost_ct(scenario: Scenario, samples: list[_Sample]) -> float:
+    """Cost (eurocents) of the *perfect-foresight* battery dispatch — the
+    achievable floor this scenario's controller is benchmarked against.
+
+    The household net load is ``_Sample.consumption`` (load + noise - solar,
+    the same source the controller fights to zero out).  The oracle runs a
+    single ideal aggregate battery (summed capacity / charge / discharge power
+    across the fleet, lossless to match the simulator's lossless plant) with
+    perfect foresight and instantaneous response, greedily storing every watt of
+    surplus it can and discharging to cover every watt of deficit it can.
+
+    Under a flat tariff with a lossless battery this greedy dispatch *is* the
+    optimum: every stored Wh is equally valuable, foresight cannot conjure energy
+    a causal controller lacks, and ``retail >= feed-in`` makes storing surplus
+    always worth more than exporting it.  What it leaves on the grid is therefore
+    physically irreducible — surplus when the pack is full, deficit when it is
+    empty or power-limited — so ``actual_cost - oracle_cost`` isolates the cost
+    the *controller* could have avoided.
+
+    Approximations (documented, not exact): the fleet is treated as one AC
+    battery, so per-phase routing is ignored (slightly optimistic in the
+    three-phase scenario) and a DC-only B2500's PV-passthrough is not modelled
+    (it contributes 0 charge power, its discharge + capacity still count)."""
+    specs = scenario.batteries
+    cap_wh = sum(s.capacity_wh for s in specs)
+    max_charge = sum(s.max_charge_power for s in specs)
+    max_discharge = sum(s.max_discharge_power for s in specs)
+    energy_wh = sum(s.initial_soc * s.capacity_wh for s in specs)
+    import_wh = export_wh = 0.0
+    for prev, cur in itertools.pairwise(samples):
+        dt = min(cur.t - prev.t, 5.0)
+        if dt <= 0:
+            continue
+        h = dt / 3600.0
+        net = prev.consumption  # >0 deficit (would import), <0 surplus (export)
+        if net > 0:
+            discharge = min(net, max_discharge, energy_wh / h if h > 0 else net)
+            energy_wh -= discharge * h
+            grid = net - discharge
+        else:
+            room_wh = cap_wh - energy_wh
+            charge = min(-net, max_charge, room_wh / h if h > 0 else -net)
+            energy_wh += charge * h
+            grid = net + charge
+        if grid > 0:
+            import_wh += grid * h
+        else:
+            export_wh += -grid * h
+    return _grid_cost_ct(import_wh, export_wh)
+
+
 def _compute_metrics(
     scenario: Scenario,
     seed: int,
@@ -518,6 +587,18 @@ def _compute_metrics(
     all_grid = [s.grid for s in samples]
     grid_p2p = _percentile(all_grid, 0.95) - _percentile(all_grid, 0.05)
 
+    # --- whole-run L2 tracking error (control quality) ---
+    # RMS grid power over the *entire* run, transients included (unlike
+    # steady_rms_w, which excludes post-event windows). This is the L2 tracking
+    # term of the classic control objective: squaring punishes large excursions
+    # (overshoot, big swings) far harder than a small steady offset, so it reads
+    # "how cleanly did the loop hold zero?" as one number. Its effort partner is
+    # battery_travel_w_per_h; the two are kept separate rather than fused into a
+    # single weighted scalar so neither needs an arbitrary trade-off constant.
+    grid_rms = (
+        math.sqrt(sum(g * g for g in all_grid) / len(all_grid)) if all_grid else 0.0
+    )
+
     # --- energy & battery travel ---
     import_wh = export_wh = avoid_import_wh = avoid_export_wh = 0.0
     travel_w = 0.0
@@ -549,6 +630,18 @@ def _compute_metrics(
                 avoid_export_wh += -wh
         travel_w += sum(abs(cur.powers[i] - prev.powers[i]) for i in range(len(specs)))
 
+    # --- money: cost vs perfect-foresight oracle (the north-star metric) ---
+    # The actual electricity bill (eurocents) for the residual grid this
+    # controller left, minus what an ideal perfect-foresight battery would have
+    # paid on the same load. The difference is the money the *controller* could
+    # have saved — ungameable (both import and export cost), 0 = matched perfect
+    # foresight. Clamped at 0: the oracle is optimal by construction, so any
+    # negative is aggregate-model slack (phase routing / DC passthrough), not a
+    # controller beating perfect foresight.
+    grid_cost = _grid_cost_ct(import_wh, export_wh)
+    oracle_cost = _oracle_cost_ct(scenario, samples)
+    cost_regret = max(0.0, grid_cost - oracle_cost)
+
     # Lowest / highest state of charge any battery reached over the run — lets a
     # scenario verify it actually drives the pack into empty/full saturation
     # (not reported in the metric tables; available for tests and context).
@@ -575,12 +668,16 @@ def _compute_metrics(
         "overshoot_max_w": round(max(overshoots), 1) if overshoots else 0.0,
         "band_crossings_per_h": round(crossings / duration_h, 2),
         "grid_p2p_w": round(grid_p2p, 1),
+        "grid_rms_w": round(grid_rms, 1),
         "steady_rms_w": round(steady_rms, 1),
         "mean_abs_grid_w": round(mean_abs, 1),
         "import_wh": round(import_wh, 1),
         "export_wh": round(export_wh, 1),
         "avoidable_import_wh": round(avoid_import_wh, 1),
         "avoidable_export_wh": round(avoid_export_wh, 1),
+        "grid_cost_ct": round(grid_cost, 2),
+        "oracle_cost_ct": round(oracle_cost, 2),
+        "cost_regret_ct": round(cost_regret, 2),
         "battery_travel_w_per_h": round(travel_w / duration_h, 0),
         "grid_trace": _downsample_series(
             samples, scenario.duration_s, lambda s: s.grid
@@ -1451,10 +1548,12 @@ _REPORT_METRICS = [
     "overshoot_max_w",
     "band_crossings_per_h",
     "grid_p2p_w",
+    "grid_rms_w",
     "steady_rms_w",
     "mean_abs_grid_w",
     "avoidable_import_wh",
     "avoidable_export_wh",
+    "cost_regret_ct",
     "battery_travel_w_per_h",
 ]
 
@@ -1464,10 +1563,14 @@ _REPORT_METRICS = [
 # in the field those are worth very different amounts.  These weights encode the
 # value hierarchy a self-consumption controller is actually judged on:
 #
+#   * **Cost regret vs perfect foresight is the money north-star** — the single
+#     ungameable scalar (real bill minus the optimal-dispatch bill), so it
+#     carries top weight alongside import.
 #   * **Self-consumption energy is the product's purpose**, and the two sides
 #     are not symmetric: avoidable grid *import* is paid at the retail tariff
 #     while avoidable *export* earns only the (much lower) feed-in tariff, so
-#     import is weighted ~4x export.
+#     import is weighted ~4x export.  (``cost_regret_ct`` is the fused money view
+#     of the same effect; the two energy metrics keep their finer-grained lens.)
 #   * **Sign-flip overshoot and sustained hunting are do-no-harm guardrails** —
 #     overshoot flips the grid sign (actively worse than no battery) and hunting
 #     wastes energy, wears the pack and reads as "broken" — so they carry heavy
@@ -1478,12 +1581,14 @@ _REPORT_METRICS = [
 # All metrics are lower-is-better, so a negative weighted change is an overall
 # improvement.  Weights are relative (only their ratios matter).
 _METRIC_WEIGHTS: dict[str, float] = {
+    "cost_regret_ct": 4.0,
     "avoidable_import_wh": 4.0,
     "avoidable_export_wh": 1.0,
     "overshoot_max_w": 3.0,
     "band_crossings_per_h": 2.0,
     "battery_travel_w_per_h": 2.0,
     "grid_p2p_w": 1.5,
+    "grid_rms_w": 1.0,
     "overshoot_mean_w": 1.0,
     "mean_abs_grid_w": 1.0,
     "steady_rms_w": 0.5,
@@ -1496,10 +1601,14 @@ _METRIC_WEIGHTS: dict[str, float] = {
 # worse than doing nothing*.  Overshoot flips the grid sign; band crossings /
 # peak-to-peak are sustained hunting; avoidable import is missed self-consumption
 # (energy imported while a battery could have supplied it) — the product's
-# purpose, paid at the retail tariff and free to fix (just discharge).  A
-# regression beyond ``_GUARDRAIL_TOLERANCE`` (5%) is surfaced as a hard warning
-# regardless of how good the weighted score looks, so a smoother controller
-# can't silently trade self-consumption for stability.
+# purpose, paid at the retail tariff and free to fix (just discharge).  Cost
+# regret is the headline money metric — the bill the controller ran up over what
+# perfect foresight would have paid — ungameable (both grid directions cost) and
+# 0 only when the controller matched the optimum, so a regression there is real
+# money lost regardless of which component moved.  A regression beyond
+# ``_GUARDRAIL_TOLERANCE`` (5%) is surfaced as a hard warning regardless of how
+# good the weighted score looks, so a smoother controller can't silently trade
+# self-consumption for stability.
 #
 # Avoidable *export* is deliberately NOT a guardrail (it keeps its 1.0 soft
 # weight in ``_METRIC_WEIGHTS``).  The metric conflates two behaviours: free-to-
@@ -1512,14 +1621,16 @@ _METRIC_WEIGHTS: dict[str, float] = {
 # noisy in steady solar-surplus scenarios.  A future device-agnostic
 # over-discharge-only metric could be guardrailed cleanly.
 #
-# ``avoidable_import_wh`` also legitimately sits at 0 in the base (a controller
-# already self-consuming perfectly), so a base of 0 going positive is itself the
-# regression — see ``_guardrail_regressions`` for the zero-base handling.
+# ``avoidable_import_wh`` and ``cost_regret_ct`` also legitimately sit at 0 in
+# the base (a controller already matching perfect foresight), so a base of 0
+# going positive is itself the regression — see ``_guardrail_regressions`` for
+# the zero-base handling.
 _GUARDRAIL_METRICS = (
     "overshoot_max_w",
     "band_crossings_per_h",
     "grid_p2p_w",
     "avoidable_import_wh",
+    "cost_regret_ct",
 )
 _GUARDRAIL_TOLERANCE = 0.05
 
@@ -1564,6 +1675,13 @@ _METRIC_GLOSSARY = [
         "(settle/overshoot) miss.",
     ),
     (
+        "grid_rms_w",
+        "RMS grid power (W) over the *whole* run, transients included — the L2 "
+        "tracking error: how cleanly the loop held zero, penalising big "
+        "excursions (overshoot, swings) far harder than a small steady offset. "
+        "Pairs with battery_travel_w_per_h as the control-effort term.",
+    ),
+    (
         "steady_rms_w",
         f"RMS grid power (W) during steady state (excluding the "
         f"{STEADY_EXCLUDE_S:g} s after each event) — residual jitter when "
@@ -1582,6 +1700,15 @@ _METRIC_GLOSSARY = [
         "avoidable_export_wh",
         "Energy exported to the grid (Wh) an AC-chargeable battery could have "
         "absorbed (it had room and charge headroom) — missed charging.",
+    ),
+    (
+        "cost_regret_ct",
+        f"Money north-star: electricity bill (eurocents, import @ "
+        f"{RETAIL_CT_PER_KWH:g} ct/kWh, export @ {FEEDIN_CT_PER_KWH:g} ct/kWh) "
+        f"over what a perfect-foresight optimal battery would have paid on the "
+        f"same load. Ungameable (both grid directions cost); 0 = matched the "
+        f"optimum. The single number that says how much the controller left on "
+        f"the table.",
     ),
     (
         "battery_travel_w_per_h",

--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -43,7 +43,7 @@ verdict that weights metrics by real-world value — import-heavy self-consumpti
 energy, do-no-harm overshoot/hunting guardrails, and cycle-life battery travel
 (see :data:`_METRIC_WEIGHTS`) — and hard-flags any do-no-harm guardrail
 regression (:data:`_GUARDRAIL_METRICS`: overshoot/hunting plus avoidable grid
-import — the retail-tariff money metric). The flat mean answers "did most numbers
+import/export — the self-consumption money metrics). The flat mean answers "did most numbers
 move down?"; the priority verdict answers "did it get better *where it matters*,
 and did it break a guardrail?".
 """
@@ -1493,27 +1493,29 @@ _METRIC_WEIGHTS: dict[str, float] = {
 }
 
 # Do-no-harm guardrails: regressing one of these makes the system *actively
-# worse than doing nothing* (overshoot flips the grid sign; band crossings /
-# peak-to-peak are sustained hunting; avoidable import is missed
-# self-consumption — the product's purpose, paid at the retail tariff).  A
+# worse than doing nothing*.  Overshoot flips the grid sign; band crossings /
+# peak-to-peak are sustained hunting; avoidable import (missed self-consumption,
+# paid at the retail tariff) and avoidable export (stored energy dumped to the
+# grid because discharge wasn't throttled when the house load dropped — energy
+# that could have offset later retail import) are both real money left on the
+# table, and both are largely free to fix (throttle discharge / charge), so a
+# regression there is a do-no-harm failure rather than a worthwhile trade.  A
 # regression beyond ``_GUARDRAIL_TOLERANCE`` (5%) is surfaced as a hard warning
-# regardless of how good the weighted score looks — the "hard penalty for
-# sign-flip overshoot", plus the money metric so a smoother controller can't
-# silently trade self-consumption for stability.  Avoidable *export* is left
-# off: it earns only the (much lower) feed-in tariff and avoiding it means
-# AC-charging the pack (round-trip losses + cycle wear), so a hard flag there
-# would perversely reward over-charging to chase low-value feed-in — its 1.0
-# soft weight already prices it in.
+# regardless of how good the weighted score looks, so a smoother controller
+# can't silently trade self-consumption for stability.  The import>export value
+# asymmetry lives in ``_METRIC_WEIGHTS`` (4.0 vs 1.0), not here: the guardrail is
+# a one-sided regression flag, so including export doesn't reward over-charging —
+# it only forbids exporting *more* than the base.
 #
-# ``avoidable_import_wh`` is also the one guardrail metric that legitimately
-# sits at 0 in the base (a controller already self-consuming perfectly), so a
-# base of 0 going positive is itself the regression — see
-# ``_guardrail_regressions`` for the zero-base handling.
+# The energy metrics also legitimately sit at 0 in the base (a controller
+# already self-consuming perfectly), so a base of 0 going positive is itself the
+# regression — see ``_guardrail_regressions`` for the zero-base handling.
 _GUARDRAIL_METRICS = (
     "overshoot_max_w",
     "band_crossings_per_h",
     "grid_p2p_w",
     "avoidable_import_wh",
+    "avoidable_export_wh",
 )
 _GUARDRAIL_TOLERANCE = 0.05
 

--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -42,7 +42,8 @@ The roll-up leads with **two** one-line verdicts: an equal-weighted ``Overall``
 verdict that weights metrics by real-world value — import-heavy self-consumption
 energy, do-no-harm overshoot/hunting guardrails, and cycle-life battery travel
 (see :data:`_METRIC_WEIGHTS`) — and hard-flags any do-no-harm guardrail
-regression (:data:`_GUARDRAIL_METRICS`). The flat mean answers "did most numbers
+regression (:data:`_GUARDRAIL_METRICS`: overshoot/hunting plus avoidable grid
+import — the retail-tariff money metric). The flat mean answers "did most numbers
 move down?"; the priority verdict answers "did it get better *where it matters*,
 and did it break a guardrail?".
 """
@@ -1493,10 +1494,27 @@ _METRIC_WEIGHTS: dict[str, float] = {
 
 # Do-no-harm guardrails: regressing one of these makes the system *actively
 # worse than doing nothing* (overshoot flips the grid sign; band crossings /
-# peak-to-peak are sustained hunting).  A regression beyond
-# ``_GUARDRAIL_TOLERANCE`` (5%) is surfaced as a hard warning regardless of how
-# good the weighted score looks — the "hard penalty for sign-flip overshoot".
-_GUARDRAIL_METRICS = ("overshoot_max_w", "band_crossings_per_h", "grid_p2p_w")
+# peak-to-peak are sustained hunting; avoidable import is missed
+# self-consumption — the product's purpose, paid at the retail tariff).  A
+# regression beyond ``_GUARDRAIL_TOLERANCE`` (5%) is surfaced as a hard warning
+# regardless of how good the weighted score looks — the "hard penalty for
+# sign-flip overshoot", plus the money metric so a smoother controller can't
+# silently trade self-consumption for stability.  Avoidable *export* is left
+# off: it earns only the (much lower) feed-in tariff and avoiding it means
+# AC-charging the pack (round-trip losses + cycle wear), so a hard flag there
+# would perversely reward over-charging to chase low-value feed-in — its 1.0
+# soft weight already prices it in.
+#
+# ``avoidable_import_wh`` is also the one guardrail metric that legitimately
+# sits at 0 in the base (a controller already self-consuming perfectly), so a
+# base of 0 going positive is itself the regression — see
+# ``_guardrail_regressions`` for the zero-base handling.
+_GUARDRAIL_METRICS = (
+    "overshoot_max_w",
+    "band_crossings_per_h",
+    "grid_p2p_w",
+    "avoidable_import_wh",
+)
 _GUARDRAIL_TOLERANCE = 0.05
 
 # Short, human-readable description for each metric in `_REPORT_METRICS`,
@@ -1716,17 +1734,28 @@ def _weighted_overall(base_agg: dict, head_agg: dict) -> float | None:
 
 def _guardrail_regressions(base_agg: dict, head_agg: dict) -> list[str]:
     """Do-no-harm guardrail metrics (:data:`_GUARDRAIL_METRICS`) that regressed
-    beyond :data:`_GUARDRAIL_TOLERANCE`, formatted as ``metric +N%``.
+    beyond :data:`_GUARDRAIL_TOLERANCE`, formatted as ``metric +N%`` (or
+    ``metric 0→N`` when the base was zero).
 
     These are surfaced as a hard warning independent of the weighted score: a
-    controller that wins on average but flips the grid sign harder, or hunts
-    more, has made the system worse where it matters most."""
+    controller that wins on average but flips the grid sign harder, hunts more,
+    or imports more from the grid has made the system worse where it matters
+    most.
+
+    A zero base needs explicit handling: a relative change against 0 is
+    undefined, so the old ``bv > 0`` filter silently dropped the worst possible
+    breach — a metric going from *nothing* to *something* (e.g. zero overshoot
+    becoming a real sign flip, or a perfectly self-consuming controller starting
+    to import). That transition is now flagged outright as ``0→N``."""
     out: list[str] = []
     for key in _GUARDRAIL_METRICS:
         if key not in base_agg or key not in head_agg:
             continue
         bv, hv = float(base_agg[key]), float(head_agg[key])
-        if bv > 0 and (hv - bv) / bv > _GUARDRAIL_TOLERANCE:
+        if bv == 0:
+            if hv > 0:
+                out.append(f"{key} 0→{hv:g}")
+        elif (hv - bv) / bv > _GUARDRAIL_TOLERANCE:
             out.append(f"{key} +{(hv - bv) / bv * 100.0:.0f}%")
     return out
 

--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -43,7 +43,7 @@ verdict that weights metrics by real-world value — import-heavy self-consumpti
 energy, do-no-harm overshoot/hunting guardrails, and cycle-life battery travel
 (see :data:`_METRIC_WEIGHTS`) — and hard-flags any do-no-harm guardrail
 regression (:data:`_GUARDRAIL_METRICS`: overshoot/hunting plus avoidable grid
-import/export — the self-consumption money metrics). The flat mean answers "did most numbers
+import — the retail-tariff money metric). The flat mean answers "did most numbers
 move down?"; the priority verdict answers "did it get better *where it matters*,
 and did it break a guardrail?".
 """
@@ -1494,20 +1494,25 @@ _METRIC_WEIGHTS: dict[str, float] = {
 
 # Do-no-harm guardrails: regressing one of these makes the system *actively
 # worse than doing nothing*.  Overshoot flips the grid sign; band crossings /
-# peak-to-peak are sustained hunting; avoidable import (missed self-consumption,
-# paid at the retail tariff) and avoidable export (stored energy dumped to the
-# grid because discharge wasn't throttled when the house load dropped — energy
-# that could have offset later retail import) are both real money left on the
-# table, and both are largely free to fix (throttle discharge / charge), so a
-# regression there is a do-no-harm failure rather than a worthwhile trade.  A
+# peak-to-peak are sustained hunting; avoidable import is missed self-consumption
+# (energy imported while a battery could have supplied it) — the product's
+# purpose, paid at the retail tariff and free to fix (just discharge).  A
 # regression beyond ``_GUARDRAIL_TOLERANCE`` (5%) is surfaced as a hard warning
 # regardless of how good the weighted score looks, so a smoother controller
-# can't silently trade self-consumption for stability.  The import>export value
-# asymmetry lives in ``_METRIC_WEIGHTS`` (4.0 vs 1.0), not here: the guardrail is
-# a one-sided regression flag, so including export doesn't reward over-charging —
-# it only forbids exporting *more* than the base.
+# can't silently trade self-consumption for stability.
 #
-# The energy metrics also legitimately sit at 0 in the base (a controller
+# Avoidable *export* is deliberately NOT a guardrail (it keeps its 1.0 soft
+# weight in ``_METRIC_WEIGHTS``).  The metric conflates two behaviours: free-to-
+# fix over-discharge (a battery discharging *into* a grid export because it
+# wasn't throttled when load dropped — genuine do-no-harm) and a legitimate
+# missed-AC-charging trade (letting a surplus export rather than pay a charge
+# round-trip).  A hard flag on the conflated sum would penalise the second,
+# legitimate case; it is also gated on ``ac_chargeable`` so it misses over-
+# discharge entirely for DC-only packs (e.g. B2500), and it dominates / gets
+# noisy in steady solar-surplus scenarios.  A future device-agnostic
+# over-discharge-only metric could be guardrailed cleanly.
+#
+# ``avoidable_import_wh`` also legitimately sits at 0 in the base (a controller
 # already self-consuming perfectly), so a base of 0 going positive is itself the
 # regression — see ``_guardrail_regressions`` for the zero-base handling.
 _GUARDRAIL_METRICS = (
@@ -1515,7 +1520,6 @@ _GUARDRAIL_METRICS = (
     "band_crossings_per_h",
     "grid_p2p_w",
     "avoidable_import_wh",
-    "avoidable_export_wh",
 )
 _GUARDRAIL_TOLERANCE = 0.05
 

--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -253,6 +253,11 @@ class _Sample:
     consumption: float
     powers: tuple[float, ...]
     socs: tuple[float, ...]
+    # Total DC-input power (W) across the fleet at this tick — PV wired straight
+    # into a battery's DC side (B2500, hybrid Venus), energy that never crosses
+    # the house meter so it is *not* in ``consumption``. The oracle needs it to
+    # know that free energy is arriving; 0 for pure-AC fleets.
+    dc_input: float = 0.0
 
 
 def _free_udp_port() -> int:
@@ -358,6 +363,7 @@ async def run_scenario(
                 consumption=contribution[0] + contribution[1] + contribution[2],
                 powers=tuple(b.current_power for b in batteries),
                 socs=tuple(b.soc for b in batteries),
+                dc_input=sum(b.dc_input_power for b in batteries),
             )
         )
         return [
@@ -475,12 +481,18 @@ def _oracle_cost_ct(scenario: Scenario, samples: list[_Sample]) -> float:
     """Cost (eurocents) of the *perfect-foresight* battery dispatch — the
     achievable floor this scenario's controller is benchmarked against.
 
-    The household net load is ``_Sample.consumption`` (load + noise - solar,
-    the same source the controller fights to zero out).  The oracle runs a
-    single ideal aggregate battery (summed capacity / charge / discharge power
-    across the fleet, lossless to match the simulator's lossless plant) with
-    perfect foresight and instantaneous response, greedily storing every watt of
-    surplus it can and discharging to cover every watt of deficit it can.
+    The oracle runs a single ideal aggregate battery (summed capacity / charge /
+    discharge power across the fleet, lossless to match the simulator's lossless
+    plant) with perfect foresight and instantaneous response.  Each step it picks
+    the battery's net AC output ``p`` to zero the grid if it can, otherwise to
+    store / shed the residual optimally.  Two energy streams feed it:
+      * the **household net load** ``consumption`` (load + noise - AC solar) — the
+        deficit/surplus the controller fights to zero out; and
+      * **DC-input solar** ``dc_input`` — PV wired into a battery's DC side, which
+        never crosses the house meter (so it is *not* in ``consumption``).  The
+        cells gain ``dc - p`` each step: DC solar first offsets the grid, the rest
+        charges the pack, and at a full pack it passes straight through to export
+        (matching the real B2500 / hybrid-Venus plant).
 
     Under a flat tariff with a lossless battery this greedy dispatch *is* the
     optimum: every stored Wh is equally valuable, foresight cannot conjure energy
@@ -488,21 +500,14 @@ def _oracle_cost_ct(scenario: Scenario, samples: list[_Sample]) -> float:
     always worth more than exporting it.  What it leaves on the grid is therefore
     physically irreducible — surplus when the pack is full, deficit when it is
     empty or power-limited — so ``actual_cost - oracle_cost`` isolates the cost
-    the *controller* could have avoided.
+    the *controller* could have avoided, and the oracle is a true lower bound (so
+    ``cost_regret_ct`` stays >= 0).
 
-    Two aggregation approximations bias the floor in *opposite* directions:
-      * **Phase routing is ignored** (the fleet is one battery): a real per-phase
-        controller can be forced to import on one phase while exporting on
-        another, which the netted aggregate avoids — so the oracle is *optimistic*
-        (a true lower bound) in the three-phase scenario.  Regret stays >= 0.
-      * **A DC-only B2500's PV-passthrough is not modelled** (it contributes 0
-        charge power; only its discharge + capacity count).  The real B2500 self-
-        consumes DC solar the aggregate — fed only by ``consumption`` — never sees
-        as chargeable, so here the oracle is *pessimistic* and a real controller
-        can beat it.  ``cost_regret_ct`` clamps at 0, so in ``mixed_venus_b2500``
-        scenarios regret is a conservative under-estimate of controller skill, not
-        a true lower bound.  (Feeding the DC-input trace into the oracle would fix
-        this; it is not in ``_Sample`` today.)"""
+    One approximation remains: **per-phase routing is ignored** (the fleet is one
+    battery).  A real per-phase controller can be forced to import on one phase
+    while exporting on another, which the netted aggregate avoids — so the oracle
+    is mildly *optimistic* (still a valid lower bound) in the three-phase
+    scenario."""
     specs = scenario.batteries
     cap_wh = sum(s.capacity_wh for s in specs)
     max_charge = sum(s.max_charge_power for s in specs)
@@ -515,15 +520,17 @@ def _oracle_cost_ct(scenario: Scenario, samples: list[_Sample]) -> float:
             continue
         h = dt / 3600.0
         net = prev.consumption  # >0 deficit (would import), <0 surplus (export)
-        if net > 0:
-            discharge = min(net, max_discharge, energy_wh / h)
-            energy_wh -= discharge * h
-            grid = net - discharge
-        else:
-            room_wh = cap_wh - energy_wh
-            charge = min(-net, max_charge, room_wh / h)
-            energy_wh += charge * h
-            grid = net + charge
+        dc = prev.dc_input  # free DC-side solar entering the pack this step
+        # Feasible net AC output p (positive = to house/grid). The cells change by
+        # (dc - p) per step, bounded by stored energy (can't over-drain) and room
+        # (can't over-fill); p is also bounded by the AC charge/discharge limits.
+        hi = min(max_discharge, dc + energy_wh / h)
+        lo = max(-max_charge, dc - (cap_wh - energy_wh) / h)
+        if lo > hi:  # DC inflow exceeds what a full pack can shed via the inverter
+            lo = hi  # → curtail the excess (output at the cap)
+        p = min(max(net, lo), hi)  # zero the grid if feasible, else store/shed
+        energy_wh = max(0.0, min(cap_wh, energy_wh + (dc - p) * h))
+        grid = net - p
         if grid > 0:
             import_wh += grid * h
         else:
@@ -649,11 +656,10 @@ def _compute_metrics(
     # controller left, minus what an ideal perfect-foresight battery would have
     # paid on the same load. The difference is the money the *controller* could
     # have saved — ungameable (both import and export cost), 0 = matched perfect
-    # foresight. Clamped at 0 because the aggregate oracle is a true lower bound
-    # in every AC scenario (phase netting only makes it optimistic); the one case
-    # it can be *beaten* is a B2500 self-consuming DC solar the oracle doesn't
-    # model (see ``_oracle_cost_ct``), where the clamp deliberately reports the
-    # conservative 0 rather than a misleading "controller beat the optimum".
+    # foresight. The oracle is a true lower bound (it sees the same load *and* the
+    # DC-input solar — see ``_oracle_cost_ct``), so the max(0.0, …) clamp only
+    # ever absorbs tiny per-phase-routing slack in the three-phase scenario, not a
+    # real "controller beat the optimum".
     grid_cost = _grid_cost_ct(import_wh, export_wh)
     oracle_cost = _oracle_cost_ct(scenario, samples)
     cost_regret = max(0.0, grid_cost - oracle_cost)

--- a/tests/test_steering_eval.py
+++ b/tests/test_steering_eval.py
@@ -15,18 +15,23 @@ from astrameter.simulator.eval_report import render_html_report
 from astrameter.simulator.evaluation import (
     _METRIC_GLOSSARY,
     _REPORT_METRICS,
+    FEEDIN_CT_PER_KWH,
     GRAPH_POINTS,
+    RETAIL_CT_PER_KWH,
     BatterySpec,
     Event,
     Scenario,
     _aggregate,
     _compare_aggregates,
     _fmt_delta,
+    _grid_cost_ct,
     _guardrail_regressions,
     _merge_seeds,
+    _oracle_cost_ct,
     _overall_summary,
     _priority_summary,
     _run_all,
+    _Sample,
     _seed_label,
     _weighted_overall,
     build_scenarios,
@@ -34,6 +39,57 @@ from astrameter.simulator.evaluation import (
     render_text,
     run_scenario,
 )
+
+
+def _steady_samples(net_w: float, duration_s: float) -> list[_Sample]:
+    """A flat net-load trace at 1 s cadence (grid/powers/socs are unused by the
+    oracle, which reads only ``consumption`` and ``t``)."""
+    n = int(duration_s) + 1
+    return [
+        _Sample(t=float(i), grid=0.0, consumption=net_w, powers=(0.0,), socs=(0.0,))
+        for i in range(n)
+    ]
+
+
+def _one_battery_scenario(spec: BatterySpec, duration_s: float) -> Scenario:
+    return Scenario(
+        name="cost",
+        description="",
+        batteries=[spec],
+        duration_s=duration_s,
+        build_events=lambda _rng: [],
+    )
+
+
+def test_grid_cost_asymmetric_tariff():
+    # 1 kWh imported costs the retail tariff; 1 kWh exported earns the (lower)
+    # feed-in tariff as a credit (negative cost).
+    assert _grid_cost_ct(1000.0, 0.0) == pytest.approx(RETAIL_CT_PER_KWH)
+    assert _grid_cost_ct(0.0, 1000.0) == pytest.approx(-FEEDIN_CT_PER_KWH)
+
+
+def test_oracle_zero_cost_when_battery_covers_load():
+    # A steady 500 W deficit for an hour against a battery with ample energy and
+    # power: the perfect-foresight battery supplies all of it, so the optimal
+    # grid exchange — and its cost — is zero.
+    spec = BatterySpec(max_discharge_power=2500, capacity_wh=5000.0, initial_soc=1.0)
+    cost = _oracle_cost_ct(
+        _one_battery_scenario(spec, 3600.0), _steady_samples(500.0, 3600.0)
+    )
+    assert cost == pytest.approx(0.0, abs=1e-6)
+
+
+def test_oracle_floor_when_battery_too_small():
+    # Only 100 Wh of stored energy but the load asks 500 W for an hour (500 Wh).
+    # The oracle supplies its 100 Wh and the remaining ~400 Wh must import — a
+    # physically irreducible floor no controller can beat.
+    spec = BatterySpec(
+        max_discharge_power=2500, max_charge_power=0, capacity_wh=100.0, initial_soc=1.0
+    )
+    cost = _oracle_cost_ct(
+        _one_battery_scenario(spec, 3600.0), _steady_samples(500.0, 3600.0)
+    )
+    assert cost == pytest.approx(RETAIL_CT_PER_KWH * 400.0 / 1000.0, rel=0.02)
 
 
 def _tiny_scenario() -> Scenario:
@@ -77,14 +133,22 @@ def test_run_scenario_produces_metrics():
         "settle_mean_s",
         "overshoot_max_w",
         "band_crossings_per_h",
+        "grid_rms_w",
         "steady_rms_w",
         "import_wh",
         "export_wh",
         "avoidable_import_wh",
         "avoidable_export_wh",
+        "cost_regret_ct",
         "battery_travel_w_per_h",
     ):
         assert res[key] >= 0, key
+    # Whole-run RMS grid >= mean |grid| (quadratic vs arithmetic mean) on the
+    # same samples — a property that must hold for any run.
+    assert res["grid_rms_w"] >= res["mean_abs_grid_w"]
+    # Regret is the actual bill minus the perfect-foresight floor; the oracle is
+    # optimal, so it never costs more than the controller actually did.
+    assert res["oracle_cost_ct"] <= res["grid_cost_ct"] + 1e-9
     # The battery covers the initial 200 W base load well before the end.
     assert res["settle_mean_s"] < res["duration_h"] * 3600
 

--- a/tests/test_steering_eval.py
+++ b/tests/test_steering_eval.py
@@ -27,6 +27,7 @@ from astrameter.simulator.evaluation import (
     _grid_cost_ct,
     _guardrail_regressions,
     _merge_seeds,
+    _metric_ndp,
     _oracle_cost_ct,
     _overall_summary,
     _priority_summary,
@@ -385,10 +386,31 @@ def test_aggregate_is_per_metric_mean_across_scenarios():
     agg = _aggregate(results)
     assert agg["scenario"] == "AGGREGATE"
     assert agg["n_scenarios"] == 2
-    # Every reported metric is the unweighted mean of the two scenarios.
+    # Every reported metric is the unweighted mean of the two scenarios, rounded
+    # at the metric's precision (eurocent costs keep 2 dp, the rest 1 dp).
     for key in _REPORT_METRICS:
         expected = (float(results[0][key]) + float(results[1][key])) / 2
-        assert agg[key] == round(expected, 1), key
+        assert agg[key] == round(expected, _metric_ndp(key)), key
+
+
+def test_cost_keys_keep_two_decimals_through_aggregation():
+    # Regret clusters at fractions of a cent, so the aggregate/seed-merge must
+    # keep 2 dp for *_ct keys (1 dp would quantize the guardrail's 5% test into
+    # noise). A sub-0.1 ct mean must survive, not round to 0.0.
+    base = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
+    a = dict(base, scenario="a", cost_regret_ct=0.03)
+    b = dict(base, scenario="b", cost_regret_ct=0.05)
+    assert _aggregate([a, b])["cost_regret_ct"] == 0.04
+    # Seed-merge of the same scenario keeps 2 dp too.
+    merged = _merge_seeds(
+        [
+            dict(base, seed=1, cost_regret_ct=0.03),
+            dict(base, seed=2, cost_regret_ct=0.06),
+        ]
+    )
+    assert merged["cost_regret_ct"] == 0.04
+    # Non-cost metrics still round to the 1-dp report convention.
+    assert _metric_ndp("grid_rms_w") == 1 and _metric_ndp("cost_regret_ct") == 2
 
 
 def test_aggregate_omits_metrics_absent_from_every_result():

--- a/tests/test_steering_eval.py
+++ b/tests/test_steering_eval.py
@@ -378,6 +378,39 @@ def test_guardrail_regression_is_flagged():
     assert _guardrail_regressions(base, {**base, "overshoot_max_w": 103.0}) == []
 
 
+def test_guardrail_includes_avoidable_import():
+    # Avoidable grid import is the retail-tariff money metric: a regression past
+    # the tolerance is a do-no-harm breach even when the dynamics are flat.
+    base = {"avoidable_import_wh": 100.0, "overshoot_max_w": 100.0}
+    head = {"avoidable_import_wh": 120.0, "overshoot_max_w": 100.0}
+    assert _guardrail_regressions(base, head) == ["avoidable_import_wh +20%"]
+    # Avoidable export is NOT guardrailed (low-value feed-in; avoiding it costs
+    # round-trip losses + wear) — a big export regression alone stays clean.
+    assert (
+        _guardrail_regressions(
+            {"avoidable_export_wh": 100.0}, {"avoidable_export_wh": 200.0}
+        )
+        == []
+    )
+
+
+def test_guardrail_flags_regression_from_zero_base():
+    # The worst do-no-harm breach: a metric going from nothing to something
+    # (zero overshoot becoming a real sign flip, or a perfectly self-consuming
+    # controller starting to import). A relative change against 0 is undefined,
+    # so it's flagged outright as 0→N rather than silently dropped.
+    assert _guardrail_regressions(
+        {"overshoot_max_w": 0.0}, {"overshoot_max_w": 12.0}
+    ) == ["overshoot_max_w 0→12"]
+    assert _guardrail_regressions(
+        {"avoidable_import_wh": 0.0}, {"avoidable_import_wh": 5.0}
+    ) == ["avoidable_import_wh 0→5"]
+    # 0 → 0 is not a regression.
+    assert (
+        _guardrail_regressions({"overshoot_max_w": 0.0}, {"overshoot_max_w": 0.0}) == []
+    )
+
+
 def test_priority_summary_clean_when_no_guardrail_regresses():
     base = {"avoidable_import_wh": 100.0, "overshoot_max_w": 100.0}
     head = {"avoidable_import_wh": 80.0, "overshoot_max_w": 80.0}

--- a/tests/test_steering_eval.py
+++ b/tests/test_steering_eval.py
@@ -378,17 +378,23 @@ def test_guardrail_regression_is_flagged():
     assert _guardrail_regressions(base, {**base, "overshoot_max_w": 103.0}) == []
 
 
-def test_guardrail_includes_avoidable_energy():
-    # Both self-consumption money metrics are do-no-harm guardrails: a regression
-    # past the tolerance is a breach even when the dynamics are flat. Export is
-    # largely free-to-fix over-discharge (throttle the battery), not AC-charging,
-    # so a worse export figure is genuine harm — not a worthwhile trade.
+def test_guardrail_includes_import_not_export():
+    # Avoidable grid import is the retail-tariff money metric, free to fix
+    # (discharge): a regression past the tolerance is a do-no-harm breach even
+    # when the dynamics are flat.
     base = {"avoidable_import_wh": 100.0, "overshoot_max_w": 100.0}
     head = {"avoidable_import_wh": 120.0, "overshoot_max_w": 100.0}
     assert _guardrail_regressions(base, head) == ["avoidable_import_wh +20%"]
-    assert _guardrail_regressions(
-        {"avoidable_export_wh": 100.0}, {"avoidable_export_wh": 120.0}
-    ) == ["avoidable_export_wh +20%"]
+    # Avoidable export is NOT guardrailed: the metric conflates free-to-fix
+    # over-discharge with a legitimate missed-AC-charging trade (and is gated on
+    # ac_chargeable / noisy in solar), so a hard flag would penalise the
+    # legitimate case — it keeps its 1.0 soft weight instead.
+    assert (
+        _guardrail_regressions(
+            {"avoidable_export_wh": 100.0}, {"avoidable_export_wh": 120.0}
+        )
+        == []
+    )
 
 
 def test_guardrail_flags_regression_from_zero_base():

--- a/tests/test_steering_eval.py
+++ b/tests/test_steering_eval.py
@@ -378,20 +378,17 @@ def test_guardrail_regression_is_flagged():
     assert _guardrail_regressions(base, {**base, "overshoot_max_w": 103.0}) == []
 
 
-def test_guardrail_includes_avoidable_import():
-    # Avoidable grid import is the retail-tariff money metric: a regression past
-    # the tolerance is a do-no-harm breach even when the dynamics are flat.
+def test_guardrail_includes_avoidable_energy():
+    # Both self-consumption money metrics are do-no-harm guardrails: a regression
+    # past the tolerance is a breach even when the dynamics are flat. Export is
+    # largely free-to-fix over-discharge (throttle the battery), not AC-charging,
+    # so a worse export figure is genuine harm — not a worthwhile trade.
     base = {"avoidable_import_wh": 100.0, "overshoot_max_w": 100.0}
     head = {"avoidable_import_wh": 120.0, "overshoot_max_w": 100.0}
     assert _guardrail_regressions(base, head) == ["avoidable_import_wh +20%"]
-    # Avoidable export is NOT guardrailed (low-value feed-in; avoiding it costs
-    # round-trip losses + wear) — a big export regression alone stays clean.
-    assert (
-        _guardrail_regressions(
-            {"avoidable_export_wh": 100.0}, {"avoidable_export_wh": 200.0}
-        )
-        == []
-    )
+    assert _guardrail_regressions(
+        {"avoidable_export_wh": 100.0}, {"avoidable_export_wh": 120.0}
+    ) == ["avoidable_export_wh +20%"]
 
 
 def test_guardrail_flags_regression_from_zero_base():

--- a/tests/test_steering_eval.py
+++ b/tests/test_steering_eval.py
@@ -42,12 +42,21 @@ from astrameter.simulator.evaluation import (
 )
 
 
-def _steady_samples(net_w: float, duration_s: float) -> list[_Sample]:
+def _steady_samples(
+    net_w: float, duration_s: float, dc_w: float = 0.0
+) -> list[_Sample]:
     """A flat net-load trace at 1 s cadence (grid/powers/socs are unused by the
-    oracle, which reads only ``consumption`` and ``t``)."""
+    oracle, which reads only ``consumption``, ``dc_input`` and ``t``)."""
     n = int(duration_s) + 1
     return [
-        _Sample(t=float(i), grid=0.0, consumption=net_w, powers=(0.0,), socs=(0.0,))
+        _Sample(
+            t=float(i),
+            grid=0.0,
+            consumption=net_w,
+            powers=(0.0,),
+            socs=(0.0,),
+            dc_input=dc_w,
+        )
         for i in range(n)
     ]
 
@@ -91,6 +100,25 @@ def test_oracle_floor_when_battery_too_small():
         _one_battery_scenario(spec, 3600.0), _steady_samples(500.0, 3600.0)
     )
     assert cost == pytest.approx(RETAIL_CT_PER_KWH * 400.0 / 1000.0, rel=0.02)
+
+
+def test_oracle_credits_dc_input_solar():
+    # 500 W deficit for an hour, the battery starts EMPTY but receives 500 W of
+    # solar straight into its DC side (B2500-style). A DC-blind oracle would
+    # import the whole 500 Wh; the DC-aware oracle passes the solar through to
+    # cover the house and pays nothing.
+    spec = BatterySpec(
+        max_discharge_power=800,
+        max_charge_power=0,
+        capacity_wh=2240.0,
+        initial_soc=0.0,
+        max_dc_input=1000,
+    )
+    cost = _oracle_cost_ct(
+        _one_battery_scenario(spec, 3600.0),
+        _steady_samples(500.0, 3600.0, dc_w=500.0),
+    )
+    assert cost == pytest.approx(0.0, abs=1e-6)
 
 
 def _tiny_scenario() -> Scenario:


### PR DESCRIPTION
## Summary

Introduces a money-focused evaluation metric (`cost_regret_ct`) that measures the electricity bill difference between the actual controller and a perfect-foresight optimal battery dispatch. This becomes the headline metric for assessing controller performance, complementing the existing energy self-consumption and stability metrics.

## Key Changes

- **Cost metric infrastructure**: Added `RETAIL_CT_PER_KWH` and `FEEDIN_CT_PER_KWH` tariff constants and `_grid_cost_ct()` function to compute electricity bills with asymmetric import/export pricing.

- **Perfect-foresight oracle**: Implemented `_oracle_cost_ct()` that simulates an ideal lossless aggregate battery with perfect load foresight. The oracle greedily zeros the grid when possible, otherwise stores/sheds optimally. It accounts for DC-input solar (e.g., B2500 hybrid systems) that bypasses the house meter, making it a true lower bound on achievable cost.

- **DC-input solar tracking**: Extended `_Sample` dataclass with `dc_input` field to capture PV power wired directly into battery DC sides. This is collected from battery specs during simulation and passed to the oracle for accurate cost benchmarking.

- **New metrics in reports**:
  - `cost_regret_ct`: Actual bill minus oracle bill (eurocents) — the money the controller could have saved
  - `grid_rms_w`: Whole-run L2 tracking error (RMS grid power including transients) — control quality metric
  - `grid_cost_ct` and `oracle_cost_ct`: Supporting cost values for transparency

- **Metric weighting & guardrails**: 
  - Added `cost_regret_ct` with weight 4.0 (equal to avoidable import) as the money north-star
  - Added `grid_rms_w` with weight 1.0 for control quality
  - Expanded `_GUARDRAIL_METRICS` to include `avoidable_import_wh` and `cost_regret_ct` (do-no-harm breaches)
  - Avoidable export deliberately excluded from guardrails (conflates legitimate AC-charging trade with over-discharge)

- **Precision handling**: Introduced `_metric_ndp()` to keep eurocent costs at 2 decimal places (vs. 1 dp for other metrics) through aggregation and seed-merging, preventing quantization noise in the 5% guardrail tolerance test.

- **Zero-base guardrail detection**: Enhanced `_guardrail_regressions()` to flag metrics transitioning from 0 to non-zero (e.g., zero overshoot becoming a sign flip, or perfect self-consumption starting to import) as `0→N` rather than silently dropping them.

- **Documentation**: Updated metric glossary, weights commentary, and guardrail rationale to explain the cost metric's role and why avoidable export is soft-weighted rather than guardrailed.

## Implementation Details

The oracle is provably optimal under a flat tariff: every stored Wh is equally valuable, foresight cannot conjure energy a causal controller lacks, and `retail >= feed-in` makes storing surplus always worth more than exporting. The greedy dispatch therefore minimizes cost, and any surplus left on the grid (when pack is full) or deficit (when empty/power-limited) is physically irreducible. This makes `cost_regret` a true lower bound and an ungameable metric — both import and export cost money, so controllers cannot game it by shifting between grid directions.

Per-phase routing is ignored (fleet treated as one battery), making the oracle mildly optimistic in three-phase scenarios but still a valid lower bound.

https://claude.ai/code/session_01N5NyxNavPnM32pmuk6pF8g

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cost-regret metric to measure controller efficiency against an optimal oracle.
  * Extended energy-tracking metrics with grid RMS power and time-weighted statistics.
  * Expanded do-no-harm guardrails with 5% regression threshold and zero-baseline detection.

* **Documentation**
  * Updated metric definitions and guardrail guidance in steering-quality evaluation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->