### PR TITLE
Make Tibber Pulse timeout configurable to fix frequent connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- **Fixed** **Tibber Pulse** readings frequently dropping with connection-timeout errors because the bridge's slow webserver couldn't answer within the old hardcoded 1-second limit: the default timeout is now a more forgiving 5 seconds and can be tuned with a new `TIMEOUT` option ([#551](https://github.com/tomquist/astrameter/issues/551)).
 - **Fixed** active control silently breaking until a restart after a single invalid grid reading (a NaN value, e.g. from a briefly unavailable ESPHome sensor or a glitchy meter source): the controller could get stuck sending every battery a small constant discharge command regardless of the actual grid. An invalid reading is now treated like an unavailable meter — batteries hold their output for that poll and normal control resumes with the next good reading ([#548](https://github.com/tomquist/astrameter/issues/548), [#550](https://github.com/tomquist/astrameter/pull/550)).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** **Tibber Pulse** readings frequently dropping with connection-timeout errors because the bridge's slow webserver couldn't answer within the old hardcoded 1-second limit: the default timeout is now a more forgiving 5 seconds and can be tuned with a new `TIMEOUT` option ([#551](https://github.com/tomquist/astrameter/issues/551)).
+- **Fixed** **Tibber Pulse** readings frequently dropping with connection-timeout errors because the bridge's slow webserver couldn't answer within the old hardcoded 1-second connection limit: the default timeout is now a more forgiving 5 seconds and can be tuned with a new `TIMEOUT` option ([#551](https://github.com/tomquist/astrameter/issues/551), [#565](https://github.com/tomquist/astrameter/pull/565)).
 - **Fixed** active control silently breaking until a restart after a single invalid grid reading (a NaN value, e.g. from a briefly unavailable ESPHome sensor or a glitchy meter source): the controller could get stuck sending every battery a small constant discharge command regardless of the actual grid. An invalid reading is now treated like an unavailable meter — batteries hold their output for that poll and normal control resumes with the next good reading ([#548](https://github.com/tomquist/astrameter/issues/548), [#550](https://github.com/tomquist/astrameter/pull/550)).
 
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -440,6 +440,9 @@ THROTTLE_INTERVAL = 0
 # NODE_ID = 1
 ## Optional: override the Basic-auth user (defaults to "admin").
 # USER = admin
+## Optional: request timeout in seconds (default 5). The bridge's webserver can
+## be slow to respond — raise this if readings drop with connection timeouts.
+# TIMEOUT = 5.0
 ## Optional OBIS overrides (12 hex digits; omit to use eHZ-style defaults)
 # OBIS_POWER_CURRENT = 0100100700ff
 # OBIS_POWER_L1 = 0100240700ff

--- a/docs/powermeters.md
+++ b/docs/powermeters.md
@@ -493,6 +493,9 @@ PASSWORD = AD56-54BA
 # NODE_ID = 1
 # Optional: override the Basic-auth user (defaults to "admin")
 # USER = admin
+# Optional: request timeout in seconds (default 5); the bridge's webserver can
+# be slow, so raise this if readings drop with connection timeouts
+# TIMEOUT = 5.0
 ## Optional OBIS overrides (12 hex digits; omit to use eHZ-style defaults)
 # OBIS_POWER_CURRENT = 0100100700ff
 # OBIS_POWER_L1 = 0100240700ff

--- a/src/astrameter/config/config_loader.py
+++ b/src/astrameter/config/config_loader.py
@@ -752,6 +752,7 @@ def create_tibber_pulse_powermeter(
         config.get(section, "PASSWORD", fallback=""),
         config.get(section, "NODE_ID", fallback="1"),
         config.get(section, "USER", fallback="admin"),
+        timeout=config.getfloat(section, "TIMEOUT", fallback=5.0),
         obis_power_current=oc,
         obis_power_l1=o1,
         obis_power_l2=o2,

--- a/src/astrameter/config/config_loader_test.py
+++ b/src/astrameter/config/config_loader_test.py
@@ -526,17 +526,20 @@ def test_create_tibber_pulse_powermeter():
     assert pm.password == "AD56-54BA"
     assert pm.node_id == "1"
     assert pm.user == "admin"
+    assert pm.timeout == 5.0
 
     config["TIBBER_PULSE_2"] = {
         "IP": "127.0.0.1",
         "PASSWORD": "pw",
         "NODE_ID": "2",
         "USER": "root",
+        "TIMEOUT": "10",
         "OBIS_POWER_CURRENT": "0100100700ff",
     }
     pm = create_tibber_pulse_powermeter("TIBBER_PULSE_2", config)
     assert pm.node_id == "2"
     assert pm.user == "root"
+    assert pm.timeout == 10.0
     assert pm._obis_current == "0100100700ff"
 
 

--- a/src/astrameter/powermeter/tibber_pulse.py
+++ b/src/astrameter/powermeter/tibber_pulse.py
@@ -22,6 +22,10 @@ from .sml import (
 # Beyond the window a genuinely broken bridge/meter still surfaces as an error.
 _STALE_AFTER_S = 15.0
 
+# The bridge's webserver is slow — responses regularly take >1 s (#551) — so
+# the default must leave comfortable headroom. Overridable via TIMEOUT.
+DEFAULT_TIMEOUT_S = 5.0
+
 
 class TibberPulse(Powermeter):
     """Reads a Tibber Pulse via the local Pulse Bridge HTTP API.
@@ -48,12 +52,14 @@ class TibberPulse(Powermeter):
         obis_power_l1: str = _OBIS_POWER_L1,
         obis_power_l2: str = _OBIS_POWER_L2,
         obis_power_l3: str = _OBIS_POWER_L3,
+        timeout: float = DEFAULT_TIMEOUT_S,
         clock: Callable[[], float] | None = None,
     ):
         self.ip = ip
         self.password = password
         self.node_id = node_id
         self.user = user
+        self.timeout = timeout
         self._obis_current = obis_power_current
         self._obis_l1 = obis_power_l1
         self._obis_l2 = obis_power_l2
@@ -68,11 +74,11 @@ class TibberPulse(Powermeter):
     async def start(self) -> None:
         if self.session:
             return
-        # Fail fast: the battery polls ~1/s, so a slow source should error
-        # quickly and let the next poll retry rather than pin a handler.
+        # No separate connect timeout: the bridge's accept alone can exceed
+        # 1 s (#551), and a bounded total already caps a stuck request.
         self.session = aiohttp.ClientSession(
             auth=BasicAuth(self.user, self.password),
-            timeout=ClientTimeout(total=2, connect=1),
+            timeout=ClientTimeout(total=self.timeout),
         )
 
     async def stop(self) -> None:

--- a/src/astrameter/powermeter/tibber_pulse_test.py
+++ b/src/astrameter/powermeter/tibber_pulse_test.py
@@ -33,9 +33,25 @@ async def test_get_powermeter_watts_builds_authenticated_url(mock_aiohttp_sessio
     _, kwargs = session_cls.call_args
     assert kwargs["auth"].login == "admin"
     assert kwargs["auth"].password == "pw"
+    # The bridge webserver is slow, so no tight connect timeout — only the
+    # configurable total applies (#551).
+    assert kwargs["timeout"].total == 5.0
+    assert kwargs["timeout"].connect is None
     # The requested URL carries the configured node id.
     url = mock_aiohttp_session.get.call_args[0][0]
     assert url == "http://10.0.0.5/data.json?node_id=2"
+
+
+async def test_timeout_is_configurable(mock_aiohttp_session):
+    mock_aiohttp_session.set_read(_build_sml_frame(power_agg=100))
+    with patch(
+        "aiohttp.ClientSession", return_value=mock_aiohttp_session
+    ) as session_cls:
+        pm = TibberPulse("10.0.0.5", "pw", timeout=12.5)
+        await pm.start()
+        await pm.stop()
+    _, kwargs = session_cls.call_args
+    assert kwargs["timeout"].total == 12.5
 
 
 async def test_get_powermeter_watts_raises_on_undecodable_telegram(

--- a/src/astrameter/web_config.py
+++ b/src/astrameter/web_config.py
@@ -388,7 +388,10 @@ SECTION_KEY_TYPES: dict[str, dict[str, dict[str, object]]] = {
         DEVICE_ID={"type": "integer"},
         PER_PHASE={"type": "boolean"},
     ),
-    "TIBBER_PULSE": _pm(PASSWORD={"type": "password"}),
+    "TIBBER_PULSE": _pm(
+        PASSWORD={"type": "password"},
+        TIMEOUT={"type": "float"},
+    ),
     "SCRIPT": _pm(),
     "SML": _pm(),
     "MQTT_INSIGHTS": {

--- a/web/ts/generate.test.ts
+++ b/web/ts/generate.test.ts
@@ -108,6 +108,15 @@ const fronius3 = generateConfigIni({
 });
 has(fronius3, "PER_PHASE = True", "fronius: PER_PHASE emitted in three-phase");
 
+// ── config.ini: Tibber Pulse timeout (#551) ──────────────────────────────────
+const tibber = generateConfigIni({
+  target: "python",
+  general: { deviceTypes: ["ct002"] },
+  meters: [{ type: "tibber_pulse", phases: 1, fields: { IP: "192.168.1.140", PASSWORD: "AD56-54BA", TIMEOUT: "10" }, tuning: {} }],
+});
+has(tibber, "[TIBBER_PULSE]", "tibber: section header");
+has(tibber, "TIMEOUT = 10", "tibber: timeout override emitted");
+
 // ── config.ini: multi-meter NETMASK ──────────────────────────────────────────
 const multi = generateConfigIni({
   target: "python",

--- a/web/ts/schema.ts
+++ b/web/ts/schema.ts
@@ -682,6 +682,7 @@ export const POWERMETERS: Powermeter[] = [
       { key: "PASSWORD", label: "Bridge password", type: "password", placeholder: "AD56-54BA", required: true, help: "The nine-character code printed on the bridge (with the dash)." },
       { key: "USER", label: "Username", type: "text", default: "admin", placeholder: "admin", advanced: true, help: "HTTP Basic-auth user; the bridge uses 'admin'." },
       { key: "NODE_ID", label: "Node id", type: "text", default: "1", placeholder: "1", advanced: true, help: "Pulse node id (see http://<bridge>/nodes/). Usually 1." },
+      { key: "TIMEOUT", label: "Timeout (seconds)", type: "number", default: "5.0", placeholder: "5.0", advanced: true, help: "Request timeout. The bridge's webserver can be slow to respond — raise this if readings drop with connection timeouts." },
       { key: "OBIS_POWER_CURRENT", label: "OBIS: aggregate power", type: "text", placeholder: "0100100700ff", advanced: true, help: "12-hex OBIS code. Leave blank for the common eHZ default." },
       { key: "OBIS_POWER_L1", label: "OBIS: L1", type: "text", placeholder: "0100240700ff", advanced: true, help: "Per-phase OBIS code (optional)." },
       { key: "OBIS_POWER_L2", label: "OBIS: L2", type: "text", placeholder: "0100380700ff", advanced: true, help: "Per-phase OBIS code (optional)." },


### PR DESCRIPTION
## Summary

The Tibber Pulse bridge's webserver is slow and frequently takes >1 second to respond, causing readings to drop with connection-timeout errors under the old hardcoded 1-second limit. This change makes the timeout configurable with a more forgiving 5-second default.

## Changes

- **Core implementation** (`tibber_pulse.py`):
  - Added `DEFAULT_TIMEOUT_S = 5.0` constant with explanatory comment
  - Added `timeout` parameter to `TibberPulse.__init__()` (defaults to 5 seconds)
  - Changed `ClientTimeout` from hardcoded `total=2, connect=1` to `total=self.timeout` with no separate connect timeout (the bridge's accept alone can exceed 1s, and a bounded total already caps stuck requests)
  - Updated comment to explain the timeout strategy

- **Configuration surfaces** (required by parity rules):
  - `config_loader.py`: Parse `TIMEOUT` config key as float with 5.0 fallback
  - `config.ini.example`: Added commented `TIMEOUT` option with explanation
  - `web_config.py`: Registered `TIMEOUT` as float type in `TIBBER_PULSE` schema
  - `web/ts/schema.ts`: Added `TIMEOUT` field to Tibber Pulse config UI (advanced, number type, default 5.0)
  - `docs/powermeters.md`: Documented the new `TIMEOUT` option

- **Tests**:
  - Updated `test_get_powermeter_watts_builds_authenticated_url` to assert the new timeout values
  - Added `test_timeout_is_configurable` to verify custom timeout is applied
  - Updated `config_loader_test.py` to verify timeout parsing (default and custom values)
  - Added web config generator test for Tibber Pulse timeout emission

- **Documentation**:
  - Updated `CHANGELOG.md` with user-facing summary

## Implementation Details

The timeout strategy changed from separate connect (1s) and total (2s) limits to a single configurable total timeout with no connect limit. This is because the bridge's accept queue can take >1s even when healthy, and a bounded total timeout already prevents indefinitely stuck requests.

https://claude.ai/code/session_01HvA3sVYjmpzB3ovpN3fYjK