### PR TITLE
sim: add initial_power + full-battery freeze scenario for issue #522

### DIFF
--- a/src/astrameter/simulator/battery.py
+++ b/src/astrameter/simulator/battery.py
@@ -46,6 +46,7 @@ class BatterySimulator:
         max_dc_input: int = 0,
         dc_input_power: float = 0.0,
         participates: bool = True,
+        initial_power: float = 0.0,
     ) -> None:
         if phase not in protocol.PHASE_FIELD_INDEX:
             raise ValueError(
@@ -126,6 +127,25 @@ class BatterySimulator:
         self._venus_d_steering = (
             VenusDSteeringController() if self._is_venus_d else None
         )
+
+        # Optionally start already in motion (net output W; positive = discharge,
+        # negative = charge) instead of cold-starting from rest. The firmware
+        # input deadband holds a sub-deadband command only while a unit is at
+        # rest, so a from-rest-only model can't represent a system already
+        # running when a disturbance arrives. The relevant steering controller's
+        # setpoint is seeded so its ramp law holds the seeded output instead of
+        # winding back to zero on the first cycle.
+        if initial_power:
+            self._current_power = float(initial_power)
+            self._target_power = float(initial_power)
+            self._requested_target = float(initial_power)
+            if self._venus_d_steering is not None:
+                self._venus_d_steering.setpoint = round(initial_power)
+            elif not self._b2500_channels:
+                # Ramp controller: target = -setpoint, so seed the inverse. (The
+                # B2500's command-domain regulator converges from the seeded
+                # measured output, so it needs no explicit setpoint seed.)
+                self._steering.setpoint = -float(initial_power)
 
     # -- public read-only properties ---------------------------------------
 

--- a/src/astrameter/simulator/battery_test.py
+++ b/src/astrameter/simulator/battery_test.py
@@ -170,6 +170,25 @@ def test_cross_phase_dchrg_does_not_idle_battery() -> None:
     assert b.target_power == -500.0
 
 
+def test_initial_power_starts_in_motion() -> None:
+    """``initial_power`` seeds the output (and target) so the battery starts
+    already producing instead of from rest."""
+    b = _battery(initial_power=-300.0)  # already charging
+    assert b.current_power == -300.0
+    assert b.target_power == -300.0
+
+
+def test_initial_power_holds_under_balanced_grid() -> None:
+    """A seeded charging output is held by the firmware ramp on a balanced
+    grid — the steering setpoint is seeded too, so it doesn't wind back to 0 on
+    the first response (a sub-deadband command at non-zero output is held)."""
+    b = _battery(initial_power=-300.0)
+    # Balanced grid (0 W): the firmware deadband holds the setpoint, so the
+    # battery stays where it was seeded rather than collapsing to rest.
+    b._handle_ct_response(_response_fields(phase_targets=(0, 0, 0)))
+    assert b.target_power == -300.0
+
+
 def test_steering_deadband_uses_own_output() -> None:
     """A <20 W grid residual is ignored while the battery is idle, but acted
     on once its own output is above ~1 W (the firmware deadband condition)."""

--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -136,6 +136,10 @@ class BatterySpec:
     startup_delay: float = 2.0
     min_power_threshold: float = 5.0
     max_dc_input: int = 0
+    # Net output (W) already flowing at t=0 (positive = discharge, negative =
+    # charge). Default 0 cold-starts from rest; non-zero models a system already
+    # in motion, which the firmware input deadband treats differently from rest.
+    initial_power: float = 0.0
 
     @property
     def ac_chargeable(self) -> bool:
@@ -304,6 +308,7 @@ async def run_scenario(
             min_power_threshold=spec.min_power_threshold,
             startup_delay=spec.startup_delay,
             max_dc_input=spec.max_dc_input,
+            initial_power=spec.initial_power,
         )
         for i, spec in enumerate(scenario.batteries)
     ]
@@ -1527,6 +1532,63 @@ def build_scenarios() -> dict[str, Scenario]:
                 ct_kwargs=dict(kwargs),
             )
         )
