### PR TITLE
Document AstraMeter's place in the Marstek ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ meter. Your storage system sees a meter it understands; AstraMeter reads your
 actual grid power from a source of your choosing and steers the batteries toward
 net-zero grid exchange.
 
+<!-- marstek-family:start -->
+**🔋 The Marstek ecosystem.** This repo is part of a family of open-source tools for Marstek batteries (B2500, Venus, Jupiter, …):
+
+| Project | What it does |
+|---|---|
+| [hm2mqtt](https://github.com/tomquist/hm2mqtt) | Brings your battery into your smart home, turning its raw data into readable sensors and controls (e.g. in Home Assistant) |
+| [hame-relay](https://github.com/tomquist/hame-relay) | Connects the official Marstek cloud/app and your local smart home so both work together, forwarding data whichever way your battery is set up |
+| [marsrelay](https://github.com/tomquist/marsrelay) | Runs your battery completely offline, with no internet or Marstek cloud, while still sending all its data to your smart home |
+| **AstraMeter** (this repo) | Tells your battery your live grid usage (read from your existing meter) so it charges and discharges to avoid buying or selling power |
+| [hmjs](https://github.com/tomquist/hmjs) | Sets up and configures B2500 batteries over Bluetooth, right from your web browser, with no app or account needed |
+| [esphome-b2500](https://github.com/tomquist/esphome-b2500) | Continuously monitors and controls a B2500 over Bluetooth using a small ESP32 board |
+<!-- marstek-family:end -->
+
 It does this by emulating one or more of these devices:
 
 - **CT002 / CT003** (Marstek's native CT protocol) — use for **multiple** storage


### PR DESCRIPTION
Adds a new section to the README that introduces the broader Marstek open-source ecosystem and positions AstraMeter within it.

## Summary

This change adds a "Marstek ecosystem" section to the README that documents the family of open-source tools available for Marstek batteries. The section includes a table listing six related projects (hm2mqtt, hame-relay, marsrelay, AstraMeter, hmjs, and esphome-b2500) with brief descriptions of what each does.

## Key changes

- Added a new ecosystem overview section with HTML comment markers (`<!-- marstek-family:start -->` / `<!-- marstek-family:end -->`) to allow for synchronized updates across multiple repositories
- Included a reference table showing AstraMeter's role alongside complementary tools for battery integration, monitoring, control, and configuration
- Positioned the section early in the README (after the introductory paragraph) to help users discover related projects

## Notes

The HTML comment markers suggest this section may be maintained in sync across the Marstek ecosystem repositories, allowing for coordinated updates to the family of projects.

https://claude.ai/code/session_014X7oipnV3LXbrsLYoii4yq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Marstek ecosystem” section to the README.
  * Included a table of related battery tools and brief descriptions of each project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->