### PR TITLE
Coalesce concurrent polls to prevent burst responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Fixed** the CT002/CT003 emulator sending a battery several control commands in quick succession — instead of a single one — whenever a reading was delayed (with `WAIT_FOR_NEXT_MESSAGE` enabled, a throttled meter via `THROTTLE_INTERVAL`, or any slow power source). Because each command nudges the battery relative to its current output, the burst could push it well past the intended setpoint. Batteries polling during a delayed reading now get exactly one command per reading.
+
 
 ## 2.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** the CT002/CT003 emulator sending a battery several control commands in quick succession — instead of a single one — whenever a reading was delayed (with `WAIT_FOR_NEXT_MESSAGE` enabled, a throttled meter via `THROTTLE_INTERVAL`, or any slow power source). Because each command nudges the battery relative to its current output, the burst could push it well past the intended setpoint. Batteries polling during a delayed reading now get exactly one command per reading.
+- **Fixed** the CT002/CT003 and Shelly Pro 3EM emulators answering a battery several times in quick succession — instead of once — whenever a reading was delayed (with `WAIT_FOR_NEXT_MESSAGE` enabled, a throttled meter via `THROTTLE_INTERVAL`, or any slow power source). The battery acts on each reply relative to its current output, so the burst fed it the same stale correction repeatedly and could push it well past the intended setpoint. Batteries polling during a delayed reading now get exactly one reply per reading.
 
 
 ## 2.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** the CT002/CT003 and Shelly Pro 3EM emulators answering a battery several times in quick succession — instead of once — whenever a reading was delayed (with `WAIT_FOR_NEXT_MESSAGE` enabled, a throttled meter via `THROTTLE_INTERVAL`, or any slow power source). The battery acts on each reply relative to its current output, so the burst fed it the same stale correction repeatedly and could push it well past the intended setpoint. Batteries polling during a delayed reading now get exactly one reply per reading.
