### PR TITLE
Always serve the dashboard under the add-on

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -10,8 +10,8 @@ SKIP_POWERMETER_TEST = False
 # WEB_CONFIG_ENABLED = False
 # Enable the live status dashboard at http://<host>:<port>/ (opt-in, default False).
 # Shows grid power, every battery's target and reported power, power-source
-# health and the balancer's internal state.  In the Home Assistant add-on this
-# is on by default and opens from the sidebar instead.
+# health and the balancer's internal state.  Ignored by the Home Assistant
+# add-on, where the dashboard always runs and opens from the sidebar.
 # DASHBOARD_ENABLED = False
 # Let the dashboard change this file and control batteries (default False).
 # Leave it off to keep the dashboard read-only.  There is NO authentication on

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -84,6 +84,13 @@ Two add-on options control it:
 | `dashboard_allow_write` | `true` | Lets the dashboard change configuration and control batteries. Turn it off for a read-only dashboard. |
 | `dashboard_direct_access` | `false` | Also serves the page on `http://<host>:52500` **with no authentication**. See [Security](#security). |
 
+This holds for a `custom_config` file too: `DASHBOARD_ENABLED` and
+`ENABLE_WEB_SERVER` in that file are ignored, because the sidebar panel and the
+Supervisor's health check both depend on them. The file's
+`DASHBOARD_ALLOW_WRITE` and `DASHBOARD_DIRECT_ACCESS` still apply — note that
+both default to `False`, so a custom config file gives you a **read-only**
+dashboard unless you set `DASHBOARD_ALLOW_WRITE = True`.
+
 ### Docker / standalone
 
 Off by default. Add to `[GENERAL]` in your `config.ini`:

--- a/src/astrameter/config/addon.py
+++ b/src/astrameter/config/addon.py
@@ -150,6 +150,27 @@ _IGNORED_WITH_CUSTOM_CONFIG: tuple[tuple[tuple[str, ...], str], ...] = (
     ),
 )
 
+
+def _serve_the_panel(general: GeneralSettings) -> GeneralSettings:
+    """Force the two settings the add-on's manifest already commits to.
+
+    ``ha_addon/config.yaml`` declares ingress on the web port and points the
+    Supervisor watchdog at ``/health`` there. Neither is conditional on the
+    configuration, so a source that turned either off would leave the sidebar
+    panel opening onto a 404 and the watchdog restarting the add-on for being
+    unreachable. Under the add-on this is a property of the deployment rather
+    than a choice, so it is applied to *every* configuration source.
+
+    Serving the dashboard costs nothing here: Home Assistant authenticates
+    every ingress request, and the plain port stays refused unless
+    ``dashboard_direct_access`` opts into it. That is what makes it safe to
+    override the user, and why the equivalent setting is still off by default
+    for a bare Docker run, where the port is the only way in and is
+    unauthenticated.
+    """
+    return replace(general, enable_web_server=True, dashboard=True)
+
+
 SettingsT = TypeVar("SettingsT")
 
 
@@ -365,23 +386,19 @@ class AddonAppConfig(AppConfig):
             for device_type in str(self._option("device_types", "")).split(",")
             if device_type.strip()
         ]
-        general = replace(
-            defaults,
-            device_types=device_types or defaults.device_types,
-            # The add-on panel links to the built-in web UI, so it is always
-            # served; its config editor is for config files only.
-            enable_web_server=True,
-            web_config_enabled=False,
-            # The add-on's sidebar panel *is* the dashboard, so there is no
-            # option to turn it off: doing so would leave a panel that opens
-            # onto nothing. Unlike a bare Docker run it costs nothing to serve
-            # either, because Home Assistant authenticates every ingress
-            # request. Writing is on by default and can be turned off.
-            dashboard=True,
-            dashboard_allow_write=True,
-            signal=_apply_options(
-                defaults.signal, self._options, _GLOBAL_SIGNAL_FIELDS
-            ),
+        general = _serve_the_panel(
+            replace(
+                defaults,
+                device_types=device_types or defaults.device_types,
+                # The config editor is for config files only, and in this mode
+                # there is none.
+                web_config_enabled=False,
+                # Writing is on by default and can be turned off.
+                dashboard_allow_write=True,
+                signal=_apply_options(
+                    defaults.signal, self._options, _GLOBAL_SIGNAL_FIELDS
+                ),
+            )
         )
         return _apply_options(general, self._options, _GENERAL_FIELDS)
 
@@ -561,6 +578,36 @@ def _warn_ignored_options(options: Options) -> None:
             logger.warning(message)
 
 
+class AddonIniAppConfig(IniAppConfig):
+    """A user's own ``config.ini``, read with the add-on's web settings.
+
+    The file decides everything except whether the web server and dashboard
+    run — see :func:`_serve_the_panel`. Without this the file's defaults
+    applied, and since ``DASHBOARD_ENABLED`` defaults off for a bare Docker
+    run, every add-on user with a custom config file got a sidebar panel
+    serving ``{"error": "Not Found"}``.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._warned = False
+
+    def general(self) -> GeneralSettings:
+        general = _serve_the_panel(super().general())
+        overridden = self.declared_general_keys("enable_web_server", "dashboard")
+        if overridden and not self._warned:
+            self._warned = True
+            logger.warning(
+                "Ignoring %s from %s: the add-on serves the dashboard on its "
+                "sidebar panel and the Supervisor watchdog polls the same "
+                "port, so neither can be turned off here. Set "
+                "DASHBOARD_ALLOW_WRITE = False for a read-only dashboard.",
+                " and ".join(overridden),
+                self.path,
+            )
+        return general
+
+
 def load_config(
     options: Options,
     supervisor: SupervisorClient | None = None,
@@ -569,7 +616,8 @@ def load_config(
     """Pick the add-on's configuration source.
 
     The add-on options unless the user pointed the add-on at their own config
-    file, in which case that file takes over completely.
+    file, in which case that file takes over — everything except the web
+    settings the add-on's manifest depends on.
     """
     path = custom_config_path(options, config_dir)
     if path is None:
@@ -577,4 +625,4 @@ def load_config(
 
     logger.info("Using custom config file: %s", path)
     _warn_ignored_options(options)
-    return IniAppConfig.from_file(path)
+    return AddonIniAppConfig.from_file(path)

--- a/src/astrameter/config/addon_test.py
+++ b/src/astrameter/config/addon_test.py
@@ -373,6 +373,59 @@ def test_custom_config_warns_about_ignored_ui_options(tmp_path, caplog):
     assert "mqtt_uri is ignored" in caplog.text
 
 
+def _custom(tmp_path, caplog, body, level="WARNING"):
+    """Load *body* as the add-on's custom config file and return its general()."""
+    (tmp_path / "my.ini").write_text(body, encoding="utf-8")
+    with caplog.at_level(level):
+        cfg = addon.load_config(
+            {**BASE_OPTIONS, "custom_config": "my.ini"},
+            FakeSupervisor(),
+            config_dir=str(tmp_path),
+        )
+        return cfg.general()
+
+
+def test_custom_config_still_serves_the_dashboard(tmp_path, caplog):
+    """A file predating the dashboard must not leave the panel on a 404.
+
+    ``DASHBOARD_ENABLED`` is off by default for a bare Docker run, where the
+    web port is unauthenticated. Under the add-on the panel and the watchdog
+    both depend on it, so the file's default cannot be allowed to decide.
+    """
+    general = _custom(tmp_path, caplog, "[GENERAL]\nDEVICE_TYPE = ct003\n")
+
+    assert general.dashboard is True
+    assert general.enable_web_server is True
+    # The file never mentioned either key, so there is nothing to warn about.
+    assert "Ignoring" not in caplog.text
+
+
+def test_custom_config_cannot_turn_the_dashboard_or_web_server_off(tmp_path, caplog):
+    general = _custom(
+        tmp_path,
+        caplog,
+        "[GENERAL]\nDASHBOARD_ENABLED = False\nENABLE_WEB_SERVER = False\n",
+    )
+
+    assert general.dashboard is True
+    assert general.enable_web_server is True
+    # Named so the user can find them, and told what to reach for instead.
+    assert "ENABLE_WEB_SERVER and DASHBOARD_ENABLED" in caplog.text
+    assert "DASHBOARD_ALLOW_WRITE" in caplog.text
+
+
+def test_custom_config_keeps_the_rest_of_its_dashboard_settings(tmp_path, caplog):
+    """Only *whether* it runs is forced — what it may do stays the file's."""
+    general = _custom(
+        tmp_path,
+        caplog,
+        "[GENERAL]\nDASHBOARD_ALLOW_WRITE = True\nDASHBOARD_DIRECT_ACCESS = True\n",
+    )
+
+    assert general.dashboard_allow_write is True
+    assert general.dashboard_direct_access is True
+
+
 def test_wait_for_home_assistant_returns_once_the_api_answers():
     class LateSupervisor(FakeSupervisor):
         def home_assistant_ready(self) -> bool:

--- a/src/astrameter/config/ini_config.py
+++ b/src/astrameter/config/ini_config.py
@@ -48,6 +48,16 @@ class IniAppConfig(AppConfig):
         config.read(path)
         return cls(config, path)
 
+    def declared_general_keys(self, *fields: str) -> list[str]:
+        """Which of *fields* the file actually sets, named as its INI keys.
+
+        A backend that overrides a setting uses this to tell a user their
+        value is being ignored, without also nagging the majority whose file
+        never mentioned it.
+        """
+        keys = [general_key(field) for field in fields]
+        return [key for key in keys if self._config.has_option(GENERAL_SECTION, key)]
+
     def general(self) -> GeneralSettings:
         config = self._config
         defaults = GeneralSettings()
@@ -298,6 +308,17 @@ _GENERAL_KEY_OVERRIDES = {
     "device_types": "DEVICE_TYPE",
     "dashboard": "DASHBOARD_ENABLED",
 }
+
+
+def general_key(field: str) -> str:
+    """The ``[GENERAL]`` key backing *field* of :class:`GeneralSettings`.
+
+    Lets another backend name a key in a message without hardcoding it, so a
+    rename here cannot leave that message pointing at a key nobody reads.
+    """
+    return _GENERAL_KEY_OVERRIDES.get(field, field.upper())
+
+
 _SIGNAL_KEY_OVERRIDES = {
     "smooth_alpha": "SMOOTH_TARGET_ALPHA",
     "offsets": "POWER_OFFSET",

--- a/src/astrameter/config/ini_config_test.py
+++ b/src/astrameter/config/ini_config_test.py
@@ -253,3 +253,14 @@ BALANCE_GAIN = 0.44
     )
     assert cfg.ct("ct003") == CtSettings()
     assert _round_trip(cfg).ct("ct003") == CtSettings()
+
+
+def test_declared_general_keys_reports_only_what_the_file_sets():
+    """`dashboard` is not `DASHBOARD`, so the lookup goes through the map."""
+    cfg = config("[GENERAL]\nDASHBOARD_ENABLED = False\n")
+
+    assert cfg.declared_general_keys("dashboard") == ["DASHBOARD_ENABLED"]
+    assert cfg.declared_general_keys("enable_web_server") == []
+    assert cfg.declared_general_keys("enable_web_server", "dashboard") == [
+        "DASHBOARD_ENABLED"
+    ]


### PR DESCRIPTION
The add-on's sidebar panel opened onto `{"error": "Not Found"}` for every user with a `custom_config` file. Surfaced while answering a question about [#589](https://github.com/tomquist/AstraMeter/issues/589), whose reporter has exactly that setup.

## What went wrong

`ha_addon/config.yaml` declares ingress on the web port and points the Supervisor watchdog at `/health` there. Neither is conditional on the configuration — but the code saying so lived *inside* `AddonAppConfig`, and `custom_config` skips that branch entirely: `load_config` hands the whole configuration to the INI backend.

So `DASHBOARD_ENABLED` decided it instead, and that defaults **off**. For a good reason that does not apply here: a bare Docker run serves the page on an unauthenticated port, so it has to be a deliberate act. Under the add-on the panel sits behind Home Assistant's login, and the plain port stays refused unless `DASHBOARD_DIRECT_ACCESS` opts into it.

No existing file can carry the key — it only exists in the unreleased version — so **every** add-on user with a custom config file was affected, not an unlucky few.

### A second bug it closes

`ENABLE_WEB_SERVER = False` was worse than a dead panel: it takes the watchdog's `/health` endpoint with it, so the Supervisor restarts the add-on for being unreachable. A restart loop nobody would have traced back to that key.

## The fix

One function, applied to every add-on configuration source:

```python
def _serve_the_panel(general: GeneralSettings) -> GeneralSettings:
    return replace(general, enable_web_server=True, dashboard=True)
```

`AddonAppConfig` and the new `AddonIniAppConfig` both call it, so the guided and custom-config paths cannot drift apart again — which is the actual defect here, not the default itself.

## What is still the file's

Only *whether* the dashboard runs is forced. `DASHBOARD_ALLOW_WRITE` and `DASHBOARD_DIRECT_ACCESS` are read as before.

Worth knowing: both default to `False` in a file, so a custom-config user gets a **read-only** dashboard where a guided-setup user gets a writable one. Left as-is rather than widening the change, but now stated in `docs/dashboard.md` so it is not a surprise.

## The warning

A file that sets either key is told it is ignored — but only when it *actually sets* it. Comparing values instead would have nagged the majority whose file never mentioned either, including the reporter in #589.

The keys are named through the same map that renders them (`dashboard` → `DASHBOARD_ENABLED`, not `DASHBOARD`), via a new `declared_general_keys` on `IniAppConfig`, so a rename cannot leave the message pointing at a key nobody reads.

```
Ignoring ENABLE_WEB_SERVER and DASHBOARD_ENABLED from /config/astrameter.ini: the add-on
serves the dashboard on its sidebar panel and the Supervisor watchdog polls the same port,
so neither can be turned off here. Set DASHBOARD_ALLOW_WRITE = False for a read-only dashboard.
```

## Testing

Reproduced first with the reporter's exact config from #589 through the add-on's own loader — `dashboard: False`, and a route table holding nothing but `/health`, `/api` and the catch-all that returns the 404. After the change: `dashboard: True` and the full dashboard route table.

Three tests cover it, plus one for the key lookup:

- a file with no dashboard keys (the #589 shape) still serves the dashboard, and warns about nothing
- explicit `False` for both keys is overridden, and the warning names both
- `DASHBOARD_ALLOW_WRITE` / `DASHBOARD_DIRECT_ACCESS` from the file still apply

`ruff format`, `ruff check`, `mypy` (131 files) clean. **1375 passed, 77 skipped.** `cd web && npm run check` green. The C++ host-protocol tests could not run in my sandbox — the googletest tarball download is blocked by the proxy — but nothing here touches the mirror.

No parity work: the add-on config backend is Python-only by design, since an ESPHome device compiles its config into firmware.

**No changelog bullet.** The dashboard's `## Next` entry already promises "Always available in the Home Assistant add-on, straight from the sidebar" — this makes that true. #577 is unreleased, so no shipped version ever had the broken behaviour and a bullet would describe a bug users never met.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CWw7pRCh73ZpbEMwc66TqA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Home Assistant add-on now always enables the web server and dashboard.
  * Custom configuration files can still control dashboard write access and direct access.
  * Dashboard settings default to read-only unless write access is explicitly enabled.

* **Documentation**
  * Clarified which dashboard and web server settings apply to add-on and custom configurations.
  * Added guidance about warnings when forced settings are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->