### PR TITLE
Remove Last Seen sensor to prevent logbook spam (issue #576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Removed** the per-battery **Last Seen** sensor, which changed on every poll and buried the Home Assistant logbook under one entry per second. Use the Online sensor, Poll Interval, or any battery entity's own last-updated time instead ([#576](https://github.com/tomquist/astrameter/issues/576)).
+
 - **Fixed** the per-battery **Phase** sensor staying empty, and the Home Assistant log filling with "invalid option" warnings, for batteries in combined / whole-home mode ([#580](https://github.com/tomquist/astrameter/issues/580), [#596](https://github.com/tomquist/astrameter/pull/596)).
 
 - **Changed** the CT002/CT003 **Poll Interval** sensor to count every poll a battery sends rather than only the ones AstraMeter answered, and **added** an **Answer Interval** sensor for the reply rate. The two are identical until you set `DEDUPE_TIME_WINDOW`, which is exactly when you need both to tell a battery that slowed down apart from one that is simply being answered less often. A battery whose polls that window suppresses is also no longer at risk of being dropped as if it had gone silent. The dashboard and the ESPHome component report the same pair ([#589](https://github.com/tomquist/astrameter/issues/589), [#591](https://github.com/tomquist/astrameter/pull/591)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Breaking:** **removed** the per-battery **Last Seen** sensor — it changed on every poll and buried the Home Assistant logbook under one entry per second. Automations that used it should switch to the battery's entities going *unavailable*, or to `last_reported`; see [docs/mqtt-insights.md](docs/mqtt-insights.md#is-a-battery-still-reporting-home-assistant) ([#576](https://github.com/tomquist/astrameter/issues/576)).
+- **Breaking:** **removed** the per-battery **Last Seen** sensor — it changed on every poll and buried the Home Assistant logbook under one entry per second. Automations that used it should switch to the battery's entities going *unavailable*, or to `last_reported`; see [docs/mqtt-insights.md](docs/mqtt-insights.md#is-a-battery-still-reporting-home-assistant) ([#576](https://github.com/tomquist/astrameter/issues/576), [#597](https://github.com/tomquist/astrameter/pull/597)).
 
 - **Fixed** the per-battery **Phase** sensor staying empty, and the Home Assistant log filling with "invalid option" warnings, for batteries in combined / whole-home mode ([#580](https://github.com/tomquist/astrameter/issues/580), [#596](https://github.com/tomquist/astrameter/pull/596)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Removed** the per-battery **Last Seen** sensor, which changed on every poll and buried the Home Assistant logbook under one entry per second. Use the Online sensor, Poll Interval, or any battery entity's own last-updated time instead ([#576](https://github.com/tomquist/astrameter/issues/576)).
+- **Removed** the per-battery **Last Seen** sensor, which changed on every poll and buried the Home Assistant logbook under one entry per second. A battery that stops reporting still turns all of its entities *unavailable*, and [docs/mqtt-insights.md](docs/mqtt-insights.md#is-a-battery-still-reporting-home-assistant) shows how to read the timestamp itself ([#576](https://github.com/tomquist/astrameter/issues/576)).
 
 - **Fixed** the per-battery **Phase** sensor staying empty, and the Home Assistant log filling with "invalid option" warnings, for batteries in combined / whole-home mode ([#580](https://github.com/tomquist/astrameter/issues/580), [#596](https://github.com/tomquist/astrameter/pull/596)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Removed** the per-battery **Last Seen** sensor, which changed on every poll and buried the Home Assistant logbook under one entry per second. A battery that stops reporting still turns all of its entities *unavailable*, and [docs/mqtt-insights.md](docs/mqtt-insights.md#is-a-battery-still-reporting-home-assistant) shows how to read the timestamp itself ([#576](https://github.com/tomquist/astrameter/issues/576)).
+- **Breaking:** **removed** the per-battery **Last Seen** sensor — it changed on every poll and buried the Home Assistant logbook under one entry per second. Automations that used it should switch to the battery's entities going *unavailable*, or to `last_reported`; see [docs/mqtt-insights.md](docs/mqtt-insights.md#is-a-battery-still-reporting-home-assistant) ([#576](https://github.com/tomquist/astrameter/issues/576)).
 
 - **Fixed** the per-battery **Phase** sensor staying empty, and the Home Assistant log filling with "invalid option" warnings, for batteries in combined / whole-home mode ([#580](https://github.com/tomquist/astrameter/issues/580), [#596](https://github.com/tomquist/astrameter/pull/596)).
 

--- a/docs/mqtt-insights.md
+++ b/docs/mqtt-insights.md
@@ -129,7 +129,7 @@ Example payload:
 | `active` | bool | `false` when this battery is paused (steered to 0 W). |
 | `poll_interval` | number/null | Measured seconds between this battery's polls, counting every poll it sends. |
 | `answer_interval` | number/null | Measured seconds between the replies it actually receives. Matches `poll_interval` unless `DEDUPE_TIME_WINDOW` is suppressing replies. |
-| `last_seen` | string | ISO-8601 UTC timestamp of this update. No Home Assistant entity: it changes on every poll, and HA logs a timestamp sensor's every change to the logbook. HA already records the same thing as each entity's own last-updated time. |
+| `last_seen` | string | ISO-8601 UTC timestamp of this update. No Home Assistant entity — see [Is a battery still reporting?](#is-a-battery-still-reporting-home-assistant). |
 | `manual_target` | number/null | Active manual override in watts, or `null` when on automatic. |
 | `auto_target` | bool | `true` = automatic control; `false` = manual override in effect. |
 | `distribution_weight` | number | Relative share of demand when splitting across batteries (ratio-based; `1.0` neutral). |
@@ -171,7 +171,7 @@ Availability companion:
 | `grid_power` | object | Per-phase grid power forwarded to this battery plus `total` (watts; + = import). |
 | `active` | bool | `false` when the battery is marked inactive. |
 | `poll_interval` | number/null | Measured seconds between polls. |
-| `last_seen` | string | ISO-8601 UTC timestamp. No Home Assistant entity — see the note on the CT002 field above. |
+| `last_seen` | string | ISO-8601 UTC timestamp. No Home Assistant entity — see [Is a battery still reporting?](#is-a-battery-still-reporting-home-assistant). |
 
 | Topic | Retain | Payload |
 |---|---|---|
@@ -304,6 +304,69 @@ The CT device itself also exposes a config switch:
 
 Each of these controls publishes its set-command **retained**, so Home Assistant
 restores your values across an AstraMeter restart without any extra configuration.
+
+## Is a battery still reporting? (Home Assistant)
+
+There is deliberately **no "Last Seen" entity**. Its value changed on every poll,
+and Home Assistant records a timestamp sensor's every change in the logbook, so a
+battery polling once a second buried the logbook under its own heartbeat. Home
+Assistant already tracks the same thing for you.
+
+**Unavailable means "not reporting".** When a battery stops polling, AstraMeter
+drops it — by default after it misses ~2 of its own poll cycles, or after
+`CONSUMER_TTL` seconds if you set a fixed window
+([CT002 basic configuration](ct002.md#basic-configuration); 120 s for a Shelly
+battery) — publishes `offline` on its availability topic, and
+**every entity of that battery turns Unavailable**. That is the signal to alert
+on, and it needs no template:
+
+```yaml
+alias: AstraMeter – battery stopped reporting
+triggers:
+  - trigger: state
+    entity_id: sensor.astrameter_consumer_hmj_2_aabbccddeeff_poll_interval  # replace with yours
+    to: unavailable
+    for:
+      minutes: 5
+actions:
+  - action: notify.persistent_notification
+    data:
+      message: The battery has not reported to AstraMeter for five minutes.
+```
+
+**The timestamp itself is on every entity.** Home Assistant stamps each state
+write with `last_reported`, which advances even when the value is unchanged —
+exactly what Last Seen used to publish. Any entity of the battery will do:
+
+```jinja
+{{ states.sensor.astrameter_consumer_hmj_2_aabbccddeeff_poll_interval.last_reported }}
+```
+
+Seconds since the battery was last heard from:
+
+```jinja
+{{ (now() - states.sensor.astrameter_consumer_hmj_2_aabbccddeeff_poll_interval.last_reported).total_seconds() | round }}
+```
+
+Two things to know when you use these:
+
+- `last_changed` / `last_updated` — the **Last changed** line in an entity's
+  more-info dialog — only move when the value itself changes, so a battery
+  reporting the same wattage twice does not bump them. `last_reported` is the one
+  that follows every poll.
+- A template re-renders when an entity's state **changes**, not when it merely
+  re-reports the same value. Including `now()` (as above) also refreshes the
+  template at the start of every minute, which is what keeps an age calculation
+  live.
+
+**For the polling rate rather than recency**, use the **Poll Interval** and
+**Answer Interval** sensors. They carry a unit, so Home Assistant treats them as
+continuous and keeps them out of the logbook however fast they change.
+
+If you still want a Last Seen entity of your own, a
+[template sensor](https://www.home-assistant.io/integrations/template/) over
+`last_reported` gives you one — but exclude it under `recorder:` → `exclude:`,
+or it floods your logbook exactly as the built-in one did.
 
 ## Optional: Marstek mobile app (live MQTT)
 

--- a/docs/mqtt-insights.md
+++ b/docs/mqtt-insights.md
@@ -129,7 +129,7 @@ Example payload:
 | `active` | bool | `false` when this battery is paused (steered to 0 W). |
 | `poll_interval` | number/null | Measured seconds between this battery's polls, counting every poll it sends. |
 | `answer_interval` | number/null | Measured seconds between the replies it actually receives. Matches `poll_interval` unless `DEDUPE_TIME_WINDOW` is suppressing replies. |
-| `last_seen` | string | ISO-8601 UTC timestamp of this update. |
+| `last_seen` | string | ISO-8601 UTC timestamp of this update. No Home Assistant entity: it changes on every poll, and HA logs a timestamp sensor's every change to the logbook. HA already records the same thing as each entity's own last-updated time. |
 | `manual_target` | number/null | Active manual override in watts, or `null` when on automatic. |
 | `auto_target` | bool | `true` = automatic control; `false` = manual override in effect. |
 | `distribution_weight` | number | Relative share of demand when splitting across batteries (ratio-based; `1.0` neutral). |
@@ -171,7 +171,7 @@ Availability companion:
 | `grid_power` | object | Per-phase grid power forwarded to this battery plus `total` (watts; + = import). |
 | `active` | bool | `false` when the battery is marked inactive. |
 | `poll_interval` | number/null | Measured seconds between polls. |
-| `last_seen` | string | ISO-8601 UTC timestamp. |
+| `last_seen` | string | ISO-8601 UTC timestamp. No Home Assistant entity — see the note on the CT002 field above. |
 
 | Topic | Retain | Payload |
 |---|---|---|

--- a/esphome/components/ct002/ha_discovery.cpp
+++ b/esphome/components/ct002/ha_discovery.cpp
@@ -89,7 +89,7 @@ void add_power_sensor(JsonObject components, const std::string &key, const std::
 std::pair<std::string, std::string> build_ct002_consumer_discovery(
     const std::string &base_topic, const std::string &device_id,
     const std::string &consumer_id, const std::string &ha_prefix,
-    const std::string &device_type, bool efficiency_rotation) {
+    const std::string &device_type, bool efficiency_rotation, bool retire_removed) {
   const std::string safe_dev = sanitize_id(device_id);
   const std::string safe_cid = sanitize_id(consumer_id);
   const std::string node_id = "astrameter_ct002_" + safe_dev + "_" + safe_cid;
@@ -182,15 +182,21 @@ std::pair<std::string, std::string> build_ct002_consumer_discovery(
       c["entity_category"] = "diagnostic";
     }
 
-    // Last seen timestamp
-    JsonObject ls = components["last_seen"].to<JsonObject>();
-    ls["platform"] = "sensor";
-    ls["unique_id"] = uid_prefix + "_last_seen";
-    ls["name"] = "Last Seen";
-    ls["device_class"] = "timestamp";
-    ls["state_topic"] = state_topic;
-    ls["value_template"] = "{{ value_json.last_seen }}";
-    ls["entity_category"] = "diagnostic";
+    // Retired entities. HA keeps an entity that merely stops appearing in a
+    // later discovery payload, so a dropped component has to be published once
+    // with a platform-only config — which HA reads as "remove this entity" —
+    // before the payload omits it for good. Mirrors discovery.py's
+    // RETIRED_COMPONENTS / build_retirement_payload.
+    //
+    // "Last Seen" was a wall-clock timestamp stamped at publish time, so it
+    // changed on every poll, and a `timestamp` sensor carries neither a unit
+    // nor a state class — the two attributes HA's logbook uses to recognise a
+    // continuous sensor. Every poll became a logbook row (issue #576). The
+    // `last_seen` field stays in the state payload.
+    if (retire_removed) {
+      JsonObject ls = components["last_seen"].to<JsonObject>();
+      ls["platform"] = "sensor";
+    }
 
     // Poll interval
     JsonObject pi = components["poll_interval"].to<JsonObject>();

--- a/esphome/components/ct002/ha_discovery.h
+++ b/esphome/components/ct002/ha_discovery.h
@@ -27,10 +27,16 @@ std::string sanitize_id(const std::string &value);
 // battery device owned by another bridge (e.g. hm2mqtt). The device is
 // identified by its own namespaced `identifiers` and linked to the meter via
 // `via_device`. See the note in discovery.py and issue #438.
+//
+// retire_removed adds the platform-only stanza that tells HA to delete the
+// entities this payload no longer carries (discovery.py's RETIRED_COMPONENTS).
+// Publish that variant once, then the normal payload — an entity that merely
+// disappears from a discovery payload lives on in HA.
 std::pair<std::string, std::string> build_ct002_consumer_discovery(
     const std::string &base_topic, const std::string &device_id,
     const std::string &consumer_id, const std::string &ha_prefix,
-    const std::string &device_type = "", bool efficiency_rotation = false);
+    const std::string &device_type = "", bool efficiency_rotation = false,
+    bool retire_removed = false);
 
 // CT002 device-level HA Discovery payload (parent device, smooth_target
 // sensor, active_control binary_sensor, consumer_count diagnostic, and —

--- a/esphome/components/ct002/mqtt_insights.cpp
+++ b/esphome/components/ct002/mqtt_insights.cpp
@@ -280,10 +280,22 @@ void MqttInsightsComponent::publish_consumer_event_(const std::string &consumer_
         this->discovered_consumers_.find(consumer_id) == this->discovered_consumers_.end();
     if (first_sight) {
       this->discovered_consumers_.insert(consumer_id);
+      const bool rotation =
+          this->ct002_ != nullptr && this->ct002_->efficiency_rotation_enabled();
+      // Retire entities this payload no longer carries first (issue #576) —
+      // HA keeps an entity that merely stops appearing — then publish the
+      // current payload, so the retained discovery message is the current one.
+      // Mirrors service.py::_publish_discovery. Scoped so the ~7 KB retirement
+      // payload is freed before the real one is built.
+      {
+        auto [retire_topic, retire_payload] = build_ct002_consumer_discovery(
+            this->base_topic_, this->device_id_, consumer_id, this->ha_discovery_prefix_,
+            snap.device_type, rotation, /*retire_removed=*/true);
+        this->mqtt_->publish(retire_topic, retire_payload, 0, true);
+      }
       auto [topic, payload] = build_ct002_consumer_discovery(
           this->base_topic_, this->device_id_, consumer_id, this->ha_discovery_prefix_,
-          snap.device_type,
-          this->ct002_ != nullptr && this->ct002_->efficiency_rotation_enabled());
+          snap.device_type, rotation);
       this->mqtt_->publish(topic, payload, 0, true);
     }
   }

--- a/src/astrameter/mqtt_insights/discovery.py
+++ b/src/astrameter/mqtt_insights/discovery.py
@@ -31,6 +31,31 @@ def _system_availability(base_topic: str) -> dict:
     }
 
 
+# ── Retired components ────────────────────────────────────────────────────
+# Home Assistant keeps an entity that merely stops appearing in a later device
+# discovery payload, so anything we drop has to be retired explicitly: a
+# component config that is empty apart from ``platform`` reads as "remove this
+# entity".  ``build_retirement_payload`` produces that update; the service
+# publishes it right before the current payload, whose omission of the key then
+# leaves the retained discovery message up to date.
+#
+# ``last_seen`` was a wall-clock timestamp stamped at publish time, so it
+# changed on every poll — and a ``timestamp`` sensor can carry neither a unit
+# nor a state class, the two attributes HA's logbook uses to recognise a
+# continuous sensor.  Every poll therefore became a logbook row and a recorder
+# state (issue #576).  The field stays in the MQTT payload, and HA's own
+# ``last_reported`` on any entity of the device carries the same information.
+RETIRED_COMPONENTS: dict[str, str] = {"last_seen": "sensor"}
+
+
+def build_retirement_payload(payload: dict) -> dict:
+    """Copy of a discovery *payload* that also removes retired components."""
+    components = dict(payload["components"])
+    for key, platform in RETIRED_COMPONENTS.items():
+        components[key] = {"platform": platform}
+    return {**payload, "components": components}
+
+
 # ── Command topics ────────────────────────────────────────────────────────
 # One definition shared by the discovery payloads below, the service's
 # subscription/replay path, and the dashboard write path — a dashboard write
@@ -141,16 +166,7 @@ def build_ct002_consumer_discovery(
         }
         components[key] = comp
 
-    # Last seen (timestamp)
-    components["last_seen"] = {
-        "platform": "sensor",
-        "unique_id": f"{uid_prefix}_last_seen",
-        "name": "Last Seen",
-        "device_class": "timestamp",
-        "state_topic": state_topic,
-        "value_template": "{{ value_json.last_seen }}",
-        "entity_category": "diagnostic",
-    }
+    # No "Last Seen" sensor: see RETIRED_COMPONENTS above (issue #576).
 
     # Poll interval (EMA-smoothed seconds between consecutive polls)
     components["poll_interval"] = {
@@ -646,15 +662,7 @@ def build_shelly_battery_discovery(
         "entity_category": "diagnostic",
     }
 
-    components["last_seen"] = {
-        "platform": "sensor",
-        "unique_id": f"{uid_prefix}_last_seen",
-        "name": "Last Seen",
-        "device_class": "timestamp",
-        "state_topic": state_topic,
-        "value_template": "{{ value_json.last_seen }}",
-        "entity_category": "diagnostic",
-    }
+    # No "Last Seen" sensor: see RETIRED_COMPONENTS above (issue #576).
 
     # Poll interval (EMA-smoothed seconds between consecutive polls)
     components["poll_interval"] = {

--- a/src/astrameter/mqtt_insights/mqtt_insights_test.py
+++ b/src/astrameter/mqtt_insights/mqtt_insights_test.py
@@ -27,6 +27,7 @@ from .discovery import (
     build_ct002_consumer_discovery,
     build_ct002_device_discovery,
     build_powermeter_device_discovery,
+    build_retirement_payload,
     build_shelly_battery_discovery,
     build_shelly_device_discovery,
 )
@@ -94,8 +95,11 @@ def test_ct002_consumer_discovery_structure():
     assert "battery_ip" in comps
     assert "ct_type" in comps
     assert "ct_mac" in comps
-    assert "last_seen" in comps
     assert "poll_interval" in comps
+    # No Last Seen entity: it changed on every poll and, being a timestamp
+    # sensor, HA's logbook could not treat it as continuous, so every poll
+    # became a logbook row (issue #576).
+    assert "last_seen" not in comps
 
     # Poll interval sensor
     poll = comps["poll_interval"]
@@ -341,8 +345,8 @@ def test_shelly_battery_discovery_structure():
     comps = payload["components"]
     assert "grid_power_total" in comps
     assert "active" in comps
-    assert "last_seen" in comps
     assert "poll_interval" in comps
+    assert "last_seen" not in comps  # issue #576
     for power_key in (
         "grid_power_total",
         "grid_power_l1",
@@ -356,6 +360,38 @@ def test_shelly_battery_discovery_structure():
     assert poll["unit_of_measurement"] == "s"
     assert payload["availability_mode"] == "all"
     assert len(payload["availability"]) == 2
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        lambda: build_ct002_consumer_discovery(
+            "astrameter", "dev1", "aabbccddeeff", "homeassistant", device_type="HMJ-2"
+        ),
+        lambda: build_shelly_battery_discovery(
+            "astrameter", "shelly1", "192.168.1.100", "homeassistant"
+        ),
+    ],
+    ids=["ct002_consumer", "shelly_battery"],
+)
+def test_retirement_payload_removes_retired_entities(build):
+    """The retirement variant deletes dropped entities, keeps the rest intact."""
+    _topic, payload = build()
+    retirement = build_retirement_payload(payload)
+
+    # A component config that is empty apart from ``platform`` is how HA is
+    # told to remove an entity — anything else and it would be re-created.
+    assert retirement["components"]["last_seen"] == {"platform": "sensor"}
+    # Every other component, and the rest of the payload, is unchanged: the
+    # retirement update is a normal discovery payload, so it must not drop the
+    # device, origin or availability blocks.
+    for key, comp in payload["components"].items():
+        assert retirement["components"][key] == comp
+    assert retirement["device"] == payload["device"]
+    assert retirement["origin"] == payload["origin"]
+    assert retirement["availability"] == payload["availability"]
+    # The source payload keeps its own components map.
+    assert "last_seen" not in payload["components"]
 
 
 def test_shelly_device_discovery_structure():
@@ -1106,13 +1142,15 @@ async def test_publishes_ha_discovery_on_first_event(mqtt_broker):
                 sub,
                 discovery_msgs,
                 timeout=3,
-                stop=lambda _: len(discovery_msgs) >= 4,
+                stop=lambda _: len(discovery_msgs) >= 6,
             )
 
         # Expect: AstraMeter hub device (retained, now always published on
         # connect with a base-topic fallback id) + CT002 device discovery +
-        # consumer1 + consumer2 = 4 (no duplicate for the second consumer1 event)
-        assert len(discovery_msgs) == 4
+        # two publishes each for consumer1 and consumer2 (the retirement update
+        # for entities dropped in an upgrade, then the current payload) = 6 (no
+        # duplicate for the second consumer1 event)
+        assert len(discovery_msgs) == 6
         topics = [str(m.topic) for m in discovery_msgs]
         # Hub device discovery (retained, delivered on subscribe)
         assert any("astrameter_addon_" in t for t in topics)
@@ -1121,6 +1159,19 @@ async def test_publishes_ha_discovery_on_first_event(mqtt_broker):
         # Consumer-level discoveries
         assert any("consumer1" in t for t in topics)
         assert any("consumer2" in t for t in topics)
+
+        # Each consumer gets the retirement update first and the current
+        # payload second, so the retained message the broker keeps — the one a
+        # restarting HA replays — is the one without the retired entity.
+        for consumer in ("consumer1", "consumer2"):
+            payloads = [
+                json.loads(m.payload)
+                for m in discovery_msgs
+                if consumer in str(m.topic)
+            ]
+            assert len(payloads) == 2
+            assert payloads[0]["components"]["last_seen"] == {"platform": "sensor"}
+            assert "last_seen" not in payloads[1]["components"]
     finally:
         await service.stop()
 

--- a/src/astrameter/mqtt_insights/service.py
+++ b/src/astrameter/mqtt_insights/service.py
@@ -23,6 +23,7 @@ from .discovery import (
     build_ct002_consumer_discovery,
     build_ct002_device_discovery,
     build_powermeter_device_discovery,
+    build_retirement_payload,
     build_shelly_battery_discovery,
     build_shelly_device_discovery,
     consumer_command_topic,
@@ -627,6 +628,30 @@ class MqttInsightsService:
             except Exception:
                 logger.exception("Error publishing MQTT Insights event")
 
+    @staticmethod
+    async def _publish_discovery(
+        client: aiomqtt.Client,
+        topic: str,
+        payload: dict,
+        *,
+        retire: bool = False,
+    ) -> None:
+        """Publish a device discovery payload, retiring dropped entities first.
+
+        An entity that merely stops appearing in a discovery payload lives on in
+        Home Assistant, so payloads that used to carry one (see
+        ``RETIRED_COMPONENTS``) publish the retirement update first and the
+        current payload right after — the retained message the broker keeps is
+        then the current one.
+        """
+        if retire:
+            await client.publish(
+                topic,
+                payload=json.dumps(build_retirement_payload(payload)).encode(),
+                retain=True,
+            )
+        await client.publish(topic, payload=json.dumps(payload).encode(), retain=True)
+
     async def _handle_ct002_event(
         self,
         client: aiomqtt.Client,
@@ -711,9 +736,7 @@ class MqttInsightsService:
                     device_type=data.get("device_type", ""),
                     efficiency_rotation=bool(data.get("efficiency_rotation", False)),
                 )
-                await client.publish(
-                    topic, payload=json.dumps(payload).encode(), retain=True
-                )
+                await self._publish_discovery(client, topic, payload, retire=True)
 
     async def _handle_ct002_remove(
         self,
@@ -788,9 +811,7 @@ class MqttInsightsService:
                 topic, payload = build_shelly_battery_discovery(
                     base, did, ip_slug, cfg.ha_discovery_prefix
                 )
-                await client.publish(
-                    topic, payload=json.dumps(payload).encode(), retain=True
-                )
+                await self._publish_discovery(client, topic, payload, retire=True)
                 await self._publish_bridge(client, cfg)
 
     async def _handle_shelly_remove(


### PR DESCRIPTION
## Why

The per-battery **Last Seen** sensor published a wall-clock timestamp on every poll. Since Home Assistant's logbook records every state change of a timestamp sensor, a battery polling once per second created one logbook entry per second, burying the logbook under its own heartbeat and making it unusable for actual events.

Home Assistant already tracks the same information via `last_reported` on any entity of the device, which advances on every poll but is not recorded in the logbook. The battery becoming *unavailable* (when it stops reporting) is the actionable signal for automations.

This change removes the `last_seen` entity from Home Assistant discovery payloads while keeping the `last_seen` field in the MQTT state payload (for other consumers). It adds a retirement mechanism to explicitly delete the entity from existing Home Assistant instances, and documents the recommended alternatives in the MQTT Insights guide.

## Changes

- **discovery.py**: Removed `last_seen` sensor component from CT002 consumer and Shelly battery discovery payloads. Added `RETIRED_COMPONENTS` dict and `build_retirement_payload()` function to generate a retirement update that tells Home Assistant to delete dropped entities.
- **service.py**: Added `_publish_discovery()` helper that publishes a retirement update (with `retire=True`) before the current payload, ensuring the retained discovery message is the current one without the retired entity.
- **ha_discovery.cpp** (ESPHome): Mirrored the Python changes — removed the `last_seen` sensor config and added conditional retirement stanza when `retire_removed=true`.
- **mqtt_insights.cpp** (ESPHome): Updated to publish the retirement variant first, then the current payload, matching the Python service behavior.
- **mqtt_insights_test.py**: Updated assertions to verify `last_seen` is no longer in discovery components, and added `test_retirement_payload_removes_retired_entities()` to verify the retirement mechanism works correctly.
- **docs/mqtt-insights.md**: Added new section "Is a battery still reporting? (Home Assistant)" explaining how to detect stopped batteries via unavailability, how to access the timestamp via `last_reported`, and how to calculate seconds since last poll. Clarified that `last_seen` field remains in the MQTT payload.
- **CHANGELOG.md**: Added breaking change note.

## Checklist

- [x] Base branch is `develop`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest` passes
- [x] Python ↔ ESPHome parity held: both sides now omit `last_seen` from discovery and support the retirement mechanism
- [x] User-visible change documented in CHANGELOG.md under `## Next`

https://claude.ai/code/session_01Ru7frnrNc6RBYF5g3HfhHR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the per-battery **Last Seen** sensor from Home Assistant discovery.
  * The `last_seen` value remains available in MQTT state data.

* **Bug Fixes**
  * Automatically retires previously discovered Last Seen entities to prevent stale entities from remaining in Home Assistant.

* **Documentation**
  * Added guidance for monitoring battery reporting, including availability, `last_reported`, templates, and poll/answer interval sensors.
  * Documented alerting and timestamp behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->