### PR TITLE
Fix uneven multi-battery charging from deadband concentration (#523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Fixed** uneven charging/discharging across multiple batteries sharing a phase (e.g. two Marstek Venus E3 where one sat at ~88 W while the other took ~890 W and never equalized), a regression in 2.2.0. The steady-state deadband optimization now steps aside whenever the batteries are actually out of balance, so they're pulled back to an even split instead of staying lopsided ([#523](https://github.com/tomquist/astrameter/issues/523)).
+
 
 ## 2.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** uneven charging/discharging across multiple batteries sharing a phase (e.g. two Marstek Venus E3 where one sat at ~88 W while the other took ~890 W and never equalized), a regression in 2.2.0. The steady-state deadband optimization now steps aside whenever the batteries are actually out of balance, so they're pulled back to an even split instead of staying lopsided ([#523](https://github.com/tomquist/astrameter/issues/523)).
+- **Fixed** uneven charging/discharging across multiple batteries sharing a phase (e.g. two Marstek Venus E3 where one sat at ~88 W while the other took ~890 W and never equalized), a regression in 2.2.0. The steady-state deadband optimization now steps aside whenever the batteries are actually out of balance, so they're pulled back to an even split instead of staying lopsided ([#523](https://github.com/tomquist/astrameter/issues/523), [#526](https://github.com/tomquist/astrameter/pull/526)).
 
 
 ## 2.2.1

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -949,10 +949,21 @@ std::array<float, 3> LoadBalancer::compute_auto_target_(
   } else {
     residual = fair_share;
   }
-  if ((control_grid < 0.0f && residual > 0.0f) ||
-      (control_grid > 0.0f && residual < 0.0f)) {
-    residual = 0.0f;
+  // Clamp only the grid-tracking half (fair_share) against the grid direction,
+  // not the balance-correction redistribution. fair_share always carries the
+  // grid's sign by construction, so this guard never fires on it; the balance
+  // term is ~zero-sum across the same-phase pool, so letting it through is
+  // grid-neutral (the over-served battery backs off exactly as the under-served
+  // one takes on). Zeroing the whole residual on a sign disagreement made
+  // equalization one-sided near steady state, pushing the pool's net output
+  // around and disturbing the grid (issue #523 balance fix regressions).
+  // Mirrors balancer.py _compute_auto_target.
+  float tracking = fair_share;
+  if ((control_grid < 0.0f && tracking > 0.0f) ||
+      (control_grid > 0.0f && tracking < 0.0f)) {
+    tracking = 0.0f;
   }
+  residual = tracking + (residual - fair_share);
   if (consumer_id) {
     residual = this->damp_oscillation_(*consumer_id, residual);
   }

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -892,7 +892,9 @@ std::array<float, 3> LoadBalancer::compute_auto_target_(
   // over participating batteries (not charge-blind / faded-out) and only when
   // they're all on the same phase (control_grid sums phases, so on a multi-phase
   // pool concentrating it over-corrects one phase and hunts). Gated on
-  // fair_distribution. Mirrors balancer.py _compute_auto_target.
+  // fair_distribution and on the pool already being balanced
+  // (concentration_pool_balanced_) so it never suppresses equalization of a
+  // real imbalance (issue #523). Mirrors balancer.py _compute_auto_target.
   bool concentrate = false;
   std::vector<const std::string *> conc_ids;
   bool conc_single_phase = true;
@@ -919,7 +921,8 @@ std::array<float, 3> LoadBalancer::compute_auto_target_(
   if (this->cfg_.fair_distribution && this->cfg_.concentrate_deadband > 0.0f &&
       conc_ids.size() > 1 && conc_single_phase && consumer_in_conc &&
       std::fabs(control_grid) > 0.0f &&
-      std::fabs(control_grid) < this->cfg_.concentrate_deadband) {
+      std::fabs(control_grid) < this->cfg_.concentrate_deadband &&
+      this->concentration_pool_balanced_(reports, conc_ids)) {
     const std::string *designated = nullptr;
     float best_abs = -1.0f;
     for (const auto *cid : conc_ids) {
@@ -1125,6 +1128,38 @@ float LoadBalancer::pace_reading_(const std::string &consumer_id, float reading,
   state.pace_prev_reported = reported;
   limit = std::max(base, cap * dt_ratio);
   return std::max(-limit, std::min(limit, reading));
+}
+
+// True iff every battery in conc_ids already sits within balance_deadband of
+// its weight-proportional share of the pool total. Deadband concentration
+// bypasses balance correction for the tick, so it must only engage on an
+// already-balanced pool — otherwise a real imbalance (issue #523: 88 W vs
+// 890 W charge split) would be pinned forever because the equalizing
+// balance_correction_ never runs. Uses the same target/deadband as
+// balance_correction_. Mirrors balancer.py _concentration_pool_balanced.
+bool LoadBalancer::concentration_pool_balanced_(const ReportMap &reports,
+                                                const std::vector<const std::string *> &conc_ids) {
+  const float deadband = this->cfg_.balance_deadband;
+  if (deadband <= 0.0f) {
+    // No deadband means balance correction always runs at full authority;
+    // never let concentration suppress it.
+    return false;
+  }
+  float actual_total = 0.0f;
+  float total_weight = 0.0f;
+  for (const auto *cid : conc_ids) {
+    const auto &rep = reports.at(*cid);
+    actual_total += rep.power;
+    total_weight += rep.weight;
+  }
+  for (const auto *cid : conc_ids) {
+    const auto &rep = reports.at(*cid);
+    const float target_share = (total_weight > 0.0f)
+                                   ? actual_total * rep.weight / total_weight
+                                   : actual_total / static_cast<float>(conc_ids.size());
+    if (std::fabs(target_share - rep.power) >= deadband) return false;
+  }
+  return true;
 }
 
 float LoadBalancer::balance_correction_(const std::string &consumer_id,

--- a/esphome/components/ct002/balancer.h
+++ b/esphome/components/ct002/balancer.h
@@ -334,6 +334,8 @@ class LoadBalancer {
   float balance_correction_(const std::string &consumer_id, const ReportMap &reports,
                             const std::unordered_map<std::string, float> &eff_part,
                             float fair_share);
+  bool concentration_pool_balanced_(const ReportMap &reports,
+                                    const std::vector<const std::string *> &conc_ids);
   float pace_reading_(const std::string &consumer_id, float reading, float reported);
   float damp_oscillation_(const std::string &consumer_id, float residual);
   float predict_control_grid_(const ReportMap &reports, float grid_total,

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -1436,7 +1436,9 @@ class LoadBalancer:
         # absorb; zero-weight units were asked to take no share) all on the *same*
         # phase (``control_grid`` sums phases, so concentrating across phases makes
         # one battery hunt). Gated on ``fair_distribution``, being a fair-share
-        # strategy.
+        # strategy, and on the pool already being balanced
+        # (``_concentration_pool_balanced``) so it never suppresses the
+        # equalization of a real imbalance (issue #523).
         conc_ids = [
             cid
             for cid in reports
@@ -1452,6 +1454,7 @@ class LoadBalancer:
             and consumer_id in conc_ids
             and 0 < abs(control_grid) < cfg.concentrate_deadband
             and len({(reports[c].get("phase") or "A").upper() for c in conc_ids}) == 1
+            and self._concentration_pool_balanced(reports, conc_ids)
         ):
             designated = max(
                 conc_ids,
@@ -1716,6 +1719,44 @@ class LoadBalancer:
         state.pace_prev_reported = reported
         limit = max(base, cap * dt_ratio)
         return max(-limit, min(limit, reading))
+
+    def _concentration_pool_balanced(self, reports: dict, conc_ids: list[str]) -> bool:
+        """True iff every battery in *conc_ids* already sits at its fair share.
+
+        Deadband concentration (see ``_compute_auto_target``) hands the whole
+        small grid correction to one battery and *bypasses* balance correction
+        for that tick.  That is only safe once the pool is already balanced —
+        its job is to push a tiny residual past the firmware deadband at steady
+        state, not to override active rebalancing.  If a real imbalance exists
+        (issue #523: one Venus charging at 88 W while the other takes 890 W),
+        concentrating near a near-zero grid would pin that split forever because
+        the equalizing ``_balance_correction`` never runs.
+
+        A battery is "in balance" when its reported output is within
+        ``balance_deadband`` of its weight-proportional share of the pool total
+        — the same target/deadband ``_balance_correction`` uses, so the two
+        agree on what counts as balanced.  Mirrors the C++ port
+        (balancer.cpp ``concentration_pool_balanced_``).
+        """
+        deadband = self._cfg.balance_deadband
+        if deadband <= 0:
+            # No deadband means balance correction always runs at full authority;
+            # never let concentration suppress it.
+            return False
+        actual_total = sum(
+            parse_int(reports.get(cid, {}).get("power", 0)) for cid in conc_ids
+        )
+        weights = {cid: _report_weight(reports.get(cid, {})) for cid in conc_ids}
+        total_weight = sum(weights.values())
+        for cid in conc_ids:
+            actual_self = parse_int(reports.get(cid, {}).get("power", 0))
+            if total_weight > 0:
+                target_share = actual_total * weights[cid] / total_weight
+            else:
+                target_share = actual_total / len(conc_ids)
+            if abs(target_share - actual_self) >= deadband:
+                return False
+        return True
 
     def _balance_correction(
         self,

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -1481,10 +1481,27 @@ class LoadBalancer:
         else:
             residual = fair_share
 
-        # Clamp sign disagreement: prevent the inverter from acting
-        # against the current (predicted) grid direction.
-        if (control_grid < 0 and residual > 0) or (control_grid > 0 and residual < 0):
-            residual = 0
+        # Split the residual into its grid-tracking and balance-redistribution
+        # halves and clamp only the former against the (predicted) grid
+        # direction.  The grid-tracking share (``fair_share``) always carries the
+        # grid's sign by construction (``control_grid / total_effective *
+        # share``), so this guard never fires on it; what it used to *also* catch
+        # — and must no longer — is the balance-correction term flipping the
+        # residual's sign.  That term is, to first order, zero-sum across the
+        # same-phase pool (``sum(target_share_i - actual_i) == 0``), so applying
+        # it is grid-neutral: the over-served battery backs off by exactly what
+        # the under-served one takes on.  Zeroing the whole residual on a sign
+        # disagreement (the old behaviour) killed the over-served battery's "back
+        # off" half near steady state, so equalization ran one-sided — only the
+        # under-served battery moved, pushing the pool's net output around and
+        # disturbing the grid (the overshoot / slow-settle cost the issue #523
+        # balance fix otherwise carries).  Letting the zero-sum swap through
+        # equalizes without moving the pool's net output.  Mirrors the C++ port
+        # (balancer.cpp ``compute_auto_target_``).
+        tracking = fair_share
+        if (control_grid < 0 and tracking > 0) or (control_grid > 0 and tracking < 0):
+            tracking = 0.0
+        residual = tracking + (residual - fair_share)
 
         if consumer_id:
             residual = self._damp_oscillation(consumer_id, residual)

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -826,6 +826,25 @@ class TestConcentrateDeadband:
         b = self._target(lb, "b", reports, -30)
         assert b < -1.0
 
+    def test_imbalanced_pool_equalizes_from_both_sides(self):
+        # Issue #523 regression-cost fix: the equalizing swap is zero-sum across
+        # the phase, so it must move *both* batteries — the under-charging one
+        # charges more AND the over-charging one backs off. The over-charging
+        # battery's "back off" half opposes the surplus grid direction; the old
+        # blanket sign clamp zeroed it, leaving equalization one-sided (only the
+        # under-charging battery moved), which pushed the pool's net output
+        # around and disturbed the grid. Clamping only the grid-tracking half
+        # lets the grid-neutral swap through.
+        lb = self._lb(concentrate_deadband=60)
+        reports = {
+            "a": {"device_type": "VNSE3", "phase": "A", "power": -890},
+            "b": {"device_type": "VNSE3", "phase": "A", "power": -88},
+        }
+        a = self._target(lb, "a", reports, -30)
+        b = self._target(lb, "b", reports, -30)
+        assert b < 0  # under-charging battery charges more
+        assert a > 0  # over-charging battery backs off (was clamped to 0 before)
+
     def test_large_error_still_split(self):
         lb = self._lb(concentrate_deadband=60)
         reports = self._reports()
@@ -842,21 +861,25 @@ class TestConcentrateDeadband:
     def test_zero_weight_battery_not_designated(self):
         lb = self._lb(concentrate_deadband=60)
         # ``a`` is the most-active (200 W) but configured to take no share
-        # (weight 0). Without excluding it from candidates it would be picked as
-        # designee and swallow the whole correction; instead ``b`` (next most
-        # active among the weighted batteries) takes it and ``a`` stays at 0.
-        # Needs a third battery so the candidate set still has >1 after dropping
-        # ``a`` (otherwise concentration wouldn't fire at all).
+        # (weight 0). It must not be picked as the concentration designee —
+        # ``b`` (most active among the weighted batteries) takes the +30 grid
+        # correction. Needs a third battery so the candidate set still has >1
+        # after dropping ``a`` (otherwise concentration wouldn't fire at all).
         # b and c sit at their fair share (75 W each, within balance_deadband)
-        # so the pool is balanced and concentration engages.
+        # so the pool is balanced and concentration engages. ``a`` carries no
+        # weight so its fair share is 0; it is wound down toward that share (a
+        # grid-neutral redistribution the active pool absorbs), not frozen at
+        # 200 — so it reduces output rather than being designated.
         reports = {
             "a": {"device_type": "HMG-50", "phase": "A", "power": 200, "weight": 0.0},
             "b": {"device_type": "HMG-50", "phase": "A", "power": 80},
             "c": {"device_type": "HMG-50", "phase": "A", "power": 70},
         }
-        assert self._target(lb, "a", reports, 30) == pytest.approx(0.0, abs=1e-6)
+        a = self._target(lb, "a", reports, 30)
         assert self._target(lb, "b", reports, 30) == pytest.approx(30.0, abs=1.0)
         assert self._target(lb, "c", reports, 30) == pytest.approx(0.0, abs=1e-6)
+        # Not designated (b took the +30) and pulled toward its 0 share.
+        assert a < 0
 
 
 class TestImportTrim:

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -735,8 +735,10 @@ class TestGridPredictor:
 class TestConcentrateDeadband:
     """Opt-in deadband concentration: when the grid error is small enough that a
     fair-share split would drop each battery below its firmware deadband, the
-    whole correction is handed to the single most-active battery. Mirrored by the
-    C++ port and the differential parity suite."""
+    whole correction is handed to the single most-active battery. Only engages
+    on an already-balanced pool, so it never suppresses equalization of a real
+    imbalance (issue #523). Mirrored by the C++ port and the differential parity
+    suite."""
 
     def _lb(self, **cfg):
         # Disable the grid predictor so the test exercises the raw control grid
@@ -793,13 +795,36 @@ class TestConcentrateDeadband:
 
     def test_small_error_concentrated_on_most_active_battery(self):
         lb = self._lb(concentrate_deadband=60)
-        reports = self._reports()
-        # 30 W error < 60 W threshold: the most-active battery (a, 200 W) takes
-        # the whole correction; the other is left untouched.
+        # An *already-balanced* pool (both within balance_deadband of their
+        # 150 W fair share): concentration is safe here. 30 W error < 60 W
+        # threshold, so the most-active battery (a, 160 W) takes the whole
+        # correction and the other is left untouched.
+        reports = {
+            "a": {"device_type": "HMG-50", "phase": "A", "power": 160},
+            "b": {"device_type": "HMG-50", "phase": "A", "power": 140},
+        }
         a = self._target(lb, "a", reports, 30)
         b = self._target(lb, "b", reports, 30)
         assert a == pytest.approx(30.0, abs=1.0)
         assert b == pytest.approx(0.0, abs=1e-6)
+
+    def test_imbalanced_pool_is_not_concentrated(self):
+        # Regression for issue #523: two Venus E3 charging unevenly (one at
+        # 88 W, the other at 890 W). The grid error is small (< 60 W), so the
+        # pre-fix concentration handed the whole correction to the most-active
+        # battery and *bypassed* balance correction — pinning the split forever.
+        # With the balance gate, an out-of-balance pool falls through to
+        # balance correction so the lagging battery is pulled back toward its
+        # fair share instead of being left at 0.
+        lb = self._lb(concentrate_deadband=60)
+        reports = {
+            "a": {"device_type": "VNSE3", "phase": "A", "power": -890},
+            "b": {"device_type": "VNSE3", "phase": "A", "power": -88},
+        }
+        # Small surplus (charge territory): the lagging battery (b) must keep
+        # charging more rather than being parked at 0 by concentration.
+        b = self._target(lb, "b", reports, -30)
+        assert b < -1.0
 
     def test_large_error_still_split(self):
         lb = self._lb(concentrate_deadband=60)
@@ -822,10 +847,12 @@ class TestConcentrateDeadband:
         # active among the weighted batteries) takes it and ``a`` stays at 0.
         # Needs a third battery so the candidate set still has >1 after dropping
         # ``a`` (otherwise concentration wouldn't fire at all).
+        # b and c sit at their fair share (75 W each, within balance_deadband)
+        # so the pool is balanced and concentration engages.
         reports = {
             "a": {"device_type": "HMG-50", "phase": "A", "power": 200, "weight": 0.0},
-            "b": {"device_type": "HMG-50", "phase": "A", "power": 100},
-            "c": {"device_type": "HMG-50", "phase": "A", "power": 50},
+            "b": {"device_type": "HMG-50", "phase": "A", "power": 80},
+            "c": {"device_type": "HMG-50", "phase": "A", "power": 70},
         }
         assert self._target(lb, "a", reports, 30) == pytest.approx(0.0, abs=1e-6)
         assert self._target(lb, "b", reports, 30) == pytest.approx(30.0, abs=1.0)


### PR DESCRIPTION
Fixes #523. The `share_imbalance_w` metric this relies on landed in #525 (merged), so this PR targets `develop` directly and the CI steering-eval comparison shows the balance change against a base that already has the metric.

## Root cause

Deadband concentration (`concentrate_deadband`, added in 2.2.0 via #480) hands the whole small grid correction to the single most-active battery near steady state so it clears the firmware input deadband, and **bypasses balance correction for that tick**. But it fired whenever the grid error was small *regardless of how the pool was split*. An out-of-balance pair (two Venus E3 at ~88 W and ~890 W) produces no grid error — the sum is correct — so the only thing that could equalize them is balance correction, which concentration was suppressing. Result: the imbalance was pinned forever. This is absent in 2.1.2, which is why rolling back fixed it.

## Fix (two parts)

1. **Gate concentration on the pool already being balanced** — skip it (and let balance correction equalize) whenever any battery is at least `balance_deadband` off its weight-proportional fair share.
2. **Make equalization grid-neutral** — the grid-direction sign clamp used to zero any residual opposing the grid. `fair_share` always carries the grid's sign, so that clamp only ever fired on the balance-correction term — near steady state, exactly the over-served battery's "back off" half of the swap. That left equalization one-sided (only the under-served battery moved), pushing the pool's net output around and disturbing the grid. Now only the grid-tracking half is clamped; the balance redistribution (≈zero-sum across the phase) goes through, so the over-served battery backs off by exactly what the under-served one takes on. Inert during load steps; only engages near steady state.

Mirrored on the C++/ESPHome side per the parity rule. New regression tests cover both the gate and the two-sided (grid-neutral) swap.

## Measured effect (CI steering-eval, seed-averaged across 31 scenarios)

| Metric | Base | Head | Δ |
|---|--:|--:|--:|
| **share_imbalance_w** | 157.7 | 63.7 | **−60%** ✅ |
| overshoot_max_w *(guardrail)* | 91.4 | 86.7 | **−5%** ✅ |
| overshoot_mean_w | 51.0 | 44.4 | −13% ✅ |
| settle_mean_s | 30.9 | 36.1 | +17% |
| grid_p2p_w *(guardrail)* | 191.0 | 203.1 | +6% ⚠️ |
| battery_travel_w_per_h | 19619 | 21414 | +9% |
| cost_regret_ct / grid_rms / mean_abs | ~flat | ~flat | +0–4% |

**Priority-weighted verdict: −1.4% (better)** — vs +3.2% worse with the gate alone (which tripped `overshoot_max_w +24%`). The grid-neutral swap turned the fix from a net regression into a net improvement: #523's imbalance is fixed (−60%, per-scenario −22% to −86%), overshoot now *improves*, and what remains is the inherent cost of equalizing two batteries (you have to move power between them): `battery_travel +9%`, `settle +17%`, and `grid_p2p_w +6%` (a smaller guardrail flag, traded down from the +24% overshoot one). All confined to multi-battery same-phase setups; single-battery scenarios are untouched.

This effectively restores 2.1.2-style balancing (what the reporter rolled back to and prefers) without 2.1.2's overshoot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved battery balancing so multiple batteries on the same phase stay more evenly split during steady-state charging and discharging.
  * Tightened near-zero correction behavior to avoid hiding real imbalances and reduce one-sided “sticking” in edge cases.
  * Made concentration behavior safer by applying it only when the battery pool is already balanced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->