### PR TITLE
docs: document every MQTT Insights topic for non-HA use

### DIFF
--- a/docs/mqtt-insights.md
+++ b/docs/mqtt-insights.md
@@ -1,8 +1,12 @@
 # MQTT Insights & Home Assistant Entities
 
 **Primary use:** publish CT002/Shelly internal state (grid power, targets,
-saturation, topology, switches) to MQTT with **optional Home Assistant MQTT
-Device Discovery** so entities show up in HA.
+saturation, topology, switches) to MQTT. Home Assistant gets **optional MQTT
+Device Discovery** so entities show up automatically, but the underlying topics
+are **plain JSON on stable paths** — you can consume them from Node-RED,
+openHAB, Telegraf/Grafana, `mosquitto_sub`, or any custom script **without Home
+Assistant**. The [Topic reference](#topic-reference) below documents every topic
+and payload so you can build your own dashboards and automations.
 
 **Home Assistant app:** With the Mosquitto add-on installed, MQTT Insights is
 auto-configured; entities appear without manual `[MQTT_INSIGHTS]` wiring.
@@ -11,7 +15,7 @@ auto-configured; entities appear without manual `[MQTT_INSIGHTS]` wiring.
 CT002/CT003 MQTT polls** so the Marstek mobile app shows live grid power when you
 use [hame-relay](https://github.com/tomquist/hame-relay) on that broker (see
 [Optional: Marstek mobile app](#optional-marstek-mobile-app-live-mqtt) below).
-You can turn that off with `MARSTEK_MQTT_ENABLED=false` and keep HA publishing
+You can turn that off with `MARSTEK_MQTT_ENABLED=false` and keep publishing
 unchanged.
 
 ## Manual configuration
@@ -38,11 +42,209 @@ HA_DISCOVERY_PREFIX = homeassistant
 | `USERNAME` / `PASSWORD` | — | Credentials (optional) |
 | `TLS` | `false` | Enable TLS encryption |
 | `BASE_TOPIC` | `astrameter` | Root topic for all published messages |
-| `HA_DISCOVERY` | `true` | Enable Home Assistant MQTT Device Discovery |
+| `HA_DISCOVERY` | `true` | Enable Home Assistant MQTT Device Discovery (the state/command topics below are published regardless) |
 | `HA_DISCOVERY_PREFIX` | `homeassistant` | HA discovery topic prefix |
 | `MARSTEK_MQTT_ENABLED` | `true` | Optional: answer Marstek app CT002/CT003 polls on this broker (needs `[MARSTEK]`); set `false` for HA-only |
 | `MARSTEK_MQTT_INTERVAL` | `300` | Optional: seconds between background aggregate publishes for the app; `0` = polls only |
-| `POWERMETER_HEALTH_INTERVAL` | `30` | Seconds between per-powermeter **Online** diagnostic sensor updates; `0` disables it |
+| `POWERMETER_HEALTH_INTERVAL` | `30` | Seconds between per-powermeter health (Online + power) updates; `0` disables it |
+
+> **HA discovery is independent of the data.** Turning `HA_DISCOVERY` off only
+> stops the retained `homeassistant/.../config` discovery messages (and the
+> `{base}/bridge` hub summary). All of the state and command topics in the
+> [Topic reference](#topic-reference) are still published and accepted, so a
+> non-HA setup loses nothing.
+
+## Topic reference
+
+Every topic below is rooted at `BASE_TOPIC` (default `astrameter`), shown here as
+`{base}`. State topics are **published `retain`ed** unless noted, so a client
+that connects later immediately receives the last known value. JSON payloads are
+compact UTF-8 objects.
+
+Path variables:
+
+- `{did}` — the device's configured `DEVICE_ID` (sanitized: any character
+  outside `A–Z a–z 0–9 _ -` becomes `_`). Empty when no `DEVICE_ID` is set.
+- `{cid}` — a CT002 **consumer**, i.e. one Marstek battery, keyed by its
+  lowercased battery MAC (e.g. `0123456789ab`).
+- `{ip}` — a Shelly-mode battery, keyed by its IP with dots sanitized to `_`
+  (e.g. `192_168_1_50`).
+- `{pm}` — a powermeter, keyed by its sanitized config section name.
+
+### Service status (LWT)
+
+| Topic | Retain | Payload |
+|---|---|---|
+| `{base}/status` | yes | `online` while AstraMeter is connected; `offline` on clean shutdown and as the broker's Last-Will if the process dies. Plain string, not JSON. |
+
+Use this as the availability/heartbeat for everything else.
+
+### Hub summary (HA discovery only)
+
+| Topic | Retain | Payload |
+|---|---|---|
+| `{base}/bridge` | yes | `{"version": "<app version>", "consumer_count": <int>}` — only published when `HA_DISCOVERY = true`. `consumer_count` is the total of CT002 consumers + Shelly batteries currently known. |
+
+### CT002 — per-battery (consumer) state
+
+`{base}/ct002/{did}/consumer/{cid}` — published on every poll from that battery.
+Example payload:
+
+```json
+{
+  "grid_power":  {"l1": 120.0, "l2": 0.0, "l3": -30.0, "total": 90.0},
+  "target":      {"l1": -50.0, "l2": 0.0, "l3": 0.0},
+  "phase": "l1",
+  "reported_power": 600,
+  "device_type": "HMG-50",
+  "battery_ip": "192.168.1.50",
+  "ct_type": "HME-3",
+  "ct_mac": "0123456789ab",
+  "saturation": 0.0,
+  "last_target": -50.0,
+  "active": true,
+  "poll_interval": 1.0,
+  "last_seen": "2026-06-22T10:15:00+00:00",
+  "manual_target": null,
+  "auto_target": true,
+  "distribution_weight": 1.0,
+  "efficiency_window_weight": 1.0,
+  "min_dc_output": null
+}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `grid_power` | object | Smoothed grid reading sent to this battery, per phase plus `total` (watts; **+ = import**, − = export). |
+| `target` | object | Per-phase charge/discharge target the balancer computed for this battery (watts; sign convention as reported to the battery). No `total` key. |
+| `phase` | string | Phase this battery is assigned to (`l1`/`l2`/`l3`), or its reported phase. |
+| `reported_power` | number | Power the battery reported it is currently producing/consuming (watts). |
+| `device_type` | string | Battery model string it announced. |
+| `battery_ip` | string | Source IP of the battery's UDP poll. |
+| `ct_type` / `ct_mac` | string | Emulated CT type and MAC this consumer polled. |
+| `saturation` | number | 0–1 estimate of how saturated (maxed-out) the battery is; 1 = can't absorb/deliver more. |
+| `last_target` | number/null | Previous target sent, for rate-of-change context. |
+| `active` | bool | `false` when this battery is paused (steered to 0 W). |
+| `poll_interval` | number/null | Measured seconds between this battery's polls. |
+| `last_seen` | string | ISO-8601 UTC timestamp of this update. |
+| `manual_target` | number/null | Active manual override in watts, or `null` when on automatic. |
+| `auto_target` | bool | `true` = automatic control; `false` = manual override in effect. |
+| `distribution_weight` | number | Relative share of demand when splitting across batteries (ratio-based; `1.0` neutral). |
+| `efficiency_window_weight` | number | Internal 0–1 fraction of efficiency-rotation active time (HA surfaces this ×100 as a percent). |
+| `min_dc_output` | number/null | Per-battery minimum DC discharge (watts) keep-alive override, or `null`. |
+
+Availability companion:
+
+| Topic | Retain | Payload |
+|---|---|---|
+| `{base}/ct002/{did}/consumer/{cid}/availability` | yes | `online` while the battery is known; `offline` when it ages out / is removed. |
+
+### CT002 — per-device status
+
+| Topic | Retain | Payload |
+|---|---|---|
+| `{base}/ct002/{did}/status` | yes | `{"smooth_target": <w>, "active_control": <bool>, "consumer_count": <int>}` |
+
+- `smooth_target` — the device-wide smoothed grid target (watts).
+- `active_control` — `true` when the emulator is computing per-battery targets;
+  `false` in relay mode (raw aggregate forwarded).
+- `consumer_count` — number of batteries currently polling this device.
+
+### Shelly — per-battery state
+
+`{base}/shelly/{did}/battery/{ip}`:
+
+```json
+{
+  "grid_power": {"l1": 120.0, "l2": 0.0, "l3": -30.0, "total": 90.0},
+  "active": true,
+  "poll_interval": 1.0,
+  "last_seen": "2026-06-22T10:15:00+00:00"
+}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `grid_power` | object | Per-phase grid power forwarded to this battery plus `total` (watts; + = import). |
+| `active` | bool | `false` when the battery is marked inactive. |
+| `poll_interval` | number/null | Measured seconds between polls. |
+| `last_seen` | string | ISO-8601 UTC timestamp. |
+
+| Topic | Retain | Payload |
+|---|---|---|
+| `{base}/shelly/{did}/battery/{ip}/availability` | yes | `online` / `offline` |
+| `{base}/shelly/{did}/status` | yes | `{"battery_count": <int>}` — batteries currently polling this Shelly device. |
+
+### Powermeter health
+
+`{base}/powermeter/{pm}` — published every `POWERMETER_HEALTH_INTERVAL` seconds
+(0 disables):
+
+```json
+{"online": true, "grid_power": {"l1": 120.0, "l2": 0.0, "l3": -30.0, "total": 90.0}}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `online` | bool | `false` when the source stops delivering fresh, usable readings (stalled push stream, or a polling source whose reads fail) — alert on this to catch a meter that has gone quiet while AstraMeter keeps running on its last cached value. |
+| `grid_power` | object | Latest per-phase reading and `total` (watts). Single-phase meters leave `l2`/`l3` `null`. |
+
+Push sources (HomeWizard, MQTT, SMA, Home Assistant) report stream state
+directly; polling sources reflect the control loop, or are probed about once per
+interval when no battery is reading them. A multi-phase source whose value
+simply stops changing (an idle circuit reporting a steady number) stays
+**online** — only an unavailable/missing reading marks it offline.
+
+### Command topics (set values without Home Assistant)
+
+AstraMeter **subscribes** to the topics below; publish to them from any client
+to change settings live. Publishing **retained** is recommended — AstraMeter
+re-reads them on restart so your values survive a restart (this is exactly how
+the HA entities persist). An empty payload clears a retained command.
+
+Per-consumer (one battery), one scalar value per topic:
+
+| Topic suffix on `{base}/ct002/{did}/consumer/{cid}/…/set` | Payload | Effect |
+|---|---|---|
+| `active/set` | `true`/`false` (also `on`/`off`, `1`/`0`) | Pause (`false`) or resume a battery; paused is steered to 0 W. |
+| `auto_target/set` | `true`/`false` | `true` hands the battery back to automatic control; `false` keeps the manual override. |
+| `manual_target/set` | number, −10000…10000 | Force this battery's power (watts). Setting it implies manual mode. |
+| `distribution_weight/set` | number, 0.0…10.0 | Relative share of the split (ratio-based; `0` parks at 0 W but keeps it in the pool). |
+| `efficiency_window_weight/set` | number, 0…100 (**percent**) | Share of efficiency-rotation active time. `100` neutral, `0` skips while limiting. |
+| `min_dc_output/set` | number, 0…1000 | Per-battery minimum DC discharge keep-alive (watts). |
+
+Per-device, JSON body on `{base}/ct002/{did}/set`:
+
+| Payload | Effect |
+|---|---|
+| `{"active_control": true}` / `{"active_control": false}` | Turn active control on (compute per-battery targets) or off (relay mode — raw aggregate forwarded, the live equivalent of `ACTIVE_CONTROL = False`). |
+| `{"force_rotation": true}` | Immediately rotate the efficiency window to the next battery. |
+
+Out-of-range, non-numeric, or non-boolean payloads are ignored with a warning.
+
+> **Sign / unit conventions.** All power values are watts. Grid power follows
+> **import-positive** (+ = drawing from the grid, − = exporting). Battery
+> `target`/`reported_power` use the value as sent to the battery. Timestamps are
+> ISO-8601 in UTC.
+
+#### Quick examples (`mosquitto`)
+
+```bash
+# Watch everything AstraMeter publishes
+mosquitto_sub -h 192.168.1.100 -v -t 'astrameter/#'
+
+# Pause a battery (retained so it sticks across restarts)
+mosquitto_pub -h 192.168.1.100 -r \
+  -t 'astrameter/ct002/myct/consumer/0123456789ab/active/set' -m 'false'
+
+# Force a manual 300 W discharge target
+mosquitto_pub -h 192.168.1.100 -r \
+  -t 'astrameter/ct002/myct/consumer/0123456789ab/manual_target/set' -m '-300'
+
+# Switch the whole CT002 device to relay mode
+mosquitto_pub -h 192.168.1.100 \
+  -t 'astrameter/ct002/myct/set' -m '{"active_control": false}'
+```
 
 ## Powermeter health (Home Assistant entities)
 
@@ -52,25 +254,20 @@ for the label, and the device is grouped under the **AstraMeter** hub device —
 keyed on `ADDON_SLUG` on the add-on, with a stable base-topic fallback so the
 grouping also works in standalone/Docker). It carries:
 
-- an **Online** connectivity `binary_sensor` (diagnostic) that flips **off** when
-  the source stops delivering fresh, usable readings — a stalled or disconnected
-  push stream, or a polling source whose reads start failing — so you can alert on
-  a meter that has gone quiet even though AstraMeter keeps running on its last
-  cached value;
-- **Power**, **Power L1**, **Power L2**, **Power L3** sensors carrying the latest
-  per-phase readings and their total (single-phase meters leave L2/L3 empty).
+- an **Online** connectivity `binary_sensor` (diagnostic) backed by the
+  `online` field of `{base}/powermeter/{pm}`;
+- **Power**, **Power L1**, **Power L2**, **Power L3** sensors backed by that
+  topic's `grid_power` (single-phase meters leave L2/L3 empty).
 
-Push sources (HomeWizard, MQTT, SMA, Home Assistant) report their stream state
-directly; polling sources reflect the control loop, or are probed about once per
-`POWERMETER_HEALTH_INTERVAL` when no battery is reading them. For multi-phase
-sources, a phase that simply stops changing (e.g. an idle circuit reporting a
-steady value) stays **online** — only an unavailable/missing reading or a
-disconnect marks it offline.
+See [Powermeter health](#powermeter-health) above for the raw topic and the
+exact online/offline semantics.
 
 ## Per-battery controls (Home Assistant entities)
 
 When HA discovery is on, each battery gets a few **config** entities you can set
-live from Home Assistant:
+live from Home Assistant. Each maps to a command topic in
+[Command topics](#command-topics-set-values-without-home-assistant), so the same
+controls are available to any MQTT client:
 
 - **Manual Target** / **Auto Target** — override a battery's power, or hand it
   back to automatic control.
@@ -127,25 +324,6 @@ AstraMeter is unchanged for control.
   answer polls only.
 
 Replies follow the usual `hame_energy/…` / `marstek_energy/…` App/device topics
-for a real CT; AstraMeter matches your CT002/CT003 **type** and **MAC**.
-
-**Published entities** (per CT002 consumer):
-
-- Grid power (L1/L2/L3/total), charge target (L1/L2/L3), reported power,
-  saturation
-- Diagnostic: phase, device type, battery IP, CT type, CT MAC, last seen
-- **Active switch**: pause/resume individual consumers (targets zeroed when
-  inactive)
-
-**Published entities** (per CT002 device):
-
-- Smooth target, consumer count, and an **Active Control** switch (on by default;
-  turn off for relay mode)
-
-**Published entities** (per Shelly battery):
-
-- Grid power (L1/L2/L3/total), active status, last seen
-
-**Topics**: `{base}/ct002/{id}/consumer/{cid}`, `{base}/ct002/{id}/status`,
-`{base}/shelly/{id}/battery/{ip}`, `{base}/shelly/{id}/status`, `{base}/status`
-(LWT)
+for a real CT; AstraMeter matches your CT002/CT003 **type** and **MAC**. These
+are a separate, Marstek-cloud-specific protocol — unrelated to the
+`{base}/…` insight topics documented above.

--- a/docs/mqtt-insights.md
+++ b/docs/mqtt-insights.md
@@ -3,10 +3,11 @@
 **Primary use:** publish CT002/Shelly internal state (grid power, targets,
 saturation, topology, switches) to MQTT. Home Assistant gets **optional MQTT
 Device Discovery** so entities show up automatically, but the underlying topics
-are **plain JSON on stable paths** — you can consume them from Node-RED,
-openHAB, Telegraf/Grafana, `mosquitto_sub`, or any custom script **without Home
-Assistant**. The [Topic reference](#topic-reference) below documents every topic
-and payload so you can build your own dashboards and automations.
+are **plain JSON on stable paths** — Home Assistant is just one optional
+consumer, and you can read and command the same topics from Node-RED, openHAB,
+Telegraf/Grafana, `mosquitto_sub`, or any custom MQTT client. The
+[Topic reference](#topic-reference) below documents every topic and payload so
+you can build your own dashboards and automations.
 
 **Home Assistant app:** With the Mosquitto add-on installed, MQTT Insights is
 auto-configured; entities appear without manual `[MQTT_INSIGHTS]` wiring.
@@ -195,7 +196,7 @@ interval when no battery is reading them. A multi-phase source whose value
 simply stops changing (an idle circuit reporting a steady number) stays
 **online** — only an unavailable/missing reading marks it offline.
 
-### Command topics (set values without Home Assistant)
+### Command topics (set values from any MQTT client)
 
 AstraMeter **subscribes** to the topics below; publish to them from any client
 to change settings live. Publishing **retained** is recommended — AstraMeter
@@ -266,7 +267,7 @@ exact online/offline semantics.
 
 When HA discovery is on, each battery gets a few **config** entities you can set
 live from Home Assistant. Each maps to a command topic in
-[Command topics](#command-topics-set-values-without-home-assistant), so the same
+[Command topics](#command-topics-set-values-from-any-mqtt-client), so the same
 controls are available to any MQTT client:
 
 - **Manual Target** / **Auto Target** — override a battery's power, or hand it


### PR DESCRIPTION
Add a self-contained "Topic reference" section to mqtt-insights.md that documents each state and command topic with its full JSON payload schema, retain/availability semantics, path-variable meanings, sign/unit conventions, and mosquitto pub/sub examples — so the topics are usable from Node-RED, openHAB, Grafana, or custom scripts without Home Assistant. Clarify that HA discovery only adds the discovery/bridge messages while all state and command topics are published regardless.


Claude-Session: https://claude.ai/code/session_01Ty4ibpeEbCZzgAkyKuFgUj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded MQTT Insights docs with clear topic reference, payload/retention conventions, and example health semantics.
  * Updated command topic guidance, including recommended retained publishes and handling invalid payloads.
  * Improved Home Assistant integration documentation for powermeter health and entity mapping.
  * Clarified Marstek polling and mobile app behavior, including protocol separation from the Insights topics.
  * Added/updated Mosquitto CLI examples for subscribing and controlling devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->