### PR TITLE
Add inter-battery share-imbalance steering-eval metric

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,8 @@ improved/regressed and the mean relative change), so an across-the-board
 improvement or regression is visible without reading every scenario table. A
 second **priority verdict** sits below it: a value-weighted score (`_METRIC_WEIGHTS`
 — `cost_regret_ct` money north-star, import-heavy self-consumption energy,
-do-no-harm overshoot/hunting guardrails, cycle-life battery travel) plus a hard
+do-no-harm overshoot/hunting guardrails, cycle-life battery travel and
+`share_imbalance_w` inter-battery fairness) plus a hard
 flag when any do-no-harm guardrail (`_GUARDRAIL_METRICS`: overshoot,
 band-crossings, grid p2p, avoidable grid import, and cost regret) regresses past
 5% (or appears from a zero base). Read the flat mean for "did most numbers move

--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -614,9 +614,25 @@ def _compute_metrics(
     # fused with an arbitrary trade-off constant. Both grid_rms and mean_abs are
     # *time-weighted* (by dt) so they're true time-averages, not sample-averages
     # skewed by uneven / staggered poll spacing (slow meters, multi-battery).
+    # --- inter-battery share imbalance (issue #523) ---
+    # Batteries sharing a phase should split the phase's net output evenly (the
+    # balancer's fair-share target with the eval's equal distribution weights);
+    # a controller that leaves them lopsided — e.g. one Venus charging at 88 W
+    # while its twin takes 890 W — is doing real harm (uneven cycle wear, a pack
+    # that saturates first). ``share_imbalance_w`` is the time-weighted mean of
+    # the per-sample watts misallocated: within each phase group of >=2 active
+    # batteries, the sum of |power_i - phase_fair_share|. It is 0 for a perfectly
+    # balanced pool and 0 by construction for any scenario with at most one
+    # battery per phase (nothing to balance).
+    phase_groups: dict[str, list[int]] = {}
+    for i, sp in enumerate(specs):
+        phase_groups.setdefault((sp.phase or "A").upper(), []).append(i)
+    balance_groups = [grp for grp in phase_groups.values() if len(grp) >= 2]
+
     import_wh = export_wh = avoid_import_wh = avoid_export_wh = 0.0
     travel_w = 0.0
     grid_sq_dt = abs_grid_dt = total_dt = 0.0
+    imbalance_dt = 0.0
     for prev, cur in itertools.pairwise(samples):
         dt = min(cur.t - prev.t, 5.0)
         if dt <= 0:
@@ -624,6 +640,9 @@ def _compute_metrics(
         grid_sq_dt += prev.grid * prev.grid * dt
         abs_grid_dt += abs(prev.grid) * dt
         total_dt += dt
+        for grp in balance_groups:
+            fair = sum(prev.powers[i] for i in grp) / len(grp)
+            imbalance_dt += sum(abs(prev.powers[i] - fair) for i in grp) * dt
         wh = prev.grid * dt / 3600.0
         if wh > 0:
             import_wh += wh
@@ -650,6 +669,7 @@ def _compute_metrics(
 
     grid_rms = math.sqrt(grid_sq_dt / total_dt) if total_dt > 0 else 0.0
     mean_abs = abs_grid_dt / total_dt if total_dt > 0 else 0.0
+    share_imbalance = imbalance_dt / total_dt if total_dt > 0 else 0.0
 
     # --- money: cost vs perfect-foresight oracle (the north-star metric) ---
     # The actual electricity bill (eurocents) for the residual grid this
@@ -693,6 +713,7 @@ def _compute_metrics(
         "grid_rms_w": round(grid_rms, 1),
         "steady_rms_w": round(steady_rms, 1),
         "mean_abs_grid_w": round(mean_abs, 1),
+        "share_imbalance_w": round(share_imbalance, 1),
         "import_wh": round(import_wh, 1),
         "export_wh": round(export_wh, 1),
         "avoidable_import_wh": round(avoid_import_wh, 1),
@@ -1573,6 +1594,7 @@ _REPORT_METRICS = [
     "grid_rms_w",
     "steady_rms_w",
     "mean_abs_grid_w",
+    "share_imbalance_w",
     "avoidable_import_wh",
     "avoidable_export_wh",
     "cost_regret_ct",
@@ -1598,6 +1620,9 @@ _REPORT_METRICS = [
 #     wastes energy, wears the pack and reads as "broken" — so they carry heavy
 #     weight (and a separate hard regression flag, see ``_GUARDRAIL_METRICS``).
 #   * **Battery travel is cycle-life / hardware wear**, a real € cost.
+#   * **Inter-battery share imbalance is cycle-life / fairness** — a lopsided
+#     split (issue #523) wears and saturates one pack ahead of its peers, so it
+#     shares the cycle-life weight with battery travel.
 #   * **Settle time is an enabler** (it mostly feeds energy), weighted lightly.
 #
 # All metrics are lower-is-better, so a negative weighted change is an overall
@@ -1609,6 +1634,7 @@ _METRIC_WEIGHTS: dict[str, float] = {
     "overshoot_max_w": 3.0,
     "band_crossings_per_h": 2.0,
     "battery_travel_w_per_h": 2.0,
+    "share_imbalance_w": 2.0,
     "grid_p2p_w": 1.5,
     "grid_rms_w": 1.0,
     "overshoot_mean_w": 1.0,
@@ -1712,6 +1738,13 @@ _METRIC_GLOSSARY = [
     (
         "mean_abs_grid_w",
         "Mean absolute grid power (W) over the whole run — overall tracking accuracy.",
+    ),
+    (
+        "share_imbalance_w",
+        "Time-weighted watts misallocated between batteries sharing a phase (sum "
+        "of each battery's deviation from the even fair share) — 0 when the pool "
+        "splits load evenly, higher when one battery is left lopsided (issue "
+        "#523). 0 for scenarios with at most one battery per phase.",
     ),
     (
         "avoidable_import_wh",


### PR DESCRIPTION
## Summary

Adds a new steering-evaluation metric, **`share_imbalance_w`**, that measures how unevenly batteries sharing a phase split the load — the time-weighted watts misallocated between them (each battery's deviation from the even fair share, summed). It reads **0** for a perfectly balanced pool and **0** by construction for any scenario with at most one battery per phase, and rises when one battery is left lopsided.

This is the measurement counterpart to issue #523 (two Marstek Venus E3 where one charged at ~88 W while the other took ~890 W and never equalized). It gives CI a way to catch inter-battery balance regressions and improvements that none of the existing grid-tracking metrics see (an uneven split is invisible at the grid coupling point — the sum is still correct).

## What's included

- Compute `share_imbalance_w` in `_compute_metrics` (time-weighted, per-phase grouping; equal distribution weights as the eval uses).
- Wire it into the report tables, the metric glossary, and the priority-weighted verdict (cycle-life / fairness tier, weight `2.0`, alongside `battery_travel_w_per_h`).
- Update `AGENTS.md` so the next agent inherits the new metric.

## Why a separate PR

Introducing the metric on its own first means the follow-up #523 fix PR (stacked on this branch) gets a clean before/after comparison from the CI steering-eval job — the metric exists on the fix PR's base, so the sticky comparison comment will show the balance change directly.

No user-facing behavior changes (tooling only), so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiZvgThQbNq5hUfGHARuWB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new steering-evaluation metric that measures how evenly output is shared among batteries operating in the same phase.
  * This metric now appears in reported evaluation summaries and contributes to overall priority scoring.

* **Documentation**
  * Updated the evaluation guidance to include the new metric in the value-weighted score description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->