### PR TITLE
Support active control for combined-mode (phase D) batteries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- **Fixed** Marstek batteries running in combined / whole-home mode (newer firmware, no per-phase assignment) missing all their per-battery Home Assistant entities — Distribution Weight, Manual/Auto Target, Active and Min DC Output never appeared, so per-battery balancing couldn't be controlled. These batteries are now recognized as a valid, actively-steered mode: their entities show up and fair distribution applies to them like any phase-assigned battery ([#536](https://github.com/tomquist/astrameter/discussions/536)).
 - **Fixed** the generated ESPHome config for HTTP-polled meters (notably the **Fronius Smart Meter**) not reading the grid, which left the battery uncontrolled until the config was hand-edited. It now works as generated ([#534](https://github.com/tomquist/astrameter/discussions/534), [#535](https://github.com/tomquist/astrameter/pull/535)).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** Marstek batteries running in combined / whole-home mode (newer firmware, no per-phase assignment) missing all their per-battery Home Assistant entities — Distribution Weight, Manual/Auto Target, Active and Min DC Output never appeared, so per-battery balancing couldn't be controlled. These batteries are now recognized as a valid, actively-steered mode: their entities show up and fair distribution applies to them like any phase-assigned battery ([#536](https://github.com/tomquist/astrameter/discussions/536)).
+- **Fixed** Marstek batteries running in combined / whole-home mode (newer firmware, no per-phase assignment) missing all their per-battery Home Assistant entities — Distribution Weight, Manual/Auto Target, Active and Min DC Output never appeared, so per-battery balancing couldn't be controlled. These batteries are now recognized as a valid, actively-steered mode: their entities show up and fair distribution applies to them like any phase-assigned battery ([#536](https://github.com/tomquist/astrameter/discussions/536), [#537](https://github.com/tomquist/astrameter/pull/537)).
 - **Fixed** the generated ESPHome config for HTTP-polled meters (notably the **Fronius Smart Meter**) not reading the grid, which left the battery uncontrolled until the config was hand-edited. It now works as generated ([#534](https://github.com/tomquist/astrameter/discussions/534), [#535](https://github.com/tomquist/astrameter/pull/535)).
 
 

--- a/docs/ct002-ct003-protocol.md
+++ b/docs/ct002-ct003-protocol.md
@@ -202,10 +202,14 @@ the transient state while a device is still detecting its phase (`phase_t = 0`).
 
 > The AstraMeter emulator mirrors this bucketing: `'0'`/unassigned reporters
 > aggregate into the `x_*` fields, phase‑`D` reporters into the `ABC_*` fields
-> and the `ABC_chrg_nb` count, and `A`/`B`/`C` into their own buckets. It does
-> not yet implement a combined (`ABC`) **control** mode, though: a phase‑`D`
-> battery is served the relay path (raw grid reading + aggregates) even when
-> active control is on, exactly as during inspection.
+> and the `ABC_chrg_nb` count, and `A`/`B`/`C` into their own buckets. A phase‑`D`
+> battery is a valid, **actively‑steered** operating mode: under active control it
+> receives a per‑consumer target in the summed grid field (field 7) with an
+> `ABC_chrg_nb` count of `1` (so it applies the target as‑is instead of dividing
+> by `N`), and its instructed net power aggregates into the `ABC_*` cross‑talk
+> fields — exactly like an `A`/`B`/`C` battery. Only `'0'`/unassigned reporters
+> (still detecting their phase) are treated as inspection and served the raw relay
+> path.
 
 ### CT003 energy fields (fields 25–28)
 

--- a/esphome/components/ct002/ct002.cpp
+++ b/esphome/components/ct002/ct002.cpp
@@ -252,7 +252,13 @@ void CT002Component::handle_request_(const uint8_t *data, size_t len,
     reported_phase.erase(reported_phase.begin());
   while (!reported_phase.empty() && std::isspace(static_cast<unsigned char>(reported_phase.back())))
     reported_phase.pop_back();
-  const bool in_inspection_mode = reported_phase != "A" && reported_phase != "B" && reported_phase != "C";
+  // Only an unassigned / diagnostic reporter is inspection mode ("0", empty,
+  // or any other unexpected marker). "A"/"B"/"C" are physical phases and "D"
+  // is combined / whole-home mode (newer Marstek firmware) — all four are
+  // valid, actively-steered phases, so they are NOT inspection. Mirrors
+  // ct002.py _handle_request.
+  const bool in_inspection_mode = reported_phase != "A" && reported_phase != "B" &&
+                                  reported_phase != "C" && reported_phase != "D";
   int reported_power = 0;
   if (fields.size() > 5) {
     // Match Python's parse_int (int()): reject trailing garbage / float
@@ -311,10 +317,19 @@ void CT002Component::handle_request_(const uint8_t *data, size_t len,
 
   if (!in_inspection_mode) {
     auto &consumer = this->get_consumer_(consumer_id);
-    size_t phase_idx = 0;
-    if (consumer.phase == "B") phase_idx = 1;
-    else if (consumer.phase == "C") phase_idx = 2;
-    consumer.last_instructed_power = reported_power + values[phase_idx];
+    float delta;
+    if (consumer.phase == "D") {
+      // Combined / whole-home mode: the battery reads the summed grid field
+      // (field 7 == sum of the per-phase values), so its net is the reported
+      // power plus the whole target, not a single phase.
+      delta = values[0] + values[1] + values[2];
+    } else {
+      size_t phase_idx = 0;
+      if (consumer.phase == "B") phase_idx = 1;
+      else if (consumer.phase == "C") phase_idx = 2;
+      delta = values[phase_idx];
+    }
+    consumer.last_instructed_power = reported_power + delta;
   }
 
   auto response_fields = this->build_response_fields_(fields, values);
@@ -507,10 +522,10 @@ CT002Component::PhaseReports CT002Component::collect_reports_by_phase_() const {
     // divides the forwarded aggregate by it to take its 1/N share).
     out.count[idx] += 1;
     float power;
-    if (this->active_control_ && idx >= BUCKET_A && idx <= BUCKET_C) {
+    if (this->active_control_ && idx >= BUCKET_A && idx <= BUCKET_ABC) {
       // Active control: aggregate the net power we *instructed* this
-      // consumer to be at, so PV passthrough doesn't masquerade as
-      // discharge (issue #376).
+      // consumer to be at (A/B/C plus combined "D"/ABC), so PV passthrough
+      // doesn't masquerade as discharge (issue #376).
       power = static_cast<float>(round_half_even(c.last_instructed_power));
       // With ramp pacing the per-poll delta is capped, so the instructed
       // net power can keep the sign of the battery's involuntary output
@@ -524,7 +539,7 @@ CT002Component::PhaseReports CT002Component::collect_reports_by_phase_() const {
       }
     } else {
       // Relay mode forwards each battery's *reported* power, exactly like
-      // the real CT (issue #457). x/ABC consumers are never actively
+      // the real CT (issue #457). x (inspection) consumers are never actively
       // instructed, so their reported power is the only truthful signal in
       // either mode.
       power = static_cast<float>(round_half_even(static_cast<double>(c.power)));
@@ -663,10 +678,28 @@ std::vector<std::string> CT002Component::build_response_fields_(
   // no x count field.
   fields[14] = to_int_str(phase_reports.chrg_power[BUCKET_X]);
   fields[19] = to_int_str(phase_reports.dchrg_power[BUCKET_X]);
-  // ABC (combined, phase "D") bucket. Combined-mode consumers are never
-  // actively instructed (the emulator has no combined control mode), so they
-  // are effectively relayed in both modes: forward the real count.
-  fields[11] = std::to_string(phase_reports.count[BUCKET_ABC]);
+  // ABC (combined, phase "D") bucket. A combined-mode battery reads the summed
+  // grid field (field 7, `total`) and divides it by this count. Under active
+  // control we deliver a per-consumer target in that summed field, so report a
+  // count of 1 when a combined battery is being instructed (like the per-phase
+  // branch above) so it applies its individual target as-is instead of
+  // under-responding by a factor of N (issue #459); relay mode forwards the real
+  // count for the 1/N share. The `total` guard is scoped to a phase-"D"
+  // requester: a per-phase target also sums into that field, so an unscoped
+  // check would spuriously set the ABC count on phase-A/B/C responses.
+  std::string reported_phase = request_fields.size() > 4 ? request_fields[4] : "";
+  while (!reported_phase.empty() && std::isspace(static_cast<unsigned char>(reported_phase.front())))
+    reported_phase.erase(reported_phase.begin());
+  while (!reported_phase.empty() && std::isspace(static_cast<unsigned char>(reported_phase.back())))
+    reported_phase.pop_back();
+  for (auto &c : reported_phase) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+  if (this->active_control_) {
+    if (phase_reports.active[BUCKET_ABC] || (reported_phase == "D" && total != 0.0f)) {
+      fields[11] = "1";
+    }
+  } else {
+    fields[11] = std::to_string(phase_reports.count[BUCKET_ABC]);
+  }
   fields[18] = to_int_str(phase_reports.chrg_power[BUCKET_ABC]);
   fields[23] = to_int_str(phase_reports.dchrg_power[BUCKET_ABC]);
 

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -656,7 +656,7 @@ class CT002:
             # battery count — each battery divides the forwarded aggregate by it
             # to take its 1/N share.
             by_phase[bucket]["count"] += 1
-            if self.active_control and bucket in ("A", "B", "C"):
+            if self.active_control and bucket in ("A", "B", "C", "ABC"):
                 # Active control: use the net AC power we *instructed* this
                 # consumer to be at (its reported output plus the delta in the
                 # last response), not what it physically reported.  A battery
@@ -678,10 +678,9 @@ class CT002:
                     power = 0
             else:
                 # Relay mode forwards each battery's *reported* power, exactly
-                # like the real CT (issue #457).  x/ABC consumers are never
-                # actively instructed (the emulator has no combined control
-                # mode and gives no instruction during inspection), so their
-                # reported power is the only truthful signal in either mode.
+                # like the real CT (issue #457).  x (inspection) consumers are
+                # never actively instructed, so their reported power is the only
+                # truthful signal in either mode.
                 power = consumer.power
             if power == 0:
                 continue
@@ -839,12 +838,28 @@ class CT002:
         # carries no x count field.
         response_fields[14] = str(phase_values["x"]["chrg_power"])
         response_fields[19] = str(phase_values["x"]["dchrg_power"])
-        # ABC (combined, phase "D") bucket.  Combined-mode consumers are never
-        # actively instructed (the emulator has no combined control mode), so
-        # they are effectively relayed in both modes: forward the real count.
-        response_fields[11] = str(phase_values["ABC"]["count"])
-        response_fields[18] = str(phase_values["ABC"]["chrg_power"])
-        response_fields[23] = str(phase_values["ABC"]["dchrg_power"])
+        # ABC (combined, phase "D") bucket.  A combined-mode battery reads the
+        # summed grid field (field 7, ``measured_total_power``) and divides it
+        # by this count.  Under active control we deliver a per-consumer target
+        # in that summed field, so report a count of 1 when a combined battery
+        # is being instructed (like the per-phase branch above) so it applies
+        # its individual target as-is instead of under-responding by a factor of
+        # N (issue #459); relay mode forwards the real count so each combined
+        # battery takes its 1/N share.  The ``measured_total_power`` guard is
+        # scoped to a phase-"D" requester: a per-phase target also sums into
+        # that field, so an unscoped check would spuriously set the ABC count on
+        # phase-A/B/C responses (where the battery ignores it anyway).
+        reported_phase = (
+            (request_fields[4] if len(request_fields) > 4 else "").strip().upper()
+        )
+        abc = phase_values["ABC"]
+        if self.active_control:
+            if abc["active"] or (reported_phase == "D" and measured_total_power != 0):
+                response_fields[11] = "1"
+        else:
+            response_fields[11] = str(abc["count"])
+        response_fields[18] = str(abc["chrg_power"])
+        response_fields[23] = str(abc["dchrg_power"])
 
         response_fields += ["0"] * (len(RESPONSE_LABELS) - len(response_fields))
         self._info_idx_counter = (self._info_idx_counter + 1) % 256
@@ -942,11 +957,13 @@ class CT002:
         participate_raw = fields[6].strip() if len(fields) > 6 else ""
         participates = participate_raw == "" or parse_int(participate_raw, 1) != 0
 
-        # Anything other than A/B/C is treated as inspection mode. Observed
-        # inspection markers in real traffic include "0", empty, and "D"
-        # (newer Marstek battery firmwares); accept any other value too so
-        # future markers don't break phase detection.
-        in_inspection_mode = reported_phase not in ("A", "B", "C")
+        # Only an unassigned / diagnostic reporter is in inspection mode: "0",
+        # empty, or any other unexpected marker.  "A"/"B"/"C" are the physical
+        # phases and "D" is combined / whole-home mode (newer Marstek firmware)
+        # — all four are valid, actively-steered operating phases, so they are
+        # NOT inspection.  Accept any other value as inspection so a future
+        # marker doesn't get mistaken for a real phase.
+        in_inspection_mode = reported_phase not in ("A", "B", "C", "D")
         if in_inspection_mode:
             logger.debug(
                 "CT002 request from %s in inspection mode (phase=%r)",
@@ -1041,8 +1058,15 @@ class CT002:
         # into the x bucket from ``consumer.power`` instead.
         if not in_inspection_mode:
             consumer = self._get_consumer(consumer_id)
-            phase_idx = {"A": 0, "B": 1, "C": 2}.get(consumer.phase.upper(), 0)
-            consumer.last_instructed_power = float(reported_power + values[phase_idx])
+            if consumer.phase.upper() == "D":
+                # Combined / whole-home mode: the battery reads the summed grid
+                # field (field 7 == sum of the per-phase values), so its net is
+                # the reported power plus the whole target, not a single phase.
+                delta = sum(values)
+            else:
+                phase_idx = {"A": 0, "B": 1, "C": 2}.get(consumer.phase.upper(), 0)
+                delta = values[phase_idx]
+            consumer.last_instructed_power = float(reported_power + delta)
 
         try:
             response_fields = self._build_response_fields(fields, values)

--- a/tests/test_ct002_protocol.py
+++ b/tests/test_ct002_protocol.py
@@ -372,6 +372,38 @@ async def test_handle_request_records_net_instructed_power_not_delta():
     )
 
 
+async def test_combined_mode_records_net_from_summed_grid_field():
+    """A combined-mode (phase 'D') battery reads the *summed* grid field
+    (field 7), so its net instructed power is the reported output plus the
+    whole target — not just the phase-A slot.  Feeding a target spread across
+    phases proves the sum is used: 300 reported + (200+300) = 800, not 500."""
+    device = CT002(ct_mac="112233445566", active_control=False)
+    await _drive_request(
+        device,
+        battery_mac="AABBCCDDEEFF",
+        phase="D",
+        reported_power=300,
+        delta_values=[200, 300, 0],
+    )
+    consumer = device._consumers["aabbccddeeff"]
+    assert consumer.last_instructed_power == 800.0
+
+
+async def test_event_listener_fires_for_combined_mode_not_inspection():
+    """HA discovery/state is driven by the consumer event listener, which must
+    fire for a combined-mode ('D') battery — a valid, steered phase — but stay
+    silent for a true inspection ('0') poll (still discovering its phase)."""
+    device = CT002(ct_mac="112233445566", active_control=False)
+    fired: list[str] = []
+    device.event_listener = lambda _dev, cid, _data: fired.append(cid)
+
+    await _drive_request(device, "AABBCCDDEEFF", "D", 300, [0, 0, 0])
+    await _drive_request(device, "BBCCDDEEFFAA", "0", 0, [0, 0, 0])
+
+    assert "aabbccddeeff" in fired  # combined mode → discovery fires
+    assert "bbccddeeffaa" not in fired  # inspection → suppressed
+
+
 async def test_handle_request_pv_passthrough_net_target_and_relay_buckets():
     """Venus scenario from issue #376 driven in relay mode: reports +500
     (passthrough), the relayed grid delta is -500 → the *expected* net target
@@ -622,22 +654,53 @@ async def test_combined_phase_d_reporter_lands_in_abc_bucket():
     assert response[8] == "0"  # A_chrg_nb
 
 
-def test_active_control_x_abc_buckets_use_reported_power():
-    """Even under active control, x/ABC consumers are never instructed, so
-    their buckets carry the reported power while A/B/C keep aggregating the
-    net instructed power (issue #376 behavior preserved)."""
+def test_active_control_abc_bucket_uses_instructed_power():
+    """Under active control a combined-mode (phase 'D') battery is steered like
+    any A/B/C battery, so its ABC bucket aggregates the *instructed* net power
+    (issue #376), not the raw reported passthrough.  A true inspection ('0')
+    reporter is never instructed, so the x bucket still carries reported power."""
     device = CT002(active_control=True)
     # Phase-A battery: reported +500 passthrough, instructed net -500.
     device._update_consumer_report("venus-a", phase="A", power=500)
     device._consumers["venus-a"].last_instructed_power = -500.0
-    # Combined-mode battery: reports -300, never instructed.
-    device._update_consumer_report("venus-d", phase="D", power=-300)
+    # Combined-mode battery: reported +300 passthrough, instructed net -300.
+    device._update_consumer_report("venus-d", phase="D", power=300)
+    device._consumers["venus-d"].last_instructed_power = -300.0
+    # Inspection reporter: never instructed, reported -200 stays in the x bucket.
+    device._update_consumer_report("ins-x", phase="0", power=-200)
 
     by_phase = device._collect_reports_by_phase()
     assert by_phase["A"]["chrg_power"] == -500  # instructed net
     assert by_phase["A"]["dchrg_power"] == 0
-    assert by_phase["ABC"]["chrg_power"] == -300  # reported
+    assert by_phase["ABC"]["chrg_power"] == -300  # instructed net, not reported
     assert by_phase["ABC"]["count"] == 1
+    assert by_phase["x"]["chrg_power"] == -200  # reported (never instructed)
+
+
+def test_active_control_combined_mode_response_reports_count_one():
+    """Under active control the ABC (combined 'D') count field must be 1 so a
+    combined battery applies its individual target as-is instead of dividing by
+    N — mirroring the per-phase active-control count (issue #459)."""
+    device = CT002(active_control=True)
+    device._update_consumer_report("venus-d", phase="D", power=0)
+    device._consumers["venus-d"].last_instructed_power = -400.0
+    response = device._build_response_fields(
+        ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "D", "0"], [-400, 0, 0]
+    )
+    assert response[11] == "1"  # ABC_chrg_nb = 1 (not the real battery count)
+    assert response[18] == "-400"  # ABC_chrg_power = instructed net
+
+
+def test_relay_mode_combined_count_is_real_battery_count():
+    """Relay mode forwards the real combined-battery count so each battery takes
+    its 1/N share — the contrast with active control's count of 1."""
+    device = CT002(active_control=False)
+    device._update_consumer_report("venus-d1", phase="D", power=100)
+    device._update_consumer_report("venus-d2", phase="D", power=100)
+    response = device._build_response_fields(
+        ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "D", "0"], [0, 0, 0]
+    )
+    assert response[11] == "2"  # ABC count = real battery count in relay mode
 
 
 def test_ct002_logs_phase_detection_for_combined_mode(caplog):


### PR DESCRIPTION
## Summary

Extends active control to combined-mode (phase "D") batteries, which represent newer Marstek firmware running in whole-home mode without per-phase assignment. Previously, phase-D batteries were incorrectly treated as inspection-mode reporters and served only the relay path; now they are recognized as valid, actively-steered operating phases alongside A/B/C.

## Key Changes

- **Phase detection**: Updated inspection-mode logic to exclude "D" from inspection classification — only "0", empty, or unexpected markers are inspection; A/B/C/D are all valid operating phases
- **Instructed power calculation**: Combined-mode batteries read the summed grid field (field 7), so their net instructed power is `reported_power + sum(values)` rather than `reported_power + values[phase_idx]`
- **Active control response**: Under active control, the ABC bucket count is set to 1 when a combined battery is being instructed (matching per-phase behavior), so it applies its individual target as-is instead of dividing by N; relay mode forwards the real battery count for 1/N sharing
- **Power aggregation**: Combined-mode batteries now aggregate their instructed net power into ABC cross-talk fields under active control (not reported passthrough), preserving issue #376 behavior
- **Event listener**: Consumer event listener now fires for combined-mode batteries (valid steered phase) but remains silent for inspection reporters (still discovering their phase)
- **Python ↔ C++ parity**: Mirrored all changes in both `src/astrameter/ct002/ct002.py` and `esphome/components/ct002/ct002.cpp`
- **Documentation**: Updated protocol docs to clarify that phase-D is an actively-steered mode, not inspection

## Implementation Details

The key insight is that a combined-mode battery reads field 7 (the summed grid power across all phases) and divides it by the ABC count to determine its share. Under active control, we now deliver a per-consumer target in that summed field with count=1, so each battery applies its full target. In relay mode, the real count is forwarded so each battery takes its 1/N share of the aggregate.

The ABC count logic includes a guard scoped to phase-"D" requesters to avoid spuriously setting count=1 on per-phase responses (where the battery ignores it anyway).

Fixes issue #459 (missing Home Assistant entities for combined-mode batteries).

https://claude.ai/code/session_01V7hfUMC69s8KXiDdRMmi2D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Combined/whole-home battery mode is now recognized as an active operating mode, allowing its entities to appear and behave correctly.
  * Response handling now reflects combined-mode control more accurately for active balancing.

* **Bug Fixes**
  * Fixed combined-mode batteries being treated like inspection-only devices.
  * Corrected power tracking and response counts so combined-mode results are consistent in both active-control and relay-style operation.

* **Tests**
  * Added coverage for combined-mode power tracking, event handling, and bucket/count behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->