### PR TITLE
Fix Home Assistant add-on startup failure on 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Fixed** the Home Assistant add-on failing to start on 2.2.0 — it exited immediately on every launch (looping with no log output) for anyone not using a custom config file. Updating to this version restores normal startup ([#510](https://github.com/tomquist/astrameter/issues/510), [#511](https://github.com/tomquist/astrameter/issues/511)).
+
 
 ## 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** the Home Assistant add-on failing to start on 2.2.0 — it exited immediately on every launch (looping with no log output) for anyone not using a custom config file. Updating to this version restores normal startup ([#510](https://github.com/tomquist/astrameter/issues/510), [#511](https://github.com/tomquist/astrameter/issues/511)).
+- **Fixed** the Home Assistant add-on failing to start on 2.2.0 — it exited immediately on every launch (looping with no log output) for anyone not using a custom config file. Updating to this version restores normal startup ([#510](https://github.com/tomquist/astrameter/issues/510), [#511](https://github.com/tomquist/astrameter/issues/511), [#513](https://github.com/tomquist/astrameter/pull/513)).
 
 
 ## 2.2.0

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -110,10 +110,16 @@ else
     fi
 
     # Emit the cloud-reporting keys (if any) into the current [CT00x] section.
+    # The trailing `return 0` is required: the last `[ -n ... ] && echo` is a
+    # no-op when the key is unset (the common case), which would make the
+    # function return 1. Under `set -e` a bare call to a function returning
+    # non-zero aborts the whole script — silently, since we're inside the
+    # `{ ... } > "$CONFIG"` block — so the add-on never started (issue #510).
     emit_cloud_reporting() {
         [ -n "$cloud_reporting" ] && echo "CLOUD_REPORTING=$cloud_reporting"
         [ -n "$cloud_reporting_host" ] && echo "CLOUD_REPORTING_HOST=$cloud_reporting_host"
         [ -n "$cloud_reporting_interval" ] && echo "CLOUD_REPORTING_INTERVAL=$cloud_reporting_interval"
+        return 0
     }
 
     # Generate default config
@@ -266,8 +272,10 @@ fi
 
 print_redacted_config "$CONFIG"
 
-# Wait for Home Assistant to be ready before starting
-wait_for_homeassistant
+# Wait for Home Assistant to be ready before starting. It returns non-zero on
+# timeout (and logs a warning) but we continue anyway, so guard the bare call
+# from `set -e`.
+wait_for_homeassistant || true
 
 . /app/.venv/bin/activate
 cd /app


### PR DESCRIPTION
## Summary

Fixes the Home Assistant add-on failing to start immediately on every launch with no log output (issue #510, #511). The root cause was two functions returning non-zero in edge cases, which under `set -e` would silently abort the entire startup script.

## Changes

- **`emit_cloud_reporting()`**: Added explicit `return 0` at the end of the function. When cloud reporting keys are unset (the common case), the trailing `[ -n ... ] && echo` becomes a no-op and the function would return 1, causing the script to exit silently inside the config file redirection block.

- **`wait_for_homeassistant` call**: Guarded with `|| true` to allow the script to continue even if the function times out. The function logs a warning on timeout but should not block startup; the guard prevents `set -e` from aborting the script on non-zero return.

- **CHANGELOG.md**: Added user-facing entry documenting the fix and restoration of normal startup behavior.

## Implementation Details

Both issues stem from the `set -e` option in the script, which causes immediate exit on any command returning non-zero. The fixes ensure these functions either return 0 or are explicitly allowed to fail without aborting the script.

https://claude.ai/code/session_01NqrMkNWjawZikwHMYN6ZQT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Home Assistant add-on failing to start on version 2.2.0 for users without a custom configuration file.
  * Improved add-on startup robustness by handling edge cases in the startup sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->