### PR TITLE
Expose CT002/CT003 balancer tuning in the Home Assistant add-on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Added** the CT002/CT003 active-control and load-balancing tuning options to the Home Assistant add-on's Configuration tab (and the add-on output of the web config generator), so settings that were previously config-file only — ramp pacing (Ramp Pacing Base/Max Step), fair distribution and balance gain, grid prediction, oscillation damping, deadband concentration and steady-import trim — can be changed straight from the add-on UI. For example, raising the ramp-pacing steps (or setting the base step to 0) makes the batteries follow large load changes faster instead of in small steps.
+- **Added** the CT002/CT003 active-control and load-balancing tuning options to the Home Assistant add-on's Configuration tab (and the add-on output of the web config generator), so settings that were previously config-file only — ramp pacing (Ramp Pacing Base/Max Step), fair distribution and balance gain, grid prediction, oscillation damping, deadband concentration and steady-import trim — can be changed straight from the add-on UI. For example, raising the ramp-pacing steps (or setting the base step to 0) makes the batteries follow large load changes faster instead of in small steps ([#527](https://github.com/tomquist/astrameter/pull/527)).
 - **Fixed** uneven charging/discharging across multiple batteries sharing a phase (e.g. two Marstek Venus E3 where one sat at ~88 W while the other took ~890 W and never equalized), a regression in 2.2.0. The steady-state deadband optimization now steps aside whenever the batteries are actually out of balance, so they're pulled back to an even split instead of staying lopsided ([#523](https://github.com/tomquist/astrameter/issues/523), [#526](https://github.com/tomquist/astrameter/pull/526)).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- **Added** the CT002/CT003 active-control and load-balancing tuning options to the Home Assistant add-on's Configuration tab (and the add-on output of the web config generator), so settings that were previously config-file only — ramp pacing (Ramp Pacing Base/Max Step), fair distribution and balance gain, grid prediction, oscillation damping, deadband concentration and steady-import trim — can be changed straight from the add-on UI. For example, raising the ramp-pacing steps (or setting the base step to 0) makes the batteries follow large load changes faster instead of in small steps.
 - **Fixed** uneven charging/discharging across multiple batteries sharing a phase (e.g. two Marstek Venus E3 where one sat at ~88 W while the other took ~890 W and never equalized), a regression in 2.2.0. The steady-state deadband optimization now steps aside whenever the batteries are actually out of balance, so they're pulled back to an even split instead of staying lopsided ([#523](https://github.com/tomquist/astrameter/issues/523), [#526](https://github.com/tomquist/astrameter/pull/526)).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Added** the CT002/CT003 active-control and load-balancing tuning options to the Home Assistant add-on's Configuration tab (and the add-on output of the web config generator), so settings that were previously config-file only — ramp pacing (Ramp Pacing Base/Max Step), fair distribution and balance gain, grid prediction, oscillation damping, deadband concentration and steady-import trim — can be changed straight from the add-on UI. For example, raising the ramp-pacing steps (or setting the base step to 0) makes the batteries follow large load changes faster instead of in small steps ([#527](https://github.com/tomquist/astrameter/pull/527)).
+- **Added** the CT002/CT003 active-control and balancing tuning options (ramp pacing, fair distribution, grid prediction, oscillation damping, steady-import trim and more) to the Home Assistant add-on, so they can be changed from the add-on UI instead of a hand-edited config file ([#527](https://github.com/tomquist/astrameter/pull/527)).
 - **Fixed** uneven charging/discharging across multiple batteries sharing a phase (e.g. two Marstek Venus E3 where one sat at ~88 W while the other took ~890 W and never equalized), a regression in 2.2.0. The steady-state deadband optimization now steps aside whenever the batteries are actually out of balance, so they're pulled back to an even split instead of staying lopsided ([#523](https://github.com/tomquist/astrameter/issues/523), [#526](https://github.com/tomquist/astrameter/pull/526)).
 
 

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -63,6 +63,22 @@ schema:
   efficiency_rotation_interval: int(1,)?
   min_dc_output: float(0,)?
   grid_predict_trust: float(0,1)?
+  fair_distribution: bool?
+  balance_gain: float(0,1)?
+  balance_deadband: int(0,)?
+  max_correction_per_step: int(0,)?
+  error_boost_threshold: int(0,)?
+  error_boost_max: float(0,)?
+  error_reduce_threshold: int(0,)?
+  max_target_step: int(0,)?
+  pace_base_step: int(0,)?
+  pace_max_step: int(0,)?
+  osc_damp_max: float(0,1)?
+  osc_damp_alpha: float(0,1)?
+  osc_damp_decay: float(0,1)?
+  osc_damp_threshold: float(0,)?
+  concentrate_deadband: float(0,)?
+  import_trim_w: float(0,)?
   log_level: list(critical|error|warning|info|debug)
   power_offset: str?
   power_multiplier: str?

--- a/ha_addon/run.sh
+++ b/ha_addon/run.sh
@@ -122,6 +122,40 @@ else
         return 0
     }
 
+    # Emit the optional CT002/CT003 balancer / active-control tuning knobs (only
+    # the ones the user actually set) into the current [CT00x] section. Mirrors
+    # the "balancer" group of the web config editor; main.py reads each key from
+    # the section with a built-in default, so an unset option simply keeps that
+    # default. The trailing `return 0` guards `set -e` the same way
+    # emit_cloud_reporting does (see the note above).
+    emit_balancer_options() {
+        local pair opt key
+        for pair in \
+            "fair_distribution:FAIR_DISTRIBUTION" \
+            "balance_gain:BALANCE_GAIN" \
+            "balance_deadband:BALANCE_DEADBAND" \
+            "max_correction_per_step:MAX_CORRECTION_PER_STEP" \
+            "error_boost_threshold:ERROR_BOOST_THRESHOLD" \
+            "error_boost_max:ERROR_BOOST_MAX" \
+            "error_reduce_threshold:ERROR_REDUCE_THRESHOLD" \
+            "max_target_step:MAX_TARGET_STEP" \
+            "pace_base_step:PACE_BASE_STEP" \
+            "pace_max_step:PACE_MAX_STEP" \
+            "osc_damp_max:OSC_DAMP_MAX" \
+            "osc_damp_alpha:OSC_DAMP_ALPHA" \
+            "osc_damp_decay:OSC_DAMP_DECAY" \
+            "osc_damp_threshold:OSC_DAMP_THRESHOLD" \
+            "concentrate_deadband:CONCENTRATE_DEADBAND" \
+            "import_trim_w:IMPORT_TRIM_W"; do
+            opt="${pair%%:*}"
+            key="${pair##*:}"
+            if bashio::config.has_value "$opt"; then
+                echo "${key}=$(bashio::config "$opt")"
+            fi
+        done
+        return 0
+    }
+
     # Generate default config
     {
         echo "[GENERAL]"
@@ -140,6 +174,7 @@ else
             [ -n "$efficiency_rotation_interval" ] && echo "EFFICIENCY_ROTATION_INTERVAL=$efficiency_rotation_interval"
             [ -n "$min_dc_output" ] && echo "MIN_DC_OUTPUT=$min_dc_output"
             [ -n "$grid_predict_trust" ] && echo "GRID_PREDICT_TRUST=$grid_predict_trust"
+            emit_balancer_options
             emit_cloud_reporting
             echo ""
             echo "[CT003]"
@@ -149,6 +184,7 @@ else
             [ -n "$efficiency_rotation_interval" ] && echo "EFFICIENCY_ROTATION_INTERVAL=$efficiency_rotation_interval"
             [ -n "$min_dc_output" ] && echo "MIN_DC_OUTPUT=$min_dc_output"
             [ -n "$grid_predict_trust" ] && echo "GRID_PREDICT_TRUST=$grid_predict_trust"
+            emit_balancer_options
             emit_cloud_reporting
             echo ""
         else
@@ -159,6 +195,7 @@ else
             [ -n "$efficiency_rotation_interval" ] && echo "EFFICIENCY_ROTATION_INTERVAL=$efficiency_rotation_interval"
             [ -n "$min_dc_output" ] && echo "MIN_DC_OUTPUT=$min_dc_output"
             [ -n "$grid_predict_trust" ] && echo "GRID_PREDICT_TRUST=$grid_predict_trust"
+            emit_balancer_options
             emit_cloud_reporting
             echo ""
         fi

--- a/ha_addon/translations/en.yaml
+++ b/ha_addon/translations/en.yaml
@@ -41,6 +41,54 @@ configuration:
   grid_predict_trust:
     name: Grid Prediction
     description: "Keeps the grid closer to zero — less import, less export, less overshoot and hunting — by adapting automatically to your power meter, including meters that report with a delay (e.g. a Home Assistant push sensor). 0.5 (default) is recommended and needs no tuning; lower values react more cautiously and 0 turns the feature off (steer directly on the raw meter reading). Only applies to CT002/CT003 device types."
+  pace_base_step:
+    name: Ramp Pacing Base Step (W)
+    description: "Starting cap on how many watts each battery's command may change per poll. It grows toward the max step only while the battery is observed following the command, which keeps the firmware's accelerating ramp from overshooting when the meter reports with a delay. Lower = gentler, slower reaction to load steps; higher = faster, more like a plain CT002. Default 30; set 0 to turn pacing off entirely. Raise this (and the max step) if the batteries ramp too slowly in small steps and your meter is fast/low-latency. Only applies to CT002/CT003 device types."
+  pace_max_step:
+    name: Ramp Pacing Max Step (W)
+    description: "Ceiling the ramp-pacing cap grows toward once a battery is tracking the command. Higher lets large load changes be followed in fewer, bigger steps. Default 100 (roughly matches the firmware's own maximum ramp around 400–600 W when raised). Only used when the base step is above 0. Only applies to CT002/CT003 device types."
+  fair_distribution:
+    name: Fair Distribution
+    description: "Adjust each battery's target so multiple batteries share the load evenly. Only matters with two or more batteries. Enabled by default. Only applies to CT002/CT003 device types."
+  balance_gain:
+    name: Balance Gain
+    description: "How aggressively imbalance between batteries is corrected. 0 = equal split only (no correction); 0.3–0.5 = faster rebalancing but may overshoot. Default 0.2. Only applies to CT002/CT003 device types."
+  balance_deadband:
+    name: Balance Deadband (W)
+    description: "Ignore imbalance between batteries smaller than this many watts, to avoid micro-corrections. Kept above the battery firmware's own ~20 W input deadband so corrections it would ignore are never sent. Default 25. Only applies to CT002/CT003 device types."
+  max_correction_per_step:
+    name: Max Balance Correction Per Step (W)
+    description: "Cap on how many watts a single battery's target may deviate from its fair share in one cycle, limiting how fast rebalancing happens. Default 80. Only applies to CT002/CT003 device types."
+  error_boost_threshold:
+    name: Error Boost Threshold (W)
+    description: "When the imbalance between batteries exceeds this many watts, the balance gain is temporarily boosted to correct it faster. Default 150. Only applies to CT002/CT003 device types."
+  error_boost_max:
+    name: Error Boost Max
+    description: "Maximum extra balance-gain multiplier applied once imbalance is past the boost threshold (e.g. 0.5 = up to +50% gain). Default 0.5. Only applies to CT002/CT003 device types."
+  error_reduce_threshold:
+    name: Error Reduce Threshold (W)
+    description: "Below this much imbalance the balance gain is scaled down for gentler corrections as the batteries approach equilibrium. Default 20. Only applies to CT002/CT003 device types."
+  max_target_step:
+    name: Max Target Step (W)
+    description: "Hard clamp on how much a battery's target may change per cycle relative to its current output. 0 = disabled (default). This is separate from ramp pacing; leave at 0 unless you specifically want a fixed cap. Only applies to CT002/CT003 device types."
+  osc_damp_max:
+    name: Oscillation Damping
+    description: "Maximum reduction in correction strength while a battery is hunting (repeatedly reversing direction) under a laggy or delayed meter. Genuine load/solar steps stay at full speed. Default 0.95; set 0 to turn damping off. Only applies to CT002/CT003 device types."
+  osc_damp_alpha:
+    name: Oscillation Damping Ramp-up
+    description: "How quickly the hunting detector engages when a battery keeps reversing direction. Higher reacts sooner and damps more. Default 0.3. Only applies to CT002/CT003 device types."
+  osc_damp_decay:
+    name: Oscillation Damping Decay
+    description: "How quickly the hunting detector relaxes once a battery stops reversing direction. Default 0.05. Only applies to CT002/CT003 device types."
+  osc_damp_threshold:
+    name: Oscillation Damping Threshold (W)
+    description: "Corrections larger than this many watts are treated as a genuine demand step (kettle, solar ramp) and are never damped, so big load changes always react at full speed. Default 300. Only applies to CT002/CT003 device types."
+  concentrate_deadband:
+    name: Deadband Concentration (W)
+    description: "Multiple batteries only: when the grid is within this many watts of zero, hand the whole correction to a single battery instead of splitting it below each battery's ~20 W input deadband. Reduces small steady import/export (better self-consumption) at the cost of slightly more setpoint changes on that battery. Default 60; set 0 to turn off. Only applies to CT002/CT003 device types."
+  import_trim_w:
+    name: Steady-import Trim (W)
+    description: "Covers the few watts of real load the battery firmware leaves importing in steady state (its input deadband won't chase a small residual), recovering that self-consumption at the retail price. Only nudges once the grid has held steady for a few polls — never during a load step, so it adds no overshoot — and stays clear of a full/empty battery. Default 15; set 0 to turn off. Only applies to CT002/CT003 device types."
   marstek_auto_register_ct_device:
     name: Auto-register Managed CT Device (Marstek)
     description: "If enabled, the app signs in to your Marstek account at startup and ensures one managed fake CT device exists for each emulated CT type (ct002 -> HME-4, ct003 -> HME-3). Existing matching devices are reused to avoid duplicates."

--- a/web/ts/generate.test.ts
+++ b/web/ts/generate.test.ts
@@ -309,6 +309,14 @@ const haOpts = generateHomeAssistant({
       ACTIVE_CONTROL: "False",
       CLOUD_REPORTING: "True",
       CLOUD_REPORTING_INTERVAL: "30",
+      GRID_PREDICT_TRUST: "0.7",
+      FAIR_DISTRIBUTION: "False",
+      BALANCE_GAIN: "0.3",
+      PACE_BASE_STEP: "150",
+      PACE_MAX_STEP: "600",
+      OSC_DAMP_MAX: "0.5",
+      CONCENTRATE_DEADBAND: "0",
+      IMPORT_TRIM_W: "20",
     },
   },
 });
@@ -321,6 +329,14 @@ has(haOpts, "wait_for_next_message: false", "ha-opts: wait for next message");
 has(haOpts, "ct_mac: \"abc123\"", "ha-opts: ct mac");
 has(haOpts, "active_control: false", "ha-opts: active control off");
 has(haOpts, "min_dc_output: 30", "ha-opts: min dc output");
+has(haOpts, "grid_predict_trust: 0.7", "ha-opts: grid predict trust");
+has(haOpts, "fair_distribution: false", "ha-opts: fair distribution off");
+has(haOpts, "balance_gain: 0.3", "ha-opts: balance gain");
+has(haOpts, "pace_base_step: 150", "ha-opts: pace base step");
+has(haOpts, "pace_max_step: 600", "ha-opts: pace max step");
+has(haOpts, "osc_damp_max: 0.5", "ha-opts: oscillation damping");
+has(haOpts, "concentrate_deadband: 0", "ha-opts: concentrate deadband (explicit 0 kept)");
+has(haOpts, "import_trim_w: 20", "ha-opts: steady-import trim");
 has(haOpts, 'power_offset: "-20"', "ha-opts: power offset (quoted str)");
 has(haOpts, "smooth_target_alpha: 0.3", "ha-opts: smoothing alpha");
 has(haOpts, "deadband: 5", "ha-opts: deadband");
@@ -344,6 +360,10 @@ lacks(haMin, "pid_kp", "ha-opts: omits unset pid");
 lacks(haMin, "deadband", "ha-opts: omits unset deadband");
 lacks(haMin, "min_dc_output", "ha-opts: omits unset min dc output");
 lacks(haMin, "active_control", "ha-opts: omits default active control");
+lacks(haMin, "pace_base_step", "ha-opts: omits unset pace base step");
+lacks(haMin, "grid_predict_trust", "ha-opts: omits unset grid predict trust");
+lacks(haMin, "fair_distribution", "ha-opts: omits unset fair distribution");
+lacks(haMin, "import_trim_w", "ha-opts: omits unset import trim");
 
 // ── Home Assistant add-on options: calculate from in/out ─────────────────────
 const haCalc = generateHomeAssistant({

--- a/web/ts/generate.ts
+++ b/web/ts/generate.ts
@@ -667,6 +667,29 @@ export function generateHomeAssistant(state: State): string {
   add("min_efficient_power", ctf.MIN_EFFICIENT_POWER);
   add("efficiency_rotation_interval", ctf.EFFICIENCY_ROTATION_INTERVAL);
   add("min_dc_output", ctf.MIN_DC_OUTPUT);
+  // Balancer / active-control tuning (the "balancer" group). These map 1:1 to
+  // the add-on options of the same lower-cased name; only values the user set
+  // are emitted. Fair distribution is a tri-state select in the editor
+  // ("" = default on) but a plain bool add-on option, so only an explicit
+  // On/Off is emitted (like active_control above).
+  add("grid_predict_trust", ctf.GRID_PREDICT_TRUST);
+  if (ctf.FAIR_DISTRIBUTION === "True") add("fair_distribution", true);
+  else if (ctf.FAIR_DISTRIBUTION === "False") add("fair_distribution", false);
+  add("balance_gain", ctf.BALANCE_GAIN);
+  add("balance_deadband", ctf.BALANCE_DEADBAND);
+  add("max_correction_per_step", ctf.MAX_CORRECTION_PER_STEP);
+  add("error_boost_threshold", ctf.ERROR_BOOST_THRESHOLD);
+  add("error_boost_max", ctf.ERROR_BOOST_MAX);
+  add("error_reduce_threshold", ctf.ERROR_REDUCE_THRESHOLD);
+  add("max_target_step", ctf.MAX_TARGET_STEP);
+  add("pace_base_step", ctf.PACE_BASE_STEP);
+  add("pace_max_step", ctf.PACE_MAX_STEP);
+  add("osc_damp_max", ctf.OSC_DAMP_MAX);
+  add("osc_damp_alpha", ctf.OSC_DAMP_ALPHA);
+  add("osc_damp_decay", ctf.OSC_DAMP_DECAY);
+  add("osc_damp_threshold", ctf.OSC_DAMP_THRESHOLD);
+  add("concentrate_deadband", ctf.CONCENTRATE_DEADBAND);
+  add("import_trim_w", ctf.IMPORT_TRIM_W);
   // Opt-in cloud reporting. The toggle is a tri-state select ("" = default off);
   // the add-on option is a plain bool, so only an explicit On/Off is emitted.
   if (ctf.CLOUD_REPORTING === "True") add("cloud_reporting", true);


### PR DESCRIPTION
## Why

A user reported the batteries ramping slowly, in small ~100–200 W steps, where the original CT002 jumped in one go. That's the **ramp pacing** (`PACE_BASE_STEP` / `PACE_MAX_STEP`) of active control. The fix is to raise those caps (or set the base step to 0), but on the **Home Assistant add-on** there was no way to do that — the add-on surfaced only a small subset of the `[CT002]`/`[CT003]` options, so users had to drop to a hand-edited `config.ini` (`custom_config`).

These knobs were already:
- read by the Python loader (`main.py`, each with its own default), and
- offered by the web config editor (`web/ts/schema.ts` `CT_BALANCER` group).

Only the add-on surface (and the generator's add-on output) lagged behind.

## What this adds

The full **balancer / active-control** group to the add-on, matching the web editor:

`FAIR_DISTRIBUTION`, `BALANCE_GAIN`, `BALANCE_DEADBAND`, `MAX_CORRECTION_PER_STEP`, `ERROR_BOOST_THRESHOLD`, `ERROR_BOOST_MAX`, `ERROR_REDUCE_THRESHOLD`, `MAX_TARGET_STEP`, **`PACE_BASE_STEP`**, **`PACE_MAX_STEP`**, `OSC_DAMP_MAX`, `OSC_DAMP_ALPHA`, `OSC_DAMP_DECAY`, `OSC_DAMP_THRESHOLD`, `CONCENTRATE_DEADBAND`, `IMPORT_TRIM_W`.

Touched surfaces:
- **`ha_addon/config.yaml`** — schema entries (all optional, no defaults, like the existing `pid_*`/`hampel_*` knobs, so the default config stays clean).
- **`ha_addon/run.sh`** — a shared `emit_balancer_options` helper emits any set key into the generated `[CT00x]` section, called in all three CT blocks. Mirrors `emit_cloud_reporting`, including the `return 0` `set -e` guard from #510.
- **`ha_addon/translations/en.yaml`** — a name + description for each.
- **`web/ts/generate.ts`** — the Home Assistant generator target now emits these too, **including `grid_predict_trust`, which it was silently dropping** even though the add-on already accepted it.
- **`web/ts/generate.test.ts`** — assertions for emission + omission-when-unset.

No Python changes: `main.py` already reads every key with its own default, so an unset add-on option keeps that default. `cd web && npm run check` passes; `bash -n` and YAML parse clean.

## Still not exposed in the add-on (intentionally deferred — flagging for a decision)

The add-on still omits these `[CT002]`/`[CT003]` keys that the web editor offers. They're deeper internals less likely to be hand-tuned from the add-on UI, so I left them out to avoid bloating the flat options list — happy to add any/all if you'd prefer full parity:

- **CT identity / transport:** `UDP_PORT`, `WIFI_RSSI`, `CONSUMER_TTL` (`ct_mac` and `dedupe_time_window` are already exposed)
- **Efficiency rotation:** `PROBE_MIN_POWER`, `EFFICIENCY_FADE_ALPHA`, `EFFICIENCY_SATURATION_THRESHOLD`, `EFFICIENCY_DEMAND_ALPHA` (`min_efficient_power`, `efficiency_rotation_interval` are exposed)
- **Saturation detection:** `SATURATION_DETECTION`, `SATURATION_ALPHA`, `MIN_TARGET_FOR_SATURATION`, `SATURATION_GRACE_SECONDS`, `SATURATION_STALL_TIMEOUT_SECONDS`, `SATURATION_DECAY_FACTOR`

Draft because the scope cut above is a judgment call worth your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dJdKMtnajLoEuVByXKCDp

---
_Generated by [Claude Code](https://claude.ai/code/session_014dJdKMtnajLoEuVByXKCDp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new Home Assistant add-on UI settings for CT002/CT003 tuning, including balancing, pacing, dampening, deadband, and import-trim options.
  * These controls can now be adjusted from the UI instead of editing the config file.
  * Generated configurations now include the new options when set, while leaving unset values out of the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->