### PR TITLE
Update GitHub Actions off deprecated Node.js 20 runtimes

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -48,6 +48,11 @@ jobs:
         uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
+        with:
+          # Parallel matrix jobs race to reserve the same binfmt cache key,
+          # which only logs a noisy "Unable to reserve cache" warning. The
+          # binfmt image is tiny, so skip caching it to avoid the race.
+          cache-image: false
       - id: lower-repo
         run: |
           echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}${{ inputs.image-suffix }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -47,13 +47,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - id: lower-repo
         run: |
           echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}${{ inputs.image-suffix }}" >> $GITHUB_OUTPUT
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ inputs.registry }}/${{ steps.lower-repo.outputs.IMAGE_NAME }}
           tags: |
@@ -68,10 +68,10 @@ jobs:
           flavor: |
             latest=${{ github.ref == 'refs/heads/main' }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Log in to Container registry
         if: inputs.push
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
@@ -79,7 +79,7 @@ jobs:
       - name: Build and push by digest
         id: build
         if: inputs.push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.context }}
           platforms: ${{ inputs.platform }}
@@ -95,7 +95,7 @@ jobs:
       - name: Build (no push)
         id: build-no-push
         if: inputs.push == false
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.context }}
           platforms: ${{ inputs.platform }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -54,8 +54,17 @@ jobs:
           # binfmt image is tiny, so skip caching it to avoid the race.
           cache-image: false
       - id: lower-repo
+        # Pass inputs via env (not ${{ }} interpolation) to avoid template
+        # injection, and reject control characters so a crafted suffix can't
+        # inject extra $GITHUB_OUTPUT keys.
+        env:
+          IMAGE_SUFFIX: ${{ inputs.image-suffix }}
         run: |
-          echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}${{ inputs.image-suffix }}" >> $GITHUB_OUTPUT
+          if printf '%s' "$IMAGE_SUFFIX" | grep -q '[[:cntrl:]]'; then
+            echo "Invalid image-suffix: control characters are not allowed" >&2
+            exit 1
+          fi
+          printf 'IMAGE_NAME=%s%s\n' "${GITHUB_REPOSITORY@L}" "$IMAGE_SUFFIX" >> "$GITHUB_OUTPUT"
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -45,7 +45,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - id: lower-repo
@@ -120,7 +120,7 @@ jobs:
           echo "name=$SAFE_PLATFORM" >> $GITHUB_OUTPUT
       - name: Upload digest
         if: inputs.push
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.digest-prefix }}${{ steps.platform.outputs.name }}
           path: /tmp/digests/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -48,15 +48,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -79,7 +79,7 @@ jobs:
       matrix: ${{ steps.find.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Collect test YAML files
         id: find
@@ -96,10 +96,10 @@ jobs:
         yaml: ${{ fromJSON(needs.ct002-esphome-yaml.outputs.matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -114,15 +114,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -172,16 +172,16 @@ jobs:
         python-version: [ "3.10", "3.11", "3.12", "3.13" ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-suffix: ${{ matrix.python-version }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -196,14 +196,14 @@ jobs:
 
       - name: Upload test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.python-version }}
           path: test-results.xml
 
       - name: Upload coverage XML
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.python-version }}
           path: coverage.xml
@@ -224,15 +224,15 @@ jobs:
       matrix: ${{ steps.list.outputs.matrix }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -259,17 +259,17 @@ jobs:
         scenario: ${{ fromJSON(needs.steering-eval-discover.outputs.matrix) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -317,7 +317,7 @@ jobs:
           fi
 
       - name: Upload scenario/seed metrics
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.safe.outputs.name }}
           path: |
@@ -333,15 +333,15 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -349,7 +349,7 @@ jobs:
         run: uv sync --frozen --extra dev
 
       - name: Download all scenario metrics
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: steering-eval-*
           path: eval-artifacts
@@ -402,7 +402,7 @@ jobs:
         if: >-
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           # Direct per-artifact URL from the upload step (login-required, valid
           # until the artifact/run expires) — the closest thing to a direct

--- a/.github/workflows/merge-manifests.yml
+++ b/.github/workflows/merge-manifests.yml
@@ -33,7 +33,7 @@ jobs:
           path: /tmp/digests
           merge-multiple: true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - id: lower-repo
         run: |
           echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}${{ inputs.image-suffix }}" >> $GITHUB_OUTPUT
@@ -43,7 +43,7 @@ jobs:
           fi
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ inputs.registry }}/${{ steps.lower-repo.outputs.IMAGE_NAME }}
@@ -60,7 +60,7 @@ jobs:
           flavor: |
             latest=${{ github.ref == 'refs/heads/main' }}
       - name: Log in to Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}