+
+    # Issue #522: fair distribution, both units active, one FULL (cannot charge)
+    # on the PV-export phase while the healthy unit (on another phase) is already
+    # charging. Under a sustained surplus the balance correction pulls the
+    # healthy unit's command down toward an even split with the idle full unit,
+    # so part of its absorption falls inside the battery firmware's input
+    # deadband and is held — the healthy unit under-charges and the surplus is
+    # partly exported. The fix lets the full unit be recognised as saturated
+    # (dropping out of the share math) so the healthy unit keeps more of the
+    # command above the deadband and absorbs more. Ramp pacing's base step is
+    # below the saturation min-target (the reporter's pace_base_step <
+    # min_target_for_saturation), the condition under which the full unit's
+    # pinned command used to read as idle and never registered as saturated.
+    # The effect requires a unit already in motion (initial_power): the firmware
+    # deadband holds an in-motion sub-deadband command, where a cold start would
+    # instead just sit at rest, so without it the handoff dynamics differ and the
+    # fix shows no benefit.
+    add(
+        Scenario(
+            name="full_battery_low_pace",
+            description=(
+                "Fair distribution, both active: a full unit on the PV-export "
+                "phase + a healthy unit (already charging) on another phase, "
+                "sustained surplus; ramp-pace base step below the saturation "
+                "min-target (issue #522). The full unit must be detected "
+                "saturated so the healthy one keeps absorbing instead of having "
+                "part of its command held inside the firmware deadband"
+            ),
+            batteries=[
+                BatterySpec(
+                    device_type="VNSE3-0",
+                    phase="A",
+                    max_charge_power=0,  # full: cannot charge
+                    initial_soc=0.95,
+                ),
+                BatterySpec(
+                    device_type="VNSE3-0",
+                    phase="B",
+                    initial_soc=0.4,
+                    initial_power=-200.0,  # already charging when the run begins
+                ),
+            ],
+            duration_s=900.0,
+            base_load=[-250.0, 0.0, 0.0],  # ~250 W sustained PV surplus
+            build_events=lambda rng: [],
+            ct_kwargs={
+                "balance_gain": 0.40,
+                "balance_deadband": 30.0,
+                "max_correction_per_step": 150.0,
+                "pace_base_step": 30.0,
+                "pace_max_step": 200.0,
+                "min_target_for_saturation": 40.0,
+                "saturation_alpha": 0.9,
+            },
+            meter_latency_s=0.5,
+        )
+    )
 
     dur_mixed = 5400.0
     for mode, kwargs in (("fair", {}), ("eff", _EFF_MODE)):


### PR DESCRIPTION
Adds the simulator capability and steering scenario needed to reproduce issue #522 (saturation detection blinded by ramp pacing — the fix is #529). Standalone PR into `develop`.

## Why

The steering simulator could only **cold-start batteries from rest**, so it couldn't represent a system already in motion when a disturbance arrives — and that precondition is load-bearing for issue #522. The firmware input deadband holds an **in-motion** sub-deadband command, whereas a cold start just sits at rest, so the multi-battery handoff dynamics (and whether #529's fix helps) depend on it. Measured both ways at the same operating point:

- **cold-started**: the fix is neutral-to-slightly-worse (this is why the all-cold-start eval suite showed #522 as a no-op),
- **already in motion**: the fix clearly helps.

The reporter's healthy battery was already charging when the full one saturated, so the in-motion case is the realistic one.

## What

- **`initial_power`** on `BatterySimulator` / `BatterySpec` — net output (W) already flowing at t=0 (positive = discharge, negative = charge). The relevant steering controller's setpoint is seeded so the ramp law holds it instead of winding back to zero. Default `0.0` keeps every existing scenario cold-starting exactly as before.
- New steering scenario **`full_battery_low_pace`**: fair distribution, a full unit (can't charge) on the PV-export phase + a healthy unit *already charging* on another phase, sustained ~250 W surplus, ramp-pace base step below the saturation min-target (the issue #522 condition). On the **unfixed** balancer the healthy unit has part of its command held inside the firmware deadband and under-charges, so the surplus is partly exported.

## How this shows #529's fix

The steering-eval can only diff scenarios present on **both** base and head, so a newly-introduced scenario can't show a before/after in the PR that adds it. Once this PR merges to `develop`, #529 (rebased) compares `develop` (this scenario, no fix) vs `develop + fix`:

| metric (5-seed mean) | baseline (develop after this PR) | with #529 fix |
|---|---|---|
| grid_rms_w | 34.3 | **29.1** |
| mean_abs_grid_w | 22.7 | **14.5** |
| avoidable_export_wh | 5.7 | **3.6** |
| battery_travel_w_per_h | 32656 | 31900 |
| cost_regret_ct | 0.0 | 0.0 |

A clean, modest improvement with no metric regressing. (Modest because #526's deadband-concentration gating already covers most of the multi-battery handoff; the residual the saturation fix recovers is the part that falls inside the firmware deadband.) Verified locally; CI will display it on #529 after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvyVYm5tJWG6P2qP3DxJyB