+- **Fixed** the CT002/CT003 and Shelly Pro 3EM emulators answering a battery several times in quick succession — instead of once — whenever a reading was delayed (with `WAIT_FOR_NEXT_MESSAGE` enabled, a throttled meter via `THROTTLE_INTERVAL`, or any slow power source). The battery acts on each reply relative to its current output, so the burst fed it the same stale correction repeatedly and could push it well past the intended setpoint. Batteries polling during a delayed reading now get exactly one reply per reading ([#542](https://github.com/tomquist/astrameter/pull/542)).
 
 
 ## 2.2.3

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -249,6 +249,15 @@ class CT002:
         # onto the fresh Consumer when the battery returns — see _get_consumer
         # and _snapshot_override.
         self._consumer_overrides: dict[str, ConsumerOverride] = {}
+        # Consumers with a request handler currently parked between the meter
+        # read (``before_send``) and its response.  The battery keeps polling
+        # (~1/s) while ``WAIT_FOR_NEXT_MESSAGE`` — or a slow/throttled meter —
+        # holds that read, and each datagram spawns its own handler task, so
+        # without coalescing every parked handler would wake on the same fresh
+        # reading and fire a response, dumping a burst of deltas onto the
+        # battery.  A single in-flight handler per consumer emits the one
+        # response for the next reading; duplicate polls are dropped.
+        self._inflight_consumers: set[str] = set()
         self._info_idx_counter = 0
         # Use wall-clock (time.time) so the dedup shares a timebase with
         # _cleanup_consumers' purge; RequestDeduplicator would otherwise
@@ -1008,137 +1017,168 @@ class CT002:
             participates=participates,
         )
 
-        updated, meter_failed = await self._call_before_send(addr, fields, consumer_id)
-        if updated is not None:
-            self.set_consumer_value(consumer_id, updated)
-
-        if meter_failed:
-            # Powermeter unavailable: do NOT re-drive control from the stale
-            # cached reading.  The CT002 instruction is a delta
-            # (``new_target = current_power + grid_field``), so re-issuing a
-            # delta derived from a frozen reading winds the battery up in
-            # active control, and feeds frozen per-phase values into a phase
-            # self-diagnosis in inspection mode (issue #403).  Send a zero
-            # adjustment instead so each battery holds its current output —
-            # matching the ESPHome component, which uses ``[0, 0, 0]`` when
-            # its sensor ages out (see esphome/components/ct002/ct002.cpp).
-            values = [0, 0, 0]
-        else:
-            values = self._get_consumer_value(consumer_id)
-            if values is None:
-                values = [0, 0, 0]
-        raw_values = ([*list(values), 0, 0, 0])[:3]
-        meter_value = sum(parse_int(v, 0) for v in raw_values)
-        is_active = self.is_consumer_active(consumer_id)
-        # On a meter failure the ``[0, 0, 0]`` above is a *sentinel*, not a real
-        # reading: run active control only when the meter is healthy.  Feeding
-        # the sentinel through the balancer would let the stateful controller
-        # (the grid-state predictor, saturation EMA, ...) treat a fabricated
-        # zero grid as a fresh sample and emit a non-zero delta from its
-        # internal state — exactly the wind-up issue #403 guards against — so
-        # the battery must instead hold on the literal zero adjustment.
-        if self.active_control and not in_inspection_mode and not meter_failed:
-            values = self._compute_smooth_target(values, consumer_id)
-        values = ([*list(values), 0, 0, 0])[:3]
-
-        # Record the *net* power we expect this battery to be at after
-        # applying the instruction (its reported output plus the delta we
-        # deliver — the battery's firmware computes
-        # ``new_target = current_power + grid_reading_field``).  In active
-        # control the cross-talk *_chrg_power / *_dchrg_power fields convey
-        # this net power per phase so other batteries can see who is actively
-        # charging/discharging cells; storing only the delta would lose
-        # the steady-state signal and flip signs on small corrections
-        # (issue #376).  In relay mode the buckets forward the *reported*
-        # power instead, like the real CT (issue #457) — this value is then
-        # only a diagnostic.  Skip during inspection mode: there is no
-        # instruction to record (we send raw meter readings as information,
-        # not a target; the battery is running its phase-discovery routine,
-        # not our integral controller); its reported power is aggregated
-        # into the x bucket from ``consumer.power`` instead.
-        if not in_inspection_mode:
-            consumer = self._get_consumer(consumer_id)
-            if consumer.phase.upper() == "D":
-                # Combined / whole-home mode: the battery reads the summed grid
-                # field (field 7 == sum of the per-phase values), so its net is
-                # the reported power plus the whole target, not a single phase.
-                delta = sum(values)
-            else:
-                phase_idx = {"A": 0, "B": 1, "C": 2}.get(consumer.phase.upper(), 0)
-                delta = values[phase_idx]
-            consumer.last_instructed_power = float(reported_power + delta)
-
-        try:
-            response_fields = self._build_response_fields(fields, values)
-            response = build_payload(response_fields)
-        except Exception as exc:
-            logger.warning(
-                "Failed to build CT002 response for %s (%s): %s",
+        # Coalesce concurrent polls from the same battery.  If a handler for
+        # this consumer is already parked awaiting the next meter reading, the
+        # instruction (a delta the firmware *adds* to its output) has not been
+        # sent yet — letting this duplicate poll wait and respond too would put
+        # multiple deltas on the wire milliseconds apart the moment the meter
+        # updates and wakes every parked handler, winding the battery up by N
+        # times the intended correction and stepping the stateful balancer N
+        # times per real sample.  Drop it; the report update above already
+        # refreshed the per-consumer state, and the in-flight handler emits the
+        # one response.
+        if consumer_id in self._inflight_consumers:
+            logger.debug(
+                "Coalescing CT002 poll from %s (consumer=%s): a handler is "
+                "already awaiting the next meter reading; dropping this "
+                "duplicate to avoid a burst of deltas",
                 addr,
-                fields,
-                exc,
-                exc_info=True,
+                consumer_id,
             )
             return
-        logger.debug(
-            "CT002 response to %s: %s (fields=%s)",
-            addr,
-            response.hex(),
-            response_fields,
-        )
-        if self.debug_status:
-            phase_values = self._collect_reports_by_phase()
-            logger.info(
-                "CT002 status: %s",
-                self._format_status(values, phase_values, consumer_id, meter_value),
+        self._inflight_consumers.add(consumer_id)
+        try:
+            updated, meter_failed = await self._call_before_send(
+                addr, fields, consumer_id
             )
-        transport.sendto(response, addr)
+            if updated is not None:
+                self.set_consumer_value(consumer_id, updated)
 
-        # Fire event listener after response is sent
-        if not in_inspection_mode:
-            consumer = self._consumers.get(consumer_id)
-            self._call_event_listener(
-                consumer_id,
-                {
-                    "grid_power": {
-                        "l1": float(raw_values[0]),
-                        "l2": float(raw_values[1]),
-                        "l3": float(raw_values[2]),
-                        "total": sum(float(v) for v in raw_values),
-                    },
-                    "target": {
-                        "l1": float(values[0]),
-                        "l2": float(values[1]),
-                        "l3": float(values[2]),
-                    },
-                    "phase": consumer.phase if consumer else reported_phase,
-                    "reported_power": reported_power,
-                    "device_type": consumer.device_type if consumer else "",
-                    "battery_ip": addr[0],
-                    "ct_type": fields[2] if len(fields) > 2 else "",
-                    "ct_mac": fields[3] if len(fields) > 3 else "",
-                    "saturation": self._balancer.get_saturation(consumer_id),
-                    "last_target": self._balancer.get_last_target(consumer_id),
-                    "active": is_active,
-                    "poll_interval": consumer.poll_interval if consumer else None,
-                    "last_seen": datetime.now(timezone.utc).isoformat(),
-                    "smooth_target": self._last_smooth_target,
-                    "manual_target": consumer.manual_target if consumer else None,
-                    "auto_target": not consumer.manual_enabled if consumer else True,
-                    "distribution_weight": (
-                        consumer.distribution_weight if consumer else 1.0
-                    ),
-                    "efficiency_window_weight": (
-                        consumer.efficiency_window_weight if consumer else 1.0
-                    ),
-                    "min_dc_output": consumer.min_dc_output if consumer else None,
-                    "active_control": self.active_control,
-                    "efficiency_rotation": self._balancer.efficiency_rotation_enabled,
-                    "consumer_count": sum(
-                        1 for c in self._consumers.values() if c.timestamp > 0
-                    ),
-                },
+            if meter_failed:
+                # Powermeter unavailable: do NOT re-drive control from the stale
+                # cached reading.  The CT002 instruction is a delta
+                # (``new_target = current_power + grid_field``), so re-issuing a
+                # delta derived from a frozen reading winds the battery up in
+                # active control, and feeds frozen per-phase values into a phase
+                # self-diagnosis in inspection mode (issue #403).  Send a zero
+                # adjustment instead so each battery holds its current output —
+                # matching the ESPHome component, which uses ``[0, 0, 0]`` when
+                # its sensor ages out (see esphome/components/ct002/ct002.cpp).
+                values = [0, 0, 0]
+            else:
+                values = self._get_consumer_value(consumer_id)
+                if values is None:
+                    values = [0, 0, 0]
+            raw_values = ([*list(values), 0, 0, 0])[:3]
+            meter_value = sum(parse_int(v, 0) for v in raw_values)
+            is_active = self.is_consumer_active(consumer_id)
+            # On a meter failure the ``[0, 0, 0]`` above is a *sentinel*, not a
+            # real reading: run active control only when the meter is healthy.
+            # Feeding the sentinel through the balancer would let the stateful
+            # controller (the grid-state predictor, saturation EMA, ...) treat a
+            # fabricated zero grid as a fresh sample and emit a non-zero delta
+            # from its internal state — exactly the wind-up issue #403 guards
+            # against — so the battery must instead hold on the literal zero
+            # adjustment.
+            if self.active_control and not in_inspection_mode and not meter_failed:
+                values = self._compute_smooth_target(values, consumer_id)
+            values = ([*list(values), 0, 0, 0])[:3]
+
+            # Record the *net* power we expect this battery to be at after
+            # applying the instruction (its reported output plus the delta we
+            # deliver — the battery's firmware computes
+            # ``new_target = current_power + grid_reading_field``).  In active
+            # control the cross-talk *_chrg_power / *_dchrg_power fields convey
+            # this net power per phase so other batteries can see who is actively
+            # charging/discharging cells; storing only the delta would lose
+            # the steady-state signal and flip signs on small corrections
+            # (issue #376).  In relay mode the buckets forward the *reported*
+            # power instead, like the real CT (issue #457) — this value is then
+            # only a diagnostic.  Skip during inspection mode: there is no
+            # instruction to record (we send raw meter readings as information,
+            # not a target; the battery is running its phase-discovery routine,
+            # not our integral controller); its reported power is aggregated
+            # into the x bucket from ``consumer.power`` instead.
+            if not in_inspection_mode:
+                consumer = self._get_consumer(consumer_id)
+                if consumer.phase.upper() == "D":
+                    # Combined / whole-home mode: the battery reads the summed
+                    # grid field (field 7 == sum of the per-phase values), so its
+                    # net is the reported power plus the whole target, not a
+                    # single phase.
+                    delta = sum(values)
+                else:
+                    phase_idx = {"A": 0, "B": 1, "C": 2}.get(consumer.phase.upper(), 0)
+                    delta = values[phase_idx]
+                consumer.last_instructed_power = float(reported_power + delta)
+
+            try:
+                response_fields = self._build_response_fields(fields, values)
+                response = build_payload(response_fields)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to build CT002 response for %s (%s): %s",
+                    addr,
+                    fields,
+                    exc,
+                    exc_info=True,
+                )
+                return
+            logger.debug(
+                "CT002 response to %s: %s (fields=%s)",
+                addr,
+                response.hex(),
+                response_fields,
             )
+            if self.debug_status:
+                phase_values = self._collect_reports_by_phase()
+                logger.info(
+                    "CT002 status: %s",
+                    self._format_status(values, phase_values, consumer_id, meter_value),
+                )
+            transport.sendto(response, addr)
+
+            # Fire event listener after response is sent
+            if not in_inspection_mode:
+                consumer = self._consumers.get(consumer_id)
+                self._call_event_listener(
+                    consumer_id,
+                    {
+                        "grid_power": {
+                            "l1": float(raw_values[0]),
+                            "l2": float(raw_values[1]),
+                            "l3": float(raw_values[2]),
+                            "total": sum(float(v) for v in raw_values),
+                        },
+                        "target": {
+                            "l1": float(values[0]),
+                            "l2": float(values[1]),
+                            "l3": float(values[2]),
+                        },
+                        "phase": consumer.phase if consumer else reported_phase,
+                        "reported_power": reported_power,
+                        "device_type": consumer.device_type if consumer else "",
+                        "battery_ip": addr[0],
+                        "ct_type": fields[2] if len(fields) > 2 else "",
+                        "ct_mac": fields[3] if len(fields) > 3 else "",
+                        "saturation": self._balancer.get_saturation(consumer_id),
+                        "last_target": self._balancer.get_last_target(consumer_id),
+                        "active": is_active,
+                        "poll_interval": consumer.poll_interval if consumer else None,
+                        "last_seen": datetime.now(timezone.utc).isoformat(),
+                        "smooth_target": self._last_smooth_target,
+                        "manual_target": consumer.manual_target if consumer else None,
+                        "auto_target": (
+                            not consumer.manual_enabled if consumer else True
+                        ),
+                        "distribution_weight": (
+                            consumer.distribution_weight if consumer else 1.0
+                        ),
+                        "efficiency_window_weight": (
+                            consumer.efficiency_window_weight if consumer else 1.0
+                        ),
+                        "min_dc_output": consumer.min_dc_output if consumer else None,
+                        "active_control": self.active_control,
+                        "efficiency_rotation": (
+                            self._balancer.efficiency_rotation_enabled
+                        ),
+                        "consumer_count": sum(
+                            1 for c in self._consumers.values() if c.timestamp > 0
+                        ),
+                    },
+                )
+        finally:
+            self._inflight_consumers.discard(consumer_id)
 
     async def _cleanup_loop(self):
         try:

--- a/src/astrameter/ct002/ct002_test.py
+++ b/src/astrameter/ct002/ct002_test.py
@@ -1,6 +1,23 @@
+import asyncio
+
 import pytest
 
 from astrameter.ct002.ct002 import CT002
+from astrameter.ct002.protocol import build_payload
+
+
+class _RecordingTransport:
+    """Captures every datagram CT002 would have sent back over UDP."""
+
+    def __init__(self) -> None:
+        self.sent: list[bytes] = []
+
+    def sendto(self, data: bytes, addr) -> None:
+        self.sent.append(data)
+
+
+def _poll(mac: str, phase: str = "A", power: int = 432) -> bytes:
+    return build_payload(["HMG-50", mac, "HME-4", "112233445566", phase, str(power)])
 
 
 class FakeClock:
@@ -113,3 +130,109 @@ def test_no_override_leaves_fresh_consumer_at_defaults() -> None:
     assert consumer.active is True
     assert consumer.distribution_weight == 1.0
     assert "c1" not in ct._consumer_overrides
+
+
+# ---------------------------------------------------------------------------
+# Concurrent-poll coalescing: one response per consumer per meter reading.
+#
+# When the meter read parks the handler — WAIT_FOR_NEXT_MESSAGE awaits the next
+# push, THROTTLE_INTERVAL sleeps out the throttle window, or a slow HTTP meter
+# just takes a while — the battery keeps polling (~1/s) and every datagram is
+# its own task.  Both settings share the same failure mode: the parked handlers
+# all wake on the one fresh reading and each sends a delta, so the battery gets
+# a burst of instructions it *adds* to its output.  These tests pin the fix at
+# the request-handler level, so it covers every slow-read cause at once.
+# ---------------------------------------------------------------------------
+
+
+async def _gated_before_send(ct: CT002, gate: asyncio.Event) -> list[int]:
+    """Wire a ``before_send`` that parks on *gate* (a slow meter read) and
+    returns a fixed grid reading.  Returns a one-element call counter list."""
+    calls = [0]
+
+    async def before_send(_addr, _fields=None, _consumer_id=None):
+        calls[0] += 1
+        await gate.wait()
+        return [150.0, 0.0, 0.0]
+
+    ct.before_send = before_send
+    return calls
+
+
+async def test_concurrent_polls_coalesce_to_a_single_response() -> None:
+    """Four polls from one battery pile up in a parked read; only ONE delta
+    goes out when the reading lands — not a four-deep burst."""
+    ct = CT002(ct_mac="", active_control=True, dedupe_time_window=0.0)
+    gate = asyncio.Event()
+    calls = await _gated_before_send(ct, gate)
+
+    transport = _RecordingTransport()
+    addr = ("192.168.178.134", 22222)
+    mac = "02b250b26777"
+
+    handlers = [
+        asyncio.create_task(ct._handle_request(_poll(mac), addr, transport))
+        for _ in range(4)
+    ]
+    # Let every task reach its await point / early return.
+    await asyncio.sleep(0.05)
+    assert transport.sent == []  # nothing answered while the read is parked
+
+    # A single fresh reading arrives and wakes the parked handler.
+    gate.set()
+    await asyncio.gather(*handlers)
+
+    assert len(transport.sent) == 1  # exactly one delta, not a burst of four
+    assert calls[0] == 1  # meter + stateful balancer driven once, not four times
+    assert ct._inflight_consumers == set()  # flag cleared for the next reading
+
+
+async def test_coalescing_is_per_consumer() -> None:
+    """Coalescing is keyed per battery: two batteries polling at once each get
+    their own single response; one does not suppress the other."""
+    ct = CT002(ct_mac="", active_control=True, dedupe_time_window=0.0)
+    gate = asyncio.Event()
+    await _gated_before_send(ct, gate)
+
+    transport = _RecordingTransport()
+    handlers = []
+    for mac, addr in (
+        ("02b250b26777", ("192.168.178.134", 22222)),
+        ("02b250aaaaaa", ("192.168.178.135", 22222)),
+    ):
+        # Two concurrent polls per battery — the duplicate is coalesced away.
+        handlers.append(
+            asyncio.create_task(ct._handle_request(_poll(mac), addr, transport))
+        )
+        handlers.append(
+            asyncio.create_task(ct._handle_request(_poll(mac), addr, transport))
+        )
+
+    await asyncio.sleep(0.05)
+    gate.set()
+    await asyncio.gather(*handlers)
+
+    assert len(transport.sent) == 2  # one per battery, both answered
+    assert ct._inflight_consumers == set()
+
+
+async def test_poll_answered_again_after_burst_coalesced() -> None:
+    """Dropping the duplicate polls is not a lock-out: once the in-flight
+    handler responds, the next poll is served normally."""
+    ct = CT002(ct_mac="", active_control=True, dedupe_time_window=0.0)
+    gate = asyncio.Event()
+    gate.set()  # reads resolve immediately here
+    await _gated_before_send(ct, gate)
+
+    transport = _RecordingTransport()
+    addr = ("192.168.178.134", 22222)
+    mac = "02b250b26777"
+
+    # First poll completes end-to-end (gate already open).
+    await ct._handle_request(_poll(mac), addr, transport)
+    assert len(transport.sent) == 1
+    assert ct._inflight_consumers == set()
+
+    # A later poll (a fresh reading) is still answered — no permanent drop.
+    await ct._handle_request(_poll(mac), addr, transport)
+    assert len(transport.sent) == 2

--- a/src/astrameter/shelly/shelly.py
+++ b/src/astrameter/shelly/shelly.py
@@ -49,6 +49,18 @@ class Shelly:
         self._battery_last_seen: dict[str, float] = {}
         self._battery_poll_interval: dict[str, float] = {}
         self._inactive_batteries: set[str] = set()
+        # Batteries with a request handler currently parked between the meter
+        # read and its response.  The battery runs a closed-loop zero-export
+        # controller, so the grid reading we report is the error signal it
+        # integrates against its own output.  While WAIT_FOR_NEXT_MESSAGE — or a
+        # slow/throttled meter — holds that read, the battery keeps polling
+        # (~1/s) and each datagram spawns its own handler task; without
+        # coalescing every parked handler would wake on the same stale reading
+        # and answer, feeding the loop the same pre-adjustment error several
+        # times before the plant can reflect its response, which winds the
+        # battery past target exactly like a burst of deltas.  A single
+        # in-flight handler per battery answers per reading; duplicates drop.
+        self._inflight_batteries: set[str] = set()
         self._stopped = asyncio.Event()
         self._inactive_check_task = None
         self._dedupe_time_window = max(0.0, dedupe_time_window)
@@ -221,69 +233,90 @@ class Shelly:
                     logger.warning(f"No powermeter found for client {addr[0]}")
                     return
 
-                if wait_for_next_message:
-                    try:
-                        await powermeter.wait_for_next_message(timeout=2)
-                    except TimeoutError:
-                        logger.debug(
-                            "Powermeter %s produced no fresh message within 2s; "
-                            "serving last known value",
-                            type(powermeter).__name__,
-                        )
+                # Coalesce concurrent polls from the same battery.  If a handler
+                # for this battery is already parked awaiting the next meter
+                # reading, the reading has not been answered yet — letting this
+                # duplicate poll wait and respond too would feed the battery's
+                # zero-export loop the same stale error several times the moment
+                # the meter updates and wakes every parked handler, overshooting
+                # target.  Drop it; _track_battery_seen above already refreshed
+                # the liveness/poll-interval state, and the in-flight handler
+                # sends the one response for the next reading.
+                if addr[0] in self._inflight_batteries:
+                    logger.debug(
+                        "Coalescing Shelly poll from %s: a handler is already "
+                        "awaiting the next meter reading; dropping this "
+                        "duplicate to avoid a burst of readings",
+                        addr,
+                    )
+                    return
+                self._inflight_batteries.add(addr[0])
                 try:
-                    powers = await powermeter.get_powermeter_watts()
-                except Exception as exc:
-                    # Reading the meter can fail transiently (e.g. an HTTP
-                    # source timing out). Log a one-liner at the normal level
-                    # and reserve the full traceback for DEBUG so an outage
-                    # doesn't flood the log with stack traces on every poll.
-                    logger.warning(
-                        "Could not read meter values from %s (%s): %s",
-                        type(powermeter).__name__,
-                        addr[0],
-                        exc,
-                        exc_info=debug_traceback(),
-                    )
-                    return
+                    if wait_for_next_message:
+                        try:
+                            await powermeter.wait_for_next_message(timeout=2)
+                        except TimeoutError:
+                            logger.debug(
+                                "Powermeter %s produced no fresh message within "
+                                "2s; serving last known value",
+                                type(powermeter).__name__,
+                            )
+                    try:
+                        powers = await powermeter.get_powermeter_watts()
+                    except Exception as exc:
+                        # Reading the meter can fail transiently (e.g. an HTTP
+                        # source timing out). Log a one-liner at the normal level
+                        # and reserve the full traceback for DEBUG so an outage
+                        # doesn't flood the log with stack traces on every poll.
+                        logger.warning(
+                            "Could not read meter values from %s (%s): %s",
+                            type(powermeter).__name__,
+                            addr[0],
+                            exc,
+                            exc_info=debug_traceback(),
+                        )
+                        return
 
-                if request.get("method") == "EM.GetStatus":
-                    response = self._create_em_response(request["id"], powers)
-                elif request.get("method") == "EM1.GetStatus":
-                    response = self._create_em1_response(request["id"], powers)
-                else:
-                    return
+                    if request.get("method") == "EM.GetStatus":
+                        response = self._create_em_response(request["id"], powers)
+                    elif request.get("method") == "EM1.GetStatus":
+                        response = self._create_em1_response(request["id"], powers)
+                    else:
+                        return
 
-                response_json = json.dumps(response, separators=(",", ":"))
-                logger.debug(f"Sending response: {response_json}")
-                response_data = response_json.encode()
-                transport.sendto(response_data, addr)
+                    response_json = json.dumps(response, separators=(",", ":"))
+                    logger.debug(f"Sending response: {response_json}")
+                    response_data = response_json.encode()
+                    transport.sendto(response_data, addr)
 
-                battery_ip = addr[0]
-                if len(powers) == 1:
-                    grid_l1, grid_l2, grid_l3 = powers[0], 0.0, 0.0
-                elif len(powers) >= 3:
-                    grid_l1, grid_l2, grid_l3 = (
-                        float(powers[0]),
-                        float(powers[1]),
-                        float(powers[2]),
-                    )
-                else:
-                    grid_l1, grid_l2, grid_l3 = 0.0, 0.0, 0.0
-                self._call_event_listener(
-                    battery_ip,
-                    {
-                        "grid_power": {
-                            "l1": grid_l1,
-                            "l2": grid_l2,
-                            "l3": grid_l3,
-                            "total": grid_l1 + grid_l2 + grid_l3,
+                    battery_ip = addr[0]
+                    if len(powers) == 1:
+                        grid_l1, grid_l2, grid_l3 = powers[0], 0.0, 0.0
+                    elif len(powers) >= 3:
+                        grid_l1, grid_l2, grid_l3 = (
+                            float(powers[0]),
+                            float(powers[1]),
+                            float(powers[2]),
+                        )
+                    else:
+                        grid_l1, grid_l2, grid_l3 = 0.0, 0.0, 0.0
+                    self._call_event_listener(
+                        battery_ip,
+                        {
+                            "grid_power": {
+                                "l1": grid_l1,
+                                "l2": grid_l2,
+                                "l3": grid_l3,
+                                "total": grid_l1 + grid_l2 + grid_l3,
+                            },
+                            "active": battery_ip not in self._inactive_batteries,
+                            "poll_interval": poll_interval,
+                            "last_seen": datetime.now(timezone.utc).isoformat(),
+                            "battery_count": len(self._battery_last_seen),
                         },
-                        "active": battery_ip not in self._inactive_batteries,
-                        "poll_interval": poll_interval,
-                        "last_seen": datetime.now(timezone.utc).isoformat(),
-                        "battery_count": len(self._battery_last_seen),
-                    },
-                )
+                    )
+                finally:
+                    self._inflight_batteries.discard(addr[0])
         except json.JSONDecodeError:
             logger.error("Error: Invalid JSON")
         except Exception:

--- a/src/astrameter/shelly/shelly_udp_test.py
+++ b/src/astrameter/shelly/shelly_udp_test.py
@@ -29,6 +29,21 @@ class FailingPowermeter(Powermeter):
         raise TimeoutError("Connection timeout to host http://192.168.2.17/")
 
 
+class GatedPowermeter(Powermeter):
+    """A meter whose read parks until ``gate`` is set — models a slow/throttled
+    read or WAIT_FOR_NEXT_MESSAGE holding the handler so concurrent polls pile
+    up behind it."""
+
+    def __init__(self):
+        self.gate = asyncio.Event()
+        self.call_count = 0
+
+    async def get_powermeter_watts(self):
+        self.call_count += 1
+        await self.gate.wait()
+        return [42.0]
+
+
 class _FakeClock:
     def __init__(self) -> None:
         self.now = 0.0
@@ -84,9 +99,13 @@ async def test_dedupe_window_drops_rapid_duplicates():
     assert dummy.call_count == 2
 
 
-async def test_multiple_requests_with_throttling():
+async def test_concurrent_polls_from_one_battery_coalesce_over_udp():
+    """End-to-end burst prevention over real UDP: a battery firing several
+    polls while a throttled read is in flight gets exactly ONE response, not one
+    per poll — repeating the same reading would feed its zero-export loop the
+    same stale error before the plant can respond, overshooting target."""
     dummy = DummyPowermeter()
-    pm = ThrottledPowermeter(dummy, throttle_interval=0.2)
+    pm = ThrottledPowermeter(dummy, throttle_interval=0.3)
     cf = ClientFilter([IPv4Network("127.0.0.1/32")])
 
     shelly = Shelly([(pm, cf, True)], udp_port=0, device_id="test")
@@ -94,33 +113,120 @@ async def test_multiple_requests_with_throttling():
     port = shelly.udp_port
     assert port != 0, "Shelly should have bound to an actual port"
     try:
-        # Prime the throttle with an initial fetch so subsequent
-        # concurrent requests coalesce on the same reading.
-        resp = await _send_req(port, 99)
-        assert resp == 99
+        # Prime the throttle so the burst parks on the throttle window rather
+        # than racing the very first fetch.
+        assert await _send_req(port, 99) == 99
         initial_calls = dummy.call_count
 
         responses = []
-        errors = []
+        timeouts = []
 
         async def send_req(i):
             try:
-                resp_id = await _send_req(port, i)
-                responses.append(resp_id)
+                responses.append(await _send_req(port, i, timeout=1.0))
             except TimeoutError:
-                errors.append(f"timeout for request id={i}")
+                timeouts.append(i)
 
         await asyncio.gather(*(send_req(i) for i in range(3)))
 
-        assert errors == []
-        assert sorted(responses) == [0, 1, 2]
-        # All 3 concurrent requests should coalesce into a single fetch.
-        assert dummy.call_count - initial_calls <= 1, (
-            f"Expected at most 1 powermeter fetch for 3 concurrent requests, "
-            f"got {dummy.call_count - initial_calls}"
-        )
+        # Same source IP == same battery: exactly one poll is answered and the
+        # duplicates are coalesced away instead of each drawing a response.
+        assert len(responses) == 1
+        assert len(timeouts) == 2
+        # The one answered poll shares a single throttled fetch.
+        assert dummy.call_count - initial_calls <= 1
     finally:
         await shelly.stop()
+
+
+async def test_concurrent_polls_coalesce_to_a_single_response():
+    """Four polls from one battery pile up in a parked read; only ONE response
+    goes out when the reading lands — not a four-deep burst."""
+    pm = GatedPowermeter()
+    cf = ClientFilter([IPv4Network("127.0.0.1/32")])
+    shelly = Shelly([(pm, cf, False)], udp_port=0, device_id="test")
+    transport = _FakeTransport()
+    req = json.dumps(
+        {"id": 1, "src": "cli", "method": "EM.GetStatus", "params": {"id": 0}}
+    ).encode()
+    addr = ("127.0.0.1", 54321)
+
+    handlers = [
+        asyncio.create_task(shelly._handle_request(transport, req, addr))
+        for _ in range(4)
+    ]
+    await asyncio.sleep(0.05)
+    assert transport.sent == []  # every handler parked on the read
+
+    pm.gate.set()  # one fresh reading arrives
+    await asyncio.gather(*handlers)
+
+    assert len(transport.sent) == 1  # one response, not four
+    assert pm.call_count == 1  # the meter was read once, not four times
+    assert shelly._inflight_batteries == set()  # flag cleared for the next read
+
+
+async def test_coalescing_is_per_battery():
+    """Coalescing is keyed per battery IP: two batteries polling at once each
+    get their own response; one does not suppress the other."""
+    pm = GatedPowermeter()
+    cf = ClientFilter([IPv4Network("127.0.0.0/8")])
+    shelly = Shelly([(pm, cf, False)], udp_port=0, device_id="test")
+    transport = _FakeTransport()
+    req = json.dumps(
+        {"id": 1, "src": "cli", "method": "EM.GetStatus", "params": {"id": 0}}
+    ).encode()
+
+    handlers = []
+    for ip in ("127.0.0.1", "127.0.0.2"):
+        for _ in range(2):  # two concurrent polls per battery
+            handlers.append(
+                asyncio.create_task(shelly._handle_request(transport, req, (ip, 5000)))
+            )
+
+    await asyncio.sleep(0.05)
+    pm.gate.set()
+    await asyncio.gather(*handlers)
+
+    assert len(transport.sent) == 2  # one per battery, both answered
+    assert shelly._inflight_batteries == set()
+
+
+async def test_poll_answered_again_after_burst_coalesced():
+    """Dropping duplicates is not a lock-out: once the in-flight handler
+    responds, the next poll is served normally."""
+    pm = GatedPowermeter()
+    pm.gate.set()  # reads resolve immediately
+    cf = ClientFilter([IPv4Network("127.0.0.1/32")])
+    shelly = Shelly([(pm, cf, False)], udp_port=0, device_id="test")
+    transport = _FakeTransport()
+    req = json.dumps(
+        {"id": 1, "src": "cli", "method": "EM.GetStatus", "params": {"id": 0}}
+    ).encode()
+    addr = ("127.0.0.1", 54321)
+
+    await shelly._handle_request(transport, req, addr)
+    assert len(transport.sent) == 1
+    assert shelly._inflight_batteries == set()
+
+    await shelly._handle_request(transport, req, addr)
+    assert len(transport.sent) == 2
+
+
+async def test_inflight_flag_cleared_when_meter_read_fails():
+    """A failing meter read must still clear the in-flight flag, or the battery
+    would be locked out of every future response."""
+    cf = ClientFilter([IPv4Network("127.0.0.1/32")])
+    shelly = Shelly([(FailingPowermeter(), cf, False)], udp_port=0, device_id="test")
+    transport = _FakeTransport()
+    req = json.dumps(
+        {"id": 1, "src": "cli", "method": "EM.GetStatus", "params": {"id": 0}}
+    ).encode()
+    addr = ("127.0.0.1", 54321)
+
+    await shelly._handle_request(transport, req, addr)
+    assert transport.sent == []  # read failed, no response
+    assert shelly._inflight_batteries == set()  # but the flag is cleared
 
 
 async def _drive_failing_read(caplog, level):

--- a/src/astrameter/shelly/shelly_udp_test.py
+++ b/src/astrameter/shelly/shelly_udp_test.py
@@ -124,7 +124,10 @@ async def test_concurrent_polls_from_one_battery_coalesce_over_udp():
         async def send_req(i):
             try:
                 responses.append(await _send_req(port, i, timeout=1.0))
-            except TimeoutError:
+            except (TimeoutError, asyncio.TimeoutError):
+                # A coalesced-away duplicate never gets a reply. ``asyncio``'s
+                # TimeoutError is a *distinct* class from the builtin on Python
+                # 3.10 (they were unified in 3.11), so catch both.
                 timeouts.append(i)
 
         await asyncio.gather(*(send_req(i) for i in range(3)))


### PR DESCRIPTION
## Summary

Fix a critical issue where batteries and the CT002 meter emulator would receive multiple response deltas in quick succession when a meter read was delayed, causing the battery's control loop to overshoot its target. The fix coalesces concurrent polls from the same battery/consumer into a single response per meter reading.

## Problem

When a meter read is delayed — either via `WAIT_FOR_NEXT_MESSAGE`, a throttled meter, or a slow HTTP source — the battery keeps polling (~1/s) and each datagram spawns its own handler task. Without coalescing, all parked handlers wake on the same fresh reading and each sends a response, creating a burst of deltas that the battery's firmware adds to its output. For Shelly batteries with a zero-export controller, this feeds the same stale error signal multiple times before the plant can respond, causing overshoot. For CT002, it steps the stateful balancer multiple times per real sample, winding up the battery.

## Solution

Track in-flight handlers per battery/consumer using a set (`_inflight_consumers` for CT002, `_inflight_batteries` for Shelly). When a poll arrives:
- If a handler is already parked for that consumer/battery, drop the duplicate poll (the state was already refreshed by the report update)
- Otherwise, add it to the in-flight set, process the request, and remove it from the set in a `finally` block

This ensures exactly one response per meter reading, regardless of how many polls arrive while the read is in flight.

## Changes

**CT002 (`src/astrameter/ct002/ct002.py`)**
- Added `_inflight_consumers: set[str]` to track consumers with parked handlers
- Wrapped the meter-read and response logic in a try/finally block
- Early-return duplicate polls with a debug log
- Clear the in-flight flag in the finally block to unblock the next reading

**Shelly (`src/astrameter/shelly/shelly.py`)**
- Added `_inflight_batteries: set[str]` to track batteries with parked handlers
- Wrapped the meter-read and response logic in a try/finally block
- Early-return duplicate polls with a debug log
- Clear the in-flight flag in the finally block

**Tests**
- Added `GatedPowermeter` test fixture that parks reads on an asyncio.Event
- Added comprehensive test suite for both CT002 and Shelly covering:
  - Concurrent polls from one consumer/battery coalesce to a single response
  - Coalescing is per-consumer/battery (two batteries each get their own response)
  - Polls are answered normally after a burst is coalesced (no permanent lock-out)
  - In-flight flag is cleared even when meter reads fail

## Notes

- The fix is transparent to the battery/meter — it sees the same response it would have gotten without the burst, just once instead of N times
- The state update (report parsing) happens before the coalesce check, so dropped polls still refresh per-consumer metadata
- Both implementations use identical logic and naming for consistency

https://claude.ai/code/session_01RaCn4moMmua81wuKo8nKEK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate or repeated responses when meter readings are delayed or slow.
  * Requests from the same battery/consumer are now combined so only one reply is sent per reading.
  * Improved behavior under bursts of concurrent polls, including after temporary errors, so service resumes normally afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->