--- a/.github/workflows/merge-manifests.yml
+++ b/.github/workflows/merge-manifests.yml
@@ -35,11 +35,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - id: lower-repo
+        # Pass inputs via env (not ${{ }} interpolation) to avoid template
+        # injection, and reject control characters so a crafted suffix can't
+        # inject extra $GITHUB_OUTPUT keys.
+        env:
+          IMAGE_SUFFIX: ${{ inputs.image-suffix }}
+          LEGACY_IMAGE_NAME: ${{ inputs.legacy-image-name }}
         run: |
-          echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}${{ inputs.image-suffix }}" >> $GITHUB_OUTPUT
-          if [ -n "${{ inputs.legacy-image-name }}" ]; then
-            LEGACY_LOWER=$(echo "${{ inputs.legacy-image-name }}" | tr '[:upper:]' '[:lower:]')
-            echo "LEGACY_IMAGE_NAME=${LEGACY_LOWER}${{ inputs.image-suffix }}" >> $GITHUB_OUTPUT
+          if printf '%s' "$IMAGE_SUFFIX" | grep -q '[[:cntrl:]]'; then
+            echo "Invalid image-suffix: control characters are not allowed" >&2
+            exit 1
+          fi
+          printf 'IMAGE_NAME=%s%s\n' "${GITHUB_REPOSITORY@L}" "$IMAGE_SUFFIX" >> "$GITHUB_OUTPUT"
+          if [ -n "$LEGACY_IMAGE_NAME" ]; then
+            LEGACY_LOWER=$(printf '%s' "$LEGACY_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
+            printf 'LEGACY_IMAGE_NAME=%s%s\n' "$LEGACY_LOWER" "$IMAGE_SUFFIX" >> "$GITHUB_OUTPUT"
           fi
       - name: Extract metadata
         id: meta

--- a/.github/workflows/merge-manifests.yml
+++ b/.github/workflows/merge-manifests.yml
@@ -27,7 +27,7 @@ jobs:
       packages: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: ${{ inputs.digest-prefix }}*
           path: /tmp/digests

--- a/.github/workflows/merge-manifests.yml
+++ b/.github/workflows/merge-manifests.yml
@@ -48,6 +48,10 @@ jobs:
           fi
           printf 'IMAGE_NAME=%s%s\n' "${GITHUB_REPOSITORY@L}" "$IMAGE_SUFFIX" >> "$GITHUB_OUTPUT"
           if [ -n "$LEGACY_IMAGE_NAME" ]; then
+            if printf '%s' "$LEGACY_IMAGE_NAME" | grep -q '[[:cntrl:]]'; then
+              echo "Invalid legacy-image-name: control characters are not allowed" >&2
+              exit 1
+            fi
             LEGACY_LOWER=$(printf '%s' "$LEGACY_IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
             printf 'LEGACY_IMAGE_NAME=%s%s\n' "$LEGACY_LOWER" "$IMAGE_SUFFIX" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,8 +39,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -69,9 +69,49 @@ jobs:
         with:
           name: pr-preview-dist
           path: web/dist
-      - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
+      # Inlined in place of rossjrw/pr-preview-action@v1, whose pinned
+      # github-pages-deploy-action / sticky-pull-request-comment are still on
+      # the deprecated Node.js 20 runtime. We call the Node.js 24 releases
+      # directly. `clean` only touches this PR's own target-folder, so other
+      # PRs' previews on the shared gh-pages branch are left intact.
+      - name: Publish preview
+        if: github.event.action != 'closed'
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
-          source-dir: ./web/dist
-          preview-branch: gh-pages
-          umbrella-dir: pr-preview
+          folder: web/dist
+          target-folder: pr-preview/pr-${{ github.event.number }}
+          branch: gh-pages
+          commit-message: "Deploy preview for PR ${{ github.event.number }}"
+      - name: Comment preview link
+        if: github.event.action != 'closed'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: pr-preview
+          number: ${{ github.event.number }}
+          message: |
+            🚀 Preview for this PR is deployed at
+            https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}/
+
+            It will be live once the GitHub Pages deployment finishes.
+
+      # Teardown on close: deploy an empty folder over the PR's target-folder so
+      # `clean` removes the now-stale preview, then update the sticky comment.
+      - name: Remove preview (PR closed)
+        if: github.event.action == 'closed'
+        run: mkdir -p empty-preview
+      - name: Tear down preview
+        if: github.event.action == 'closed'
+        uses: JamesIves/github-pages-deploy-action@v4.8.0
+        with:
+          folder: empty-preview
+          target-folder: pr-preview/pr-${{ github.event.number }}
+          branch: gh-pages
+          commit-message: "Remove preview for PR ${{ github.event.number }}"
+      - name: Comment preview removed
+        if: github.event.action == 'closed'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: pr-preview
+          number: ${{ github.event.number }}
+          message: |
+            🧹 The preview for this PR has been removed now that it is closed.

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -30,8 +30,8 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm
@@ -46,7 +46,7 @@ jobs:
           npm test
           npm run build
       - name: Upload built site
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pr-preview-dist
           path: web/dist
@@ -62,10 +62,10 @@ jobs:
       group: gh-pages
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Download built site
         if: github.event.action != 'closed'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: pr-preview-dist
           path: web/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout develop
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: develop
           fetch-depth: 0
@@ -38,10 +38,10 @@ jobs:
           sudo chmod +x /usr/local/bin/yq
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          # Privileged job (RELEASE_TOKEN); don't share a cache that a PR run
+          # could poison via crafted dependency files.
+          enable-cache: false
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary
Bumps every GitHub Actions dependency that was still running on the deprecated Node.js 20 runtime to a version that runs on **Node.js 24**, clearing the `Node.js 20 is deprecated` warnings across all CI/CD pipelines. Also clears a follow-on cache warning from the new QEMU action and a couple of SAST findings on the touched lines.

## Key changes
**Official actions**
- **actions/checkout**: v4 → v5
- **actions/setup-python**: v5 → v6
- **actions/setup-node**: v4 → v5
- **actions/upload-artifact**: v4 → v7
- **actions/download-artifact**: v4 → v7
- **astral-sh/setup-uv**: v5 → v7
- **actions/github-script**: v7 → v8

**Docker actions**
- **docker/setup-qemu-action**: v3 → v4
- **docker/setup-buildx-action**: v3 → v4
- **docker/login-action**: v3 → v4
- **docker/metadata-action**: v5 → v6
- **docker/build-push-action**: v6 → v7

**PR preview job** — `rossjrw/pr-preview-action@v1` still pins `github-pages-deploy-action@v4.7.4` and `sticky-pull-request-comment@v2.9.2` (both Node 20), and no released/`main` version updates them, so the wrapper couldn't be bumped to fix it. Replaced it with inline steps calling the Node.js 24 releases directly (`JamesIves/github-pages-deploy-action@v4.8.0`, `marocchino/sticky-pull-request-comment@v3`). Deploy/teardown/sticky-comment behavior is preserved, and `clean` is scoped to the PR's own `target-folder` so other PRs' previews on the shared `gh-pages` branch are untouched.

Each version was verified against the action's `action.yml` to confirm `runs.using: node24` (e.g. `astral-sh/setup-uv@v6` and `docker/*@v3/v5` are still on node20, so they were taken to the next major).

## Additional hardening (on the touched lines)
- **QEMU cache warning**: `setup-qemu-action@v4` caches the binfmt image by default, and the parallel matrix build jobs race for the same cache key (`Unable to reserve cache`). Set `cache-image: false` — the binfmt image is tiny, so there's no benefit to caching it.
- **Release job cache poisoning**: the release job carries `RELEASE_TOKEN`; set `enable-cache: false` on its `setup-uv` step so a PR run can't poison a shared cache.
- **Workflow input injection**: in `build-image.yml` / `merge-manifests.yml`, pass `image-suffix` / `legacy-image-name` via `env:` instead of `${{ }}` interpolation (avoids template injection) and reject control characters before writing to `$GITHUB_OUTPUT` (avoids output-key injection).

## Affected workflows
- `.github/workflows/ci.yml` — test, lint, and steering evaluation jobs
- `.github/workflows/pr-preview.yml` — preview site build and deployment
- `.github/workflows/release.yml` — release preparation
- `.github/workflows/build-image.yml` — container image builds
- `.github/workflows/pages.yml` — documentation deployment
- `.github/workflows/merge-manifests.yml` — manifest merging

https://claude.ai/code/session_01W4eHektpPqS7JScN2Sq2Wt



## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure tooling across multiple workflows to use newer versions for improved stability and compatibility.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions and development tools to latest stable versions for improved security and reliability.
  * Enhanced container image building workflows with better artifact handling and automated deployment processes.
  * Streamlined pull request preview deployment automation for faster and more efficient preview management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->