### PR TITLE
Switch from aiohttp to requests for HTTP handling

### DIFF
--- a/src/astrameter/powermeter/tq_em.py
+++ b/src/astrameter/powermeter/tq_em.py
@@ -1,11 +1,12 @@
-import asyncio
+from typing import List
 import time
-
-import aiohttp
-from aiohttp import ClientTimeout
+import requests
+import logging
 
 from .base import Powermeter
 
+# Logger einbinden, um Fehler im Log zu sehen
+logger = logging.getLogger("b2500-meter")
 
 class TQEnergyManager(Powermeter):
     """Powermeter using the TQ Energy Manager JSON API."""
@@ -33,78 +34,64 @@ class TQEnergyManager(Powermeter):
         "1-0:62.4.0*255",  # L3 active power (to grid)
     )
 
-    _MAX_IDLE = 60 * 30  # 30 min
+    _MAX_IDLE = 60 * 5  # Auf 5 Minuten verkürzt für mehr Stabilität
 
     def __init__(self, host: str, password: str = "", *, timeout: float = 5.0) -> None:
         self._host, self._pw, self._timeout = host.rstrip("/"), password, timeout
-        self._sess: aiohttp.ClientSession | None = None
+        self._sess = requests.Session()
         self._serial: str | None = None
         self._last_use = 0.0
-        self._auth_lock = asyncio.Lock()
 
-    async def start(self) -> None:
-        if self._sess:
-            return
-        self._sess = aiohttp.ClientSession(
-            timeout=ClientTimeout(total=self._timeout),
-        )
-
-    async def stop(self) -> None:
-        if self._sess:
-            await self._sess.close()
-            self._sess = None
-
-    # ------------------------------------------------------------------ #
-    # PUBLIC                                                             #
-    # ------------------------------------------------------------------ #
-    async def get_powermeter_watts(self) -> list[float]:
-        if not self._sess:
-            raise RuntimeError("Session not started; call start() first")
-        async with self._auth_lock:
-            await self._ensure_session()
-
+    def get_powermeter_watts(self) -> List[float]:
+        try:
+            self._ensure_session()
             try:
-                data = await self._read_live_json()
+                data = self._read_live_json()
             except _SessionExpired:
-                await self._login()
-                data = await self._read_live_json()
+                logger.info("TQ Session abgelaufen. Erneuter Login...")
+                self._login()
+                data = self._read_live_json()
 
-        if any(k in data for k in self._PHASE_KEYS):
-            return [
-                float(data.get(self._PHASE_KEYS[self._TOTAL_TO_GRID_L1], 0))
-                - float(data.get(self._PHASE_KEYS[self._TOTAL_FROM_GRID_L1], 0)),
-                float(data.get(self._PHASE_KEYS[self._TOTAL_TO_GRID_L2], 0))
-                - float(data.get(self._PHASE_KEYS[self._TOTAL_FROM_GRID_L2], 0)),
-                float(data.get(self._PHASE_KEYS[self._TOTAL_TO_GRID_L3], 0))
-                - float(data.get(self._PHASE_KEYS[self._TOTAL_FROM_GRID_L3], 0)),
-            ]
+            # Prüfen, ob die Keys TATSÄCHLICH im JSON existieren, nicht nur pauschal "any"
+            if all(k in data for k in self._PHASE_KEYS):
+                return [
+                    float(data.get(self._PHASE_KEYS[self._TOTAL_TO_GRID_L1], 0))
+                    - float(data.get(self._PHASE_KEYS[self._TOTAL_FROM_GRID_L1], 0)),
+                    float(data.get(self._PHASE_KEYS[self._TOTAL_TO_GRID_L2], 0))
+                    - float(data.get(self._PHASE_KEYS[self._TOTAL_FROM_GRID_L2], 0)),
+                    float(data.get(self._PHASE_KEYS[self._TOTAL_TO_GRID_L3], 0))
+                    - float(data.get(self._PHASE_KEYS[self._TOTAL_FROM_GRID_L3], 0)),
+                ]
 
-        if any(k in data for k in self._TOTAL_KEYS):
-            return [
-                float(data.get(self._TOTAL_KEYS[self._TOTAL_TO_GRID], 0))
-                - float(data.get(self._TOTAL_KEYS[self._TOTAL_FROM_GRID], 0))
-            ]
+            if all(k in data for k in self._TOTAL_KEYS):
+                return [
+                    float(data.get(self._TOTAL_KEYS[self._TOTAL_TO_GRID], 0))
+                    - float(data.get(self._TOTAL_KEYS[self._TOTAL_FROM_GRID], 0))
+                ]
 
-        raise RuntimeError("Required OBIS values missing in payload")
+            # Wenn Keys fehlen, erzwingen wir beim nächsten Mal einen neuen Login
+            logger.warning("Erforderliche OBIS-Werte fehlten in der TQ-Antwort. Erwirtschafte Re-Login.")
+            self._serial = None 
+            return [0.0, 0.0, 0.0]
 
-    # ------------------------------------------------------------------ #
-    # INTERNALS                                                          #
-    # ------------------------------------------------------------------ #
-    async def _ensure_session(self) -> None:
-        if self._sess is None:
-            raise RuntimeError("Session not started; call start() first")
+        except Exception as e:
+            # Sicherheitsnetz: Verhindert das dauerhafte Sterben des Threads bei Netzwerk-Dropouts
+            logger.error(f"Fehler bei TQ-Abfrage: {e}. Setze Session zurück.")
+            self._serial = None  # Erzwingt harten Re-Login beim nächsten Durchlauf
+            self._sess = requests.Session()  # Löscht korrupte Verbindungen
+            return [0.0, 0.0, 0.0]  # Gibt Nullwerte zurück, statt abzustürzen
+
+    def _ensure_session(self) -> None:
         now = time.time()
         if self._serial is None or (now - self._last_use) > self._MAX_IDLE:
-            await self._login()
+            self._login()
         self._last_use = now
 
-    async def _login(self) -> None:
+    def _login(self) -> None:
         """Authenticate lazily with the device."""
-        if self._sess is None:
-            raise RuntimeError("Session not started; call start() first")
-        async with self._sess.get(f"http://{self._host}/start.php") as r1:
-            r1.raise_for_status()
-            j1 = await r1.json(content_type=None)
+        r1 = self._sess.get(f"http://{self._host}/start.php", timeout=self._timeout)
+        r1.raise_for_status()
+        j1 = r1.json()
 
         self._serial = j1.get("serial") or j1.get("ieq_serial")
         if not self._serial:
@@ -117,29 +104,27 @@ class TQEnergyManager(Powermeter):
         if self._pw:
             payload["password"] = self._pw
 
-        async with self._sess.post(
-            f"http://{self._host}/start.php", data=payload
-        ) as r2:
-            r2.raise_for_status()
-            j2 = await r2.json(content_type=None)
-            if j2.get("authentication") is not True:
-                raise RuntimeError("Authentication failed")
+        r2 = self._sess.post(
+            f"http://{self._host}/start.php", data=payload, timeout=self._timeout
+        )
+        r2.raise_for_status()
+        if r2.json().get("authentication") is not True:
+            raise RuntimeError("Authentication failed")
 
-    async def _read_live_json(self) -> dict:
-        if self._sess is None:
-            raise RuntimeError("Session not started; call start() first")
-        async with self._sess.get(f"http://{self._host}/mum-webservice/data.php") as r:
-            if r.status in (401, 403):
-                raise _SessionExpired
+    def _read_live_json(self) -> dict:
+        r = self._sess.get(
+            f"http://{self._host}/mum-webservice/data.php", timeout=self._timeout
+        )
+        if r.status_code in (401, 403):
+            raise _SessionExpired
 
-            r.raise_for_status()
-            data = await r.json(content_type=None)
-            if data.get("status", 0) >= 900:
-                raise _SessionExpired
-            return data
+        r.raise_for_status()
+        data = r.json()
+        if data.get("status", 0) >= 900:
+            raise _SessionExpired
+        return data
 
 
 class _SessionExpired(RuntimeError):
-    """Internal marker - triggers transparent re-login."""
-
+    """Internal marker – triggers transparent re-login."""
     pass


### PR DESCRIPTION
Refactor TQEnergyManager to use requests instead of aiohttp for HTTP calls, reducing complexity and improving stability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved powermeter reliability during network failures and expired sessions.
  * Automatically re-authenticates when the connection expires or remains idle.
  * Returns zero readings instead of stopping when meter data is incomplete or unavailable.

* **Improvements**
  * Powermeter readings are now retrieved synchronously.
  * Reduced the idle period before automatically re-authenticating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->