### PR TITLE
Retarget pull requests opened against main onto develop

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Why
+
+<!-- The problem this solves, from a user's point of view. The diff already
+     shows what changed; explain what made it worth changing. -->
+
+## Checklist
+
+- [ ] Base branch is `develop`, not `main`
+- [ ] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest`
+- [ ] Python ↔ ESPHome parity held for shared CT002 behaviour, or does not apply ([CONTRIBUTING.md](https://github.com/tomquist/AstraMeter/blob/develop/CONTRIBUTING.md))
+- [ ] `web/` changes: rebuilt the dashboard bundle (`cd web && npm run build:dashboard`) and committed it
+- [ ] User-visible change: one bullet under `## Next` in [CHANGELOG.md](https://github.com/tomquist/AstraMeter/blob/develop/CHANGELOG.md)

--- a/.github/workflows/pr-base-guard.yml
+++ b/.github/workflows/pr-base-guard.yml
@@ -1,0 +1,84 @@
+name: PR base guard
+
+# Retargets feature work opened against `main` onto `develop` (CONTRIBUTING.md
+# explains why they land there in the first place).
+#
+# `pull_request_target`, not `pull_request`, because fork pull requests get a
+# read-only token and could not retarget themselves. It only calls the API —
+# the PR's code is never checked out.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: pr-base-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  base-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            // Maintainers target main deliberately — release merges, hotfixes,
+            // repairs to CI that only take effect on the default branch.
+            const maintainer = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            if (maintainer.includes(pr.author_association)) {
+              core.info(`Opened by ${pr.author_association} — base left alone.`);
+              return;
+            }
+
+            const target = 'develop';
+            core.info(`Retargeting #${pr.number} from main onto ${target}.`);
+            try {
+              await github.rest.pulls.update({
+                ...context.repo,
+                pull_number: pr.number,
+                base: target,
+              });
+            } catch (error) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: pr.number,
+                body: [
+                  `This pull request targets \`main\`, but feature work is merged into ` +
+                  `\`${target}\` (see [CONTRIBUTING.md](https://github.com/tomquist/AstraMeter/blob/develop/CONTRIBUTING.md)).`,
+                  '',
+                  `Retargeting it automatically failed: ${error.message}`,
+                  '',
+                  `Please change the base branch to \`${target}\` using the **Edit** ` +
+                  'button next to the pull request title.',
+                ].join('\n'),
+              });
+              core.setFailed(`Could not retarget onto ${target}: ${error.message}`);
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: pr.number,
+              body: [
+                `I moved this pull request onto \`${target}\`, where feature work ` +
+                'lands — `main` only ever receives releases, and GitHub offers it ' +
+                'as the base by default, so this is nothing you did wrong.',
+                '',
+                'If you branched off `main`, the diff above now carries commits ' +
+                `that are not yours. Please rebase onto \`${target}\`:`,
+                '',
+                '```sh',
+                'git fetch origin',
+                `git rebase --onto origin/${target} origin/main`,
+                'git push --force-with-lease',
+                '```',
+                '',
+                'If you branched off `develop` to begin with, there is nothing to do.',
+              ].join('\n'),
+            });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@ not fused with an arbitrary weight).
 ## Branches and pull requests
 
 Open pull requests against **`develop`**, never `main` (see `CONTRIBUTING.md`).
+`main` takes release merges and maintainer hotfixes only — never agent work,
+and the guard below exempts maintainers, so nothing will catch it for you.
 Tooling offers `main` as the base, so set it yourself;
 `.github/workflows/pr-base-guard.yml` retargets what slips through, at the cost
 of a round-trip.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,17 @@ error (control quality, transients included), pairing with
 `battery_travel_w_per_h` as the effort term (the two LQR terms are kept separate,
 not fused with an arbitrary weight).
 
+## Branches and pull requests
+
+Open pull requests against **`develop`**, never `main` (see `CONTRIBUTING.md`).
+Tooling offers `main` as the base, so set it yourself;
+`.github/workflows/pr-base-guard.yml` retargets what slips through, at the cost
+of a round-trip.
+
+GitHub reads that workflow and `.github/pull_request_template.md` from the
+**default branch**, so edits to either do nothing until they reach `main` at the
+next release.
+
 ## Changelog
 
 For user-facing work, contribute **exactly one bullet under `## Next`** that summarizes the **overall** outcome of *that change*. The unit is the **change (feature/fix), not the branch or PR**: a single change may span several branches or PRs, and they all **edit the same bullet** rather than each adding their own. `## Next` accumulates **one bullet per change**, so it normally holds **several** bullets at once (one for each change heading into the next release) — multiple bullets under `## Next` are correct and expected, never a violation. What you must not do is author **more than one** bullet for **your own** change, or consolidate/remove a bullet belonging to a *different* change. **Add** your bullet when you first document the change; on **later iterations** (more commits, or a follow-up PR for the same change), **edit that same bullet** if the scope or wording shifts—do **not** append extra bullets for each follow-up. Skip `CHANGELOG.md` entirely when nothing users would notice changes (refactors, tests-only, etc.).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,14 @@ The `esphome` backend uses a "test-hooks" binary (`test.e2e.host.yaml`) that com
 - Base feature work on **`develop`** and open PRs against **`develop`**.
 - Releases are merged to **`main`** as appropriate for the project maintainer.
 
+`main` is the repository default branch — Home Assistant's Supervisor clones
+the add-on from there, so it has to stay the branch a fresh install sees. That
+also means GitHub prefills `main` as the base of every new pull request, which
+is the wrong one for feature work. Change the base to `develop` when you open
+the PR; if you forget, `.github/workflows/pr-base-guard.yml` moves it for you
+and leaves a comment. Maintainers are exempt — `main` still takes release
+merges and the occasional hotfix from them.
+
 ## Changelog
 
 For user-visible changes, add or update **the bullet for your change** under **`## Next`** in [CHANGELOG.md](CHANGELOG.md). The unit is the **change, not the branch or PR** — a change that spans several branches or PRs edits the *same* bullet rather than adding one each. `## Next` accumulates **one bullet per change** (so it normally holds several at once); add yours once, edit it on later iterations, and never consolidate or remove a bullet belonging to a *different* change (see [AGENTS.md](AGENTS.md) — Changelog).


### PR DESCRIPTION
## Why

Feature work belongs on `develop`, but GitHub prefills `main` as the base of every new pull request because `main` is the default branch — and it has to stay that way, since Home Assistant's Supervisor clones the add-on from the default branch. Contributors therefore target the wrong branch by default rather than by mistake, and every one of those costs a round-trip to notice and fix by hand.

`.github/workflows/pr-base-guard.yml` moves such pull requests onto `develop` and leaves a comment explaining the move, with the commands to rebase if the branch was cut from `main`. Maintainers (`OWNER` / `MEMBER` / `COLLABORATOR`) are exempt, so release merges and hotfixes into `main` are untouched. It only runs on `main`-based pull requests, and fails only if the retarget itself fails — the one case where a wrongly based pull request would otherwise sit there mergeable.

Also adds a pull request template stating the base branch, and documents the rule in `CONTRIBUTING.md` and `AGENTS.md`.

### Why this targets `main`

GitHub reads `pull_request_target` workflows and `pull_request_template.md` from the **default branch** only, so merging this to `develop` would leave it inert until the next release. This branch is cut from `main` and carries only the four files, so it does not drag unreleased `develop` work along with it. Nothing under `ha_addon/` or `repository.yaml` changes, so the add-on is unaffected and nothing re-installs for existing users.

Please merge `main` into `develop` afterwards so the two do not drift.

## Checklist

- [ ] Base branch is `develop`, not `main` — **deliberate exception**, see above; this is the bootstrap case the guard itself exempts maintainers for
- [ ] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest` — no Python changed; the workflow's script was dry-run against a stubbed GitHub API across author associations (`OWNER`/`COLLABORATOR` pass through, `CONTRIBUTOR`/`FIRST_TIME_CONTRIBUTOR`/`NONE` retargeted) and the rendered comment body checked
- [x] Python ↔ ESPHome parity held for shared CT002 behaviour, or does not apply — does not apply
- [x] `web/` changes: rebuilt the dashboard bundle — none
- [x] User-visible change: one bullet under `## Next` in CHANGELOG.md — not user-visible, contributor tooling only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTmphENRAd7rYysCVMb2aB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull request base-branch handling to redirect eligible contributions to the development branch and provide status guidance.
  * Added notifications when branch retargeting succeeds or requires action.

* **Documentation**
  * Added contributor guidance covering branch selection, pull request targeting, releases, and hotfixes.
  * Added a pull request template with change descriptions and validation checklists.
  * Documented when workflow and template updates become active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->