### PR TITLE
Add Refoss/Meross energy monitor as source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Added** Refoss / Meross energy monitors (EM01P, EM06P, EM16P) as a power source (`[REFOSS]` or `[MEROSS]`) ([#598](https://github.com/tomquist/astrameter/pull/598)).
+
 - **Breaking:** **removed** the per-battery **Last Seen** sensor — it changed on every poll and buried the Home Assistant logbook under one entry per second. Automations that used it should switch to the battery's entities going *unavailable*, or to `last_reported`; see [docs/mqtt-insights.md](docs/mqtt-insights.md#is-a-battery-still-reporting-home-assistant) ([#576](https://github.com/tomquist/astrameter/issues/576), [#597](https://github.com/tomquist/astrameter/pull/597)).
 
 - **Fixed** the per-battery **Phase** sensor staying empty, and the Home Assistant log filling with "invalid option" warnings, for batteries in combined / whole-home mode ([#580](https://github.com/tomquist/astrameter/issues/580), [#596](https://github.com/tomquist/astrameter/pull/596)).
@@ -15,7 +17,6 @@
 - **Fixed** grid-power sources reporting in kilowatts being silently misread as watts, which made typical household readings round to ~0 W and left batteries idle with no error anywhere. Both the ESPHome component and the Home Assistant powermeter now respect the sensor's declared unit: kW (and MW/mW) values are converted to watts automatically, a sensor with a non-power unit (e.g. °C or kWh) is rejected with an explicit error, and the ESPHome firmware warns when an undeclared-unit sensor's readings look like kilowatts. If you previously worked around this with a manual ×1000 multiplier on a kW sensor, remove it — the value would now be scaled twice ([#39](https://github.com/tomquist/astrameter/issues/39), [#572](https://github.com/tomquist/astrameter/issues/572), [#573](https://github.com/tomquist/astrameter/pull/573)).
 - **Fixed** **Tibber Pulse** readings frequently dropping with connection-timeout errors because the bridge's slow webserver couldn't answer within the old hardcoded 1-second connection limit: the default timeout is now a more forgiving 5 seconds and can be tuned with a new `TIMEOUT` option ([#551](https://github.com/tomquist/astrameter/issues/551), [#565](https://github.com/tomquist/astrameter/pull/565)).
 - **Fixed** active control silently breaking until a restart after a single invalid grid reading (a NaN value, e.g. from a briefly unavailable ESPHome sensor or a glitchy meter source): the controller could get stuck sending every battery a small constant discharge command regardless of the actual grid. An invalid reading is now treated like an unavailable meter — batteries hold their output for that poll and normal control resumes with the next good reading ([#548](https://github.com/tomquist/astrameter/issues/548), [#550](https://github.com/tomquist/astrameter/pull/550)).
-
 
 ## 2.2.4
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ component, see **[docs/esphome-powermeters.md](docs/esphome-powermeters.md)**.
 Supported sources include: Shelly, Tasmota, Shrdzm, Emlog, ioBroker, Home
 Assistant, VZLogger, ESPHome (Http-Polling or native API), AMIS Reader, Modbus (TCP/UDP), MQTT, JSON HTTP, TQ
 Energy Manager, HomeWizard, Enphase Envoy, SMA Energy Meter, FRITZ!Smart Energy
-250, Fronius Smart Meter, Tibber Pulse, Script, and SML.
+250, Fronius Smart Meter, Refoss / Meross energy monitors, Tibber Pulse, Script,
+and SML.
 
 ## Configuration
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -453,6 +453,17 @@ THROTTLE_INTERVAL = 0
 ## If readings are reversed, flip the sign:
 # POWER_MULTIPLIER = -1
 
+# [REFOSS]
+## Refoss / Meross energy monitor (EM01P, EM06P, EM16P) via local Open API.
+## Polls Em.Status.Get and reads signed channel power (W): positive = import,
+## negative = feed-in. [MEROSS] is an alias for the same driver.
+## The device API is cleartext HTTP — use only on a trusted local network.
+# IP = 192.168.1.150
+## CT channel id(s). One id for single-phase; three for L1/L2/L3 (e.g. 1,2,3).
+# CHANNELS = 1
+## Prefer a numeric IP in Docker — *.local mDNS often does not resolve in bridge mode.
+# POWER_MULTIPLIER = -1
+
 # [TIBBER_PULSE]
 ## Tibber Pulse read locally via the Pulse Bridge HTTP API (no Tibber cloud).
 ## Decodes the meter's SML telegram from /data.json. Enable the bridge's local

--- a/docs/esphome-powermeters.md
+++ b/docs/esphome-powermeters.md
@@ -68,6 +68,7 @@ Running the Python add-on instead? See [powermeters.md](powermeters.md).
 - [SMA Energy Meter](#sma-energy-meter) — 🔴 Not yet available
 - [FRITZ!Smart Energy 250](#fritzsmart-energy-250) — 🟠 Alternate (via Home Assistant)
 - [Fronius Smart Meter](#fronius-smart-meter) — 🔵 Generic
+- [Refoss / Meross energy monitor](#refoss--meross-energy-monitor) — 🔵 Generic
 - [Tibber Pulse](#tibber-pulse) — 🟠 Alternate (native SML / community component)
 
 > **Script** (the Python `[SCRIPT]` source) has no ESPHome equivalent by design —
@@ -972,6 +973,57 @@ per-phase power — some firmwares report it unsigned, which breaks export):
 ```
 
 …and set `power_sensor_l2` / `power_sensor_l3` on `ct002:`.
+
+## Refoss / Meross energy monitor
+
+**Tier: 🔵 Generic.** Poll the local Open API
+`GET /rpc/Em.Status.Get?id=65535` and read `status[N].power` for the CT channel
+on the grid main (`N` is channel id minus one: channel 1 → index 0). The device
+API is **cleartext HTTP** — use only on a trusted local network.
+
+```yaml
+external_components:
+  - source: github://tomquist/astrameter@develop
+    components: [ct002]
+
+http_request:
+  useragent: esphome/astrameter
+  timeout: 5s
+  # Em.Status.Get returns a full JSON status object for all channels; raise the
+  # default buffer so the response body is complete before parse_json runs.
+  buffer_size_rx: 4096
+
+sensor:
+  - platform: template
+    id: grid_l1
+    unit_of_measurement: W
+    device_class: power
+
+interval:
+  - interval: 1s
+    then:
+      - http_request.get:
+          url: http://192.168.1.150/rpc/Em.Status.Get?id=65535
+          capture_response: true
+          max_response_buffer_size: 4096
+          on_response:
+            then:
+              - lambda: |-
+                  json::parse_json(body, [](JsonObject root) -> bool {
+                    // Channel 1 → status[0]. Change index for another CT.
+                    id(grid_l1).publish_state(root["status"][0]["power"]);
+                    return true;
+                  });
+
+ct002:
+  id: ct002_main
+  power_sensor_l1: grid_l1
+```
+
+For three-phase, publish `status[0]` / `status[1]` / `status[2]` into
+`grid_l1` / `grid_l2` / `grid_l3` (or indices 3–5 for the EM06P second CT group)
+and set `power_sensor_l2` / `power_sensor_l3` on `ct002:`. Prefer a numeric IP;
+mDNS `*.local` names often fail on ESPHome as well.
 
 ## Tibber Pulse
 

--- a/docs/powermeters.md
+++ b/docs/powermeters.md
@@ -37,6 +37,7 @@ Powermeters](configuration.md#multiple-powermeters) are documented in the
 - [SMA Energy Meter](#sma-energy-meter)
 - [FRITZ!Smart Energy 250](#fritzsmart-energy-250)
 - [Fronius Smart Meter](#fronius-smart-meter)
+- [Refoss / Meross energy monitor](#refoss--meross-energy-monitor)
 - [Tibber Pulse](#tibber-pulse)
 - [Script](#script)
 - [SML](#sml)
@@ -501,6 +502,52 @@ PER_PHASE = True
 > Several meter firmwares report `PowerReal_P_Phase_*` *unsigned* (always
 > positive), which would make exported power read as imported on each phase. If
 > in doubt, leave it off and use the always-signed sum.
+
+## Refoss / Meross energy monitor
+
+Reads a [Refoss](https://docs.refoss.net/open-api/) (or Meross-branded) energy
+monitor — EM01P, EM06P, EM16P — over the local Open API. AstraMeter polls
+`Em.Status.Get` and returns the signed `power` field (watts) for each configured
+CT channel: positive = grid import, negative = feed-in. No token or login is
+required on the LAN. `[MEROSS]` is an alias for `[REFOSS]` (same hardware API).
+
+```ini
+[REFOSS]
+IP = 192.168.1.150
+# Single-phase: one CT channel id (default 1)
+CHANNELS = 1
+```
+
+**Three-phase.** List three channel ids for L1/L2/L3 (typical EM06P first CT
+group is `1,2,3`; the second group is `4,5,6`):
+
+```ini
+[REFOSS]
+IP = 192.168.1.150
+CHANNELS = 1,2,3
+```
+
+**Docker / DNS.** A numeric IP always works. Hostnames that your **LAN DNS**
+knows (router / Pi-hole / AdGuard, etc.) also work on Docker **bridge** networks
+if the container uses that resolver — for example in Compose:
+
+```yaml
+dns:
+  - 192.168.1.1   # your LAN DNS / router
+```
+
+Default Docker DNS often cannot resolve LAN names. **mDNS** hostnames
+(`meross-em06p-….local`) usually still fail in bridge mode unless you add
+mDNS support or `extra_hosts`; prefer a numeric IP or a real DNS name.
+
+**Security.** The Refoss / Meross local Open API is **cleartext HTTP** (no TLS
+on the device). Power readings can be observed or altered by anyone on the
+network path between AstraMeter and the meter. Use this source only on an
+**explicitly trusted local network** (typical home LAN). Do not expose the
+meter's HTTP port to the internet or an untrusted VLAN. Prefer `[REFOSS]`
+**or** `[MEROSS]`, not both.
+
+**Sign.** If import/export looks reversed, flip with `POWER_MULTIPLIER = -1`.
 
 ## Tibber Pulse
 

--- a/src/astrameter/config/config_loader.py
+++ b/src/astrameter/config/config_loader.py
@@ -29,6 +29,7 @@ from astrameter.powermeter import (
     MqttPowermeter,
     PidPowermeter,
     Powermeter,
+    Refoss,
     Script,
     Shelly1PM,
     Shelly3EMPro,
@@ -72,6 +73,8 @@ ENVOY_SECTION = "ENVOY"
 SMA_ENERGY_METER_SECTION = "SMA_ENERGY_METER"
 FRITZ_SECTION = "FRITZ"
 FRONIUS_SECTION = "FRONIUS"
+REFOSS_SECTION = "REFOSS"
+MEROSS_SECTION = "MEROSS"
 TIBBER_PULSE_SECTION = "TIBBER_PULSE"
 MQTT_INSIGHTS_SECTION = "MQTT_INSIGHTS"
 
@@ -388,6 +391,8 @@ def create_powermeter(
         return create_fritz_powermeter(section, config)
     elif section.startswith(FRONIUS_SECTION):
         return create_fronius_powermeter(section, config)
+    elif section.startswith(REFOSS_SECTION) or section.startswith(MEROSS_SECTION):
+        return create_refoss_powermeter(section, config)
     elif section.startswith(TIBBER_PULSE_SECTION):
         return create_tibber_pulse_powermeter(section, config)
     elif section.startswith("MQTT") and not section.startswith(MQTT_INSIGHTS_SECTION):
@@ -740,6 +745,18 @@ def create_fronius_powermeter(
         config.get(section, "IP", fallback=""),
         config.get(section, "DEVICE_ID", fallback="0"),
         per_phase=config.getboolean(section, "PER_PHASE", fallback=False),
+    )
+
+
+def create_refoss_powermeter(
+    section: str, config: configparser.ConfigParser
+) -> Powermeter:
+    """Build a Refoss/Meross powermeter from a ``[REFOSS]`` / ``[MEROSS]`` section."""
+    from astrameter.powermeter.refoss import parse_channels
+
+    return Refoss(
+        config.get(section, "IP", fallback=""),
+        parse_channels(config.get(section, "CHANNELS", fallback="1")),
     )
 
 

--- a/src/astrameter/config/config_loader_test.py
+++ b/src/astrameter/config/config_loader_test.py
@@ -20,6 +20,7 @@ from astrameter.config.config_loader import (
     create_modbus_powermeter,
     create_mqtt_powermeter,
     create_powermeter,
+    create_refoss_powermeter,
     create_script_powermeter,
     create_shelly_powermeter,
     create_shrdzm_powermeter,
@@ -547,6 +548,19 @@ def test_create_fronius_powermeter():
     assert pm.per_phase is True
 
 
+def test_create_refoss_powermeter():
+    """Test Refoss/Meross powermeter creation and CHANNELS parsing."""
+    config = configparser.ConfigParser()
+    config["REFOSS"] = {"IP": "192.168.1.150"}
+    pm = create_refoss_powermeter("REFOSS", config)
+    assert pm.ip == "192.168.1.150"
+    assert pm.channels == [1]
+
+    config["MEROSS"] = {"IP": "192.168.1.150", "CHANNELS": "1,2,3"}
+    pm = create_refoss_powermeter("MEROSS", config)
+    assert pm.channels == [1, 2, 3]
+
+
 def test_create_tibber_pulse_powermeter():
     """Test Tibber Pulse powermeter creation, defaults, and OBIS overrides."""
     config = configparser.ConfigParser()
@@ -634,6 +648,8 @@ def test_create_powermeter():
         "AIN": "12345 0123456",
     }
     config["FRONIUS_TEST"] = {"IP": "127.0.0.1"}
+    config["REFOSS_TEST"] = {"IP": "127.0.0.1", "CHANNELS": "1"}
+    config["MEROSS_TEST"] = {"IP": "127.0.0.1", "CHANNELS": "1,2,3"}
     config["TIBBER_PULSE_TEST"] = {"IP": "127.0.0.1", "PASSWORD": "pw"}
     config["UNKNOWN_TEST"] = {"SOME_KEY": "some_value"}
 

--- a/src/astrameter/powermeter/__init__.py
+++ b/src/astrameter/powermeter/__init__.py
@@ -12,6 +12,7 @@ from .iobroker import IoBroker
 from .json_http import JsonHttpPowermeter
 from .modbus import ModbusPowermeter
 from .mqtt import MqttPowermeter
+from .refoss import Refoss
 from .script import Script
 from .shelly import Shelly, Shelly1PM, Shelly3EM, Shelly3EMPro, ShellyEM, ShellyPlus1PM
 from .shrdzm import Shrdzm
@@ -50,6 +51,7 @@ __all__ = [
     "PidPowermeter",
     "Powermeter",
     "PowermeterWrapper",
+    "Refoss",
     "Script",
     "Shelly",
     "Shelly1PM",

--- a/src/astrameter/powermeter/refoss.py
+++ b/src/astrameter/powermeter/refoss.py
@@ -1,0 +1,127 @@
+"""Refoss / Meross energy monitors (EM01P, EM06P, EM16P) via local Open API."""
+
+from __future__ import annotations
+
+import math
+
+import aiohttp
+from aiohttp import ClientTimeout
+
+from .base import Powermeter
+
+
+def parse_channels(raw: str) -> list[int]:
+    """Parse a comma-separated CHANNELS value into positive channel ids.
+
+    Empty tokens (leading, trailing, or repeated commas) and duplicate ids are
+    rejected so a typo cannot silently drop a channel id or map the same CT
+    twice.
+    """
+    parts = [p.strip() for p in raw.split(",")]
+    if not parts or all(p == "" for p in parts):
+        raise ValueError("CHANNELS must list at least one channel id")
+    if any(p == "" for p in parts):
+        raise ValueError("CHANNELS must not contain empty entries")
+    channels: list[int] = []
+    seen: set[int] = set()
+    for part in parts:
+        if not part.isascii() or not part.isdecimal():
+            raise ValueError(f"Invalid CHANNELS entry {part!r}: expected an integer")
+        try:
+            channel = int(part)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid CHANNELS entry {part!r}: expected an integer"
+            ) from exc
+        if channel < 1:
+            raise ValueError(
+                f"Invalid CHANNELS entry {channel}: channel ids start at 1"
+            )
+        if channel in seen:
+            raise ValueError(f"Invalid CHANNELS entry {channel}: duplicate channel id")
+        seen.add(channel)
+        channels.append(channel)
+    return channels
+
+
+class Refoss(Powermeter):
+    """Reads a Refoss / Meross energy monitor over the local HTTP Open API.
+
+    Polls ``/rpc/Em.Status.Get?id=65535`` (all CT channels) and returns the
+    signed ``power`` field for each configured channel id — positive = import,
+    negative = export. Meross-branded EM*P hardware uses the same Refoss API
+    (see https://docs.refoss.net/open-api/).
+
+    The device exposes cleartext HTTP only (no TLS). Use only on an explicitly
+    trusted local network; do not expose the meter API beyond that LAN.
+    """
+
+    def __init__(self, ip: str, channels: list[int]):
+        """Create a meter for ``ip`` reading the given CT ``channels`` (1-based)."""
+        ip = ip.strip()
+        if not ip:
+            raise ValueError("IP is required")
+        if not channels:
+            raise ValueError("CHANNELS must list at least one channel id")
+        self.ip = ip
+        self.channels = list(channels)
+        self.session: aiohttp.ClientSession | None = None
+
+    async def start(self) -> None:
+        """Open the shared HTTP session used to poll the device."""
+        if self.session:
+            return
+        # Fail fast: the battery polls ~1/s, so a slow source should error
+        # quickly and let the next poll retry rather than pin a handler.
+        self.session = aiohttp.ClientSession(timeout=ClientTimeout(total=2, connect=1))
+
+    async def stop(self) -> None:
+        """Close the HTTP session if one is open."""
+        if self.session:
+            await self.session.close()
+            self.session = None
+
+    async def get_json(self, path: str):
+        """GET ``path`` on the device and return the decoded JSON body."""
+        if not self.session:
+            raise RuntimeError("Session not started; call start() first")
+        url = f"http://{self.ip}{path}"
+        async with self.session.get(url, allow_redirects=False) as resp:
+            if 300 <= resp.status < 400:
+                raise ValueError("Refoss API must not redirect")
+            resp.raise_for_status()
+            return await resp.json(content_type=None)
+
+    async def get_powermeter_watts(self) -> list[float]:
+        """Return watts for each configured channel, in CHANNELS order."""
+        response = await self.get_json("/rpc/Em.Status.Get?id=65535")
+        if not isinstance(response, dict):
+            raise ValueError("Refoss Em.Status.Get response must be an object")
+        status = response.get("status")
+        if not isinstance(status, list):
+            raise ValueError("Refoss Em.Status.Get response missing status array")
+
+        by_id: dict[int, float] = {}
+        for entry in status:
+            if not isinstance(entry, dict) or "id" not in entry:
+                continue
+            if "power" not in entry:
+                raise ValueError(f"Refoss status entry missing power field: {entry!r}")
+            try:
+                channel_id = int(entry["id"])
+                power = float(entry["power"])
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"Invalid Refoss status entry: {entry!r}") from exc
+            if not math.isfinite(power):
+                raise ValueError(f"Refoss status entry has non-finite power: {entry!r}")
+            by_id[channel_id] = power
+
+        watts: list[float] = []
+        for channel_id in self.channels:
+            if channel_id not in by_id:
+                raise ValueError(
+                    f"Refoss channel {channel_id} not present in Em.Status.Get "
+                    f"(have {sorted(by_id)})"
+                )
+            watts.append(by_id[channel_id])
+        return watts

--- a/src/astrameter/powermeter/refoss_test.py
+++ b/src/astrameter/powermeter/refoss_test.py
@@ -1,0 +1,155 @@
+from unittest.mock import patch
+
+import pytest
+
+from astrameter.powermeter import Refoss
+from astrameter.powermeter.refoss import parse_channels
+
+
+def _status_response(channels: dict[int, float]):
+    """Build an Em.Status.Get-shaped payload for the given channel powers."""
+    return {
+        "status": [
+            {
+                "id": channel_id,
+                "current": 0.0,
+                "voltage": 230.0,
+                "power": power,
+                "pf": 1.0,
+            }
+            for channel_id, power in channels.items()
+        ]
+    }
+
+
+def test_parse_channels():
+    """Accept positive ids and reject empty, non-integer, and zero values."""
+    assert parse_channels("1") == [1]
+    assert parse_channels("1,2,3") == [1, 2, 3]
+    assert parse_channels(" 4 , 5 ") == [4, 5]
+    with pytest.raises(ValueError, match="at least one"):
+        parse_channels("")
+    with pytest.raises(ValueError, match="empty"):
+        parse_channels("1,")
+    with pytest.raises(ValueError, match="empty"):
+        parse_channels(",1")
+    with pytest.raises(ValueError, match="empty"):
+        parse_channels("1,,2")
+    with pytest.raises(ValueError, match="integer"):
+        parse_channels("a")
+    with pytest.raises(ValueError, match="start at 1"):
+        parse_channels("0")
+    with pytest.raises(ValueError, match="duplicate"):
+        parse_channels("1,1")
+    with pytest.raises(ValueError, match="integer"):
+        parse_channels("+1")
+    with pytest.raises(ValueError, match="integer"):
+        parse_channels("-1")
+
+
+@pytest.mark.asyncio
+async def test_get_powermeter_watts_single_channel(mock_aiohttp_session):
+    """Return only the configured channel's signed power."""
+    mock_aiohttp_session.set_json(_status_response({1: 421.5, 2: 10.0}))
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
+        meter = Refoss("192.168.1.150", [1])
+        await meter.start()
+        assert await meter.get_powermeter_watts() == [421.5]
+        await meter.stop()
+
+
+@pytest.mark.asyncio
+async def test_get_powermeter_watts_three_phase(mock_aiohttp_session):
+    """Return watts in CHANNELS order even when the API lists channels out of order."""
+    # Deliberately out of channel-id order so we catch implementations that
+    # return response order instead of configured CHANNELS order.
+    mock_aiohttp_session.set_json(
+        _status_response({3: 25.5, 1: 100.0, 2: -50.0, 4: 999.0})
+    )
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
+        meter = Refoss("192.168.1.150", [1, 2, 3])
+        await meter.start()
+        assert await meter.get_powermeter_watts() == [100.0, -50.0, 25.5]
+        await meter.stop()
+
+
+@pytest.mark.asyncio
+async def test_get_powermeter_watts_missing_channel(mock_aiohttp_session):
+    """Raise when a configured channel id is absent from the device response."""
+    mock_aiohttp_session.set_json(_status_response({1: 10.0}))
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
+        meter = Refoss("192.168.1.150", [1, 2])
+        await meter.start()
+        with pytest.raises(ValueError, match="channel 2"):
+            await meter.get_powermeter_watts()
+        await meter.stop()
+
+
+@pytest.mark.asyncio
+async def test_get_powermeter_watts_missing_power_field(mock_aiohttp_session):
+    """Raise when a status entry has an id but no power field."""
+    mock_aiohttp_session.set_json(
+        {"status": [{"id": 1, "current": 0.0, "voltage": 230.0}]}
+    )
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
+        meter = Refoss("192.168.1.150", [1])
+        await meter.start()
+        with pytest.raises(ValueError, match="missing power"):
+            await meter.get_powermeter_watts()
+        await meter.stop()
+
+
+@pytest.mark.asyncio
+async def test_get_powermeter_watts_rejects_non_object_json(mock_aiohttp_session):
+    """Raise when the JSON root is not an object."""
+    mock_aiohttp_session.set_json([{"id": 1, "power": 10.0}])
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
+        meter = Refoss("192.168.1.150", [1])
+        await meter.start()
+        with pytest.raises(ValueError, match="must be an object"):
+            await meter.get_powermeter_watts()
+        await meter.stop()
+
+
+@pytest.mark.asyncio
+async def test_get_json_rejects_redirect(mock_aiohttp_session):
+    """Do not follow or accept HTTP redirects when polling the meter."""
+    mock_resp = mock_aiohttp_session.get.return_value
+    # __aenter__ returns the response mock used inside the async with block.
+    (await mock_resp.__aenter__()).status = 302
+    with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
+        meter = Refoss("192.168.1.150", [1])
+        await meter.start()
+        with pytest.raises(ValueError, match="must not redirect"):
+            await meter.get_json("/rpc/Em.Status.Get?id=65535")
+        mock_aiohttp_session.get.assert_called_with(
+            "http://192.168.1.150/rpc/Em.Status.Get?id=65535",
+            allow_redirects=False,
+        )
+        await meter.stop()
+
+
+@pytest.mark.asyncio
+async def test_get_powermeter_watts_rejects_non_finite_power(mock_aiohttp_session):
+    """Raise when power is NaN or ±infinity."""
+    for bad in ("NaN", "inf", "-inf"):
+        mock_aiohttp_session.set_json({"status": [{"id": 1, "power": bad}]})
+        with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
+            meter = Refoss("192.168.1.150", [1])
+            await meter.start()
+            with pytest.raises(ValueError, match="non-finite power"):
+                await meter.get_powermeter_watts()
+            await meter.stop()
+
+
+def test_requires_ip():
+    """Reject blank IP values before opening a session."""
+    with pytest.raises(ValueError, match="IP"):
+        Refoss("", [1])
+    with pytest.raises(ValueError, match="IP"):
+        Refoss("   ", [1])
+
+
+def test_strips_ip():
+    """Strip surrounding whitespace from the configured IP."""
+    assert Refoss("  192.168.1.150  ", [1]).ip == "192.168.1.150"

--- a/src/astrameter/web_config.py
+++ b/src/astrameter/web_config.py
@@ -392,6 +392,8 @@ SECTION_KEY_TYPES: dict[str, dict[str, dict[str, object]]] = {
         DEVICE_ID={"type": "integer"},
         PER_PHASE={"type": "boolean"},
     ),
+    "REFOSS": _pm(CHANNELS={}),
+    "MEROSS": _pm(CHANNELS={}),
     "TIBBER_PULSE": _pm(
         PASSWORD={"type": "password"},
         TIMEOUT={"type": "float"},

--- a/web/ts/generate.test.ts
+++ b/web/ts/generate.test.ts
@@ -107,6 +107,83 @@ const fronius3 = generateConfigIni({
   meters: [{ type: "fronius", phases: 3, fields: { IP: "10.0.0.9" }, tuning: {} }],
 });
 has(fronius3, "PER_PHASE = True", "fronius: PER_PHASE emitted in three-phase");
+const refoss1 = generateConfigIni({
+  target: "python",
+  general: { deviceTypes: ["shellyproem50"] },
+  meters: [{ type: "refoss", phases: 1, fields: { IP: "192.168.1.150", CHANNELS: "1" }, tuning: {} }],
+});
+has(refoss1, "[REFOSS]", "refoss: section header");
+has(refoss1, "IP = 192.168.1.150", "refoss: IP emitted");
+has(refoss1, "CHANNELS = 1", "refoss: single-phase CHANNELS");
+const refoss3 = generateConfigIni({
+  target: "python",
+  general: { deviceTypes: ["shellypro3em"] },
+  meters: [{ type: "refoss", phases: 3, fields: { IP: "192.168.1.150", CHANNELS: "1" }, tuning: {} }],
+});
+has(refoss3, "CHANNELS = 1,2,3", "refoss: three-phase defaults CHANNELS when not a three-id list");
+const refoss456 = generateConfigIni({
+  target: "python",
+  general: { deviceTypes: ["shellypro3em"] },
+  meters: [{ type: "refoss", phases: 3, fields: { IP: "192.168.1.150", CHANNELS: "4,5,6" }, tuning: {} }],
+});
+has(refoss456, "CHANNELS = 4,5,6", "refoss: three-phase preserves explicit CHANNELS");
+const eyRefoss456 = generateEsphome({
+  target: "esphome",
+  esphome: {},
+  meters: [{ type: "refoss", phases: 3, fields: { IP: "192.168.1.150", CHANNELS: "4,5,6" }, tuning: {} }],
+});
+has(
+  eyRefoss456,
+  "url: http://192.168.1.150/rpc/Em.Status.Get?id=65535",
+  "esp/refoss: polls configured IP",
+);
+has(eyRefoss456, 'root["status"][3]["power"]', "esp/refoss: L1 uses selected channel 4");
+has(eyRefoss456, 'root["status"][4]["power"]', "esp/refoss: L2 uses selected channel 5");
+has(eyRefoss456, 'root["status"][5]["power"]', "esp/refoss: L3 uses selected channel 6");
+lacks(eyRefoss456, 'root["status"][0]["power"]', "esp/refoss: does not hardcode status[0] for 4,5,6");
+const refossFloat = generateConfigIni({
+  target: "python",
+  general: { deviceTypes: ["shellyproem50"] },
+  meters: [{ type: "refoss", phases: 1, fields: { IP: "192.168.1.150", CHANNELS: "1.0" }, tuning: {} }],
+});
+has(refossFloat, "CHANNELS = 1", "refoss: rejects 1.0, defaults single-phase CHANNELS");
+lacks(refossFloat, "CHANNELS = 1.0", "refoss: does not emit float CHANNELS");
+const refossSci = generateConfigIni({
+  target: "python",
+  general: { deviceTypes: ["shellypro3em"] },
+  meters: [{ type: "refoss", phases: 3, fields: { IP: "192.168.1.150", CHANNELS: "1e2" }, tuning: {} }],
+});
+has(refossSci, "CHANNELS = 1,2,3", "refoss: rejects 1e2, defaults three-phase CHANNELS");
+const refossMixed = generateConfigIni({
+  target: "python",
+  general: { deviceTypes: ["shellypro3em"] },
+  meters: [{ type: "refoss", phases: 3, fields: { IP: "192.168.1.150", CHANNELS: "4,5,1.0" }, tuning: {} }],
+});
+has(refossMixed, "CHANNELS = 1,2,3", "refoss: rejects mixed invalid three-phase CHANNELS");
+const eyRefossFloat = generateEsphome({
+  target: "esphome",
+  esphome: {},
+  meters: [{ type: "refoss", phases: 3, fields: { IP: "192.168.1.150", CHANNELS: "1.0" }, tuning: {} }],
+});
+has(eyRefossFloat, 'root["status"][0]["power"]', "esp/refoss: 1.0 falls back to status[0]");
+has(eyRefossFloat, 'root["status"][1]["power"]', "esp/refoss: 1.0 falls back to status[1]");
+has(eyRefossFloat, 'root["status"][2]["power"]', "esp/refoss: 1.0 falls back to status[2]");
+const refossFour = generateConfigIni({
+  target: "python",
+  general: { deviceTypes: ["shellypro3em"] },
+  meters: [{ type: "refoss", phases: 3, fields: { IP: "192.168.1.150", CHANNELS: "4,5,6,7" }, tuning: {} }],
+});
+has(refossFour, "CHANNELS = 1,2,3", "refoss: four-id three-phase falls back to 1,2,3");
+lacks(refossFour, "CHANNELS = 4,5,6,7", "refoss: does not emit four-id CHANNELS for three-phase");
+const eyRefossFour = generateEsphome({
+  target: "esphome",
+  esphome: {},
+  meters: [{ type: "refoss", phases: 3, fields: { IP: "192.168.1.150", CHANNELS: "4,5,6,7" }, tuning: {} }],
+});
+has(eyRefossFour, 'root["status"][0]["power"]', "esp/refoss: four-id falls back to status[0]");
+has(eyRefossFour, 'root["status"][1]["power"]', "esp/refoss: four-id falls back to status[1]");
+has(eyRefossFour, 'root["status"][2]["power"]', "esp/refoss: four-id falls back to status[2]");
+lacks(eyRefossFour, 'root["status"][3]["power"]', "esp/refoss: four-id does not use truncated 4,5,6");
 
 // ── config.ini: Tibber Pulse timeout (#551) ──────────────────────────────────
 const tibber = generateConfigIni({

--- a/web/ts/generate.ts
+++ b/web/ts/generate.ts
@@ -4,6 +4,8 @@
 
 import {
   getPowermeter,
+  parseChannels,
+  formatChannels,
   PER_METER_TUNING,
   CT_BASIC,
   CT_ACTIVE,
@@ -86,6 +88,8 @@ function meterSection(meter: Meter, opts: { multi: boolean }): string {
   const phaseList = pm.phaseListKeys && meter.phases === 3 ? pm.phaseListKeys : null;
 
   for (const field of pm.fields) {
+    // CHANNELS is normalized below so Python and ESPHome share one grammar.
+    if (field.key === "CHANNELS") continue;
     let value = fields[field.key];
     if (phaseList && field.key === "TOPIC" && !isBlank(value)) {
       lines.push(`TOPICS = ${String(value).trim()}`);
@@ -103,6 +107,21 @@ function meterSection(meter: Meter, opts: { multi: boolean }): string {
   // PER_PHASE) rather than per-phase field lists.
   if (pm.phaseFlagKey && meter.phases === 3) {
     lines.push(`${pm.phaseFlagKey} = True`);
+  }
+
+  // CHANNELS: positive decimal ints only (same rules as Python parse_channels).
+  // Three-phase keeps a valid 3-id list or falls back to phaseChannelsValue;
+  // single-phase keeps a single valid id or defaults to "1".
+  if (pm.fields.some((f) => f.key === "CHANNELS")) {
+    let ids = parseChannels(fields.CHANNELS);
+    if (pm.phaseChannelsValue && meter.phases === 3) {
+      if (!ids || ids.length !== 3) {
+        ids = parseChannels(pm.phaseChannelsValue) ?? [1, 2, 3];
+      }
+    } else if (!ids || ids.length !== 1) {
+      ids = [1];
+    }
+    lines.push(`CHANNELS = ${formatChannels(ids)}`);
   }
 
   // Per-meter tuning (throttle, smoothing, transform, hampel, PID …)
@@ -312,7 +331,9 @@ function esphomeSensor(state: State) {
     const sensors = (use3 ? ids : ["grid_l1"]).map((id, i) => templateSensor(id) + phaseFilterBlock(i));
     const url = use3 ? esp.url3!(f) : (esp.url1 ? esp.url1(f) : "http://example.com/api");
     const lambdaBody = use3
-      ? esp.lambda3
+      ? typeof esp.lambda3 === "function"
+        ? esp.lambda3(f)
+        : esp.lambda3
       : typeof esp.lambda1 === "function"
         ? esp.lambda1(f)
         : esp.lambda1;

--- a/web/ts/schema.test.ts
+++ b/web/ts/schema.test.ts
@@ -16,6 +16,9 @@ import {
   MARSTEK_FIELDS,
   MQTT_INSIGHTS_FIELDS,
   ESP_BOARDS,
+  parseChannels,
+  formatChannels,
+  refossChannelIds,
 } from "./schema.js";
 
 let failures = 0;
@@ -29,7 +32,7 @@ function check(cond, msg) {
 // Allowed shapes — anything outside these lists is almost certainly a typo.
 const FIELD_TYPES = new Set(["text", "number", "password", "select", "checkbox"]);
 const FIELD_PROPS = new Set(["key", "label", "help", "type", "default", "placeholder", "options", "required", "phase", "advanced", "ey"]);
-const PM_PROPS = new Set(["id", "label", "section", "blurb", "docPython", "fields", "esphome", "phaseListKeys", "phaseFlagKey"]);
+const PM_PROPS = new Set(["id", "label", "section", "blurb", "docPython", "fields", "esphome", "phaseListKeys", "phaseFlagKey", "phaseChannelsValue"]);
 const ESP_KINDS = new Set(["homeassistant", "mqtt", "sml", "modbus", "http", "unsupported"]);
 const ESP_TIERS = new Set(["native", "generic", "alternate", "unsupported"]);
 const ESP_PROPS = new Set(["kind", "tier", "note", "url1", "url3", "lambda1", "lambda3", "jsonRoot", "haEntity", "headersField", "warn"]);
@@ -112,6 +115,12 @@ for (const pm of POWERMETERS) {
   if (pm.phaseListKeys) {
     check(typeof pm.phaseListKeys.topic === "string" && typeof pm.phaseListKeys.jsonPath === "string", `${where}: phaseListKeys needs topic+jsonPath`);
   }
+  if (pm.phaseChannelsValue !== undefined) {
+    check(
+      typeof pm.phaseChannelsValue === "string" && pm.phaseChannelsValue.trim() !== "",
+      `${where}: phaseChannelsValue must be a non-empty string`,
+    );
+  }
 }
 
 // ── PHASE_CAPABLE references real meters ──
@@ -145,6 +154,27 @@ check(Array.isArray(ESP_BOARDS) && ESP_BOARDS.length > 0, "ESP_BOARDS: non-empty
 for (const b of ESP_BOARDS) {
   check(typeof b.value === "string" && typeof b.label === "string", `ESP_BOARDS: each entry needs value+label (${JSON.stringify(b)})`);
 }
+
+// ── parseChannels (shared Python / ESPHome CHANNELS grammar) ──
+check(JSON.stringify(parseChannels("1")) === "[1]", "parseChannels: single id");
+check(JSON.stringify(parseChannels("4,5,6")) === "[4,5,6]", "parseChannels: three ids");
+check(JSON.stringify(parseChannels(" 4 , 5 ")) === "[4,5]", "parseChannels: trims");
+check(parseChannels("1.0") === null, "parseChannels: rejects 1.0");
+check(parseChannels("1e2") === null, "parseChannels: rejects 1e2");
+check(parseChannels("4,5,1.0") === null, "parseChannels: rejects mixed invalid");
+check(parseChannels("0") === null, "parseChannels: rejects 0");
+check(parseChannels("a,2") === null, "parseChannels: rejects non-numeric");
+check(parseChannels("+1") === null, "parseChannels: rejects leading plus sign");
+check(parseChannels("-1") === null, "parseChannels: rejects leading minus sign");
+check(parseChannels("1,") === null, "parseChannels: rejects trailing comma");
+check(parseChannels(",1") === null, "parseChannels: rejects leading comma");
+check(parseChannels("1,,2") === null, "parseChannels: rejects empty middle token");
+check(formatChannels([4, 5, 6]) === "4,5,6", "formatChannels: joins");
+check(JSON.stringify(refossChannelIds("1.0", [1])) === "[1]", "refossChannelIds: falls back on 1.0");
+check(JSON.stringify(refossChannelIds("1e2", [1, 2, 3])) === "[1,2,3]", "refossChannelIds: falls back on 1e2");
+check(JSON.stringify(refossChannelIds("4,5,6", [1, 2, 3])) === "[4,5,6]", "refossChannelIds: keeps valid 3-id list");
+check(JSON.stringify(refossChannelIds("4,5,6,7", [1, 2, 3])) === "[1,2,3]", "refossChannelIds: rejects four-id list (exact length)");
+check(JSON.stringify(refossChannelIds("1,2", [1])) === "[1]", "refossChannelIds: rejects two-id for single-phase fallback");
 
 if (failures) {
   console.error(`\n${failures} schema problem(s) found`);

--- a/web/ts/schema.ts
+++ b/web/ts/schema.ts
@@ -43,7 +43,7 @@ export interface EsphomeSpec {
   url1?: (f: Fields) => string;
   url3?: (f: Fields) => string;
   lambda1?: string | ((f: Fields) => string);
-  lambda3?: string;
+  lambda3?: string | ((f: Fields) => string);
   jsonRoot?: string;
   haEntity?: (f: Fields) => string;
   headersField?: string;
@@ -61,6 +61,12 @@ export interface Powermeter {
   phaseListKeys?: { topic: string; jsonPath: string };
   /** Boolean key set to True when three-phase is selected (e.g. Fronius PER_PHASE). */
   phaseFlagKey?: string;
+  /**
+   * Default CHANNELS list when three-phase is selected and the form value is
+   * not already three channel ids (e.g. still "1"). Explicit lists like
+   * "4,5,6" are kept as-is by the generator.
+   */
+  phaseChannelsValue?: string;
 }
 
 export interface DeviceType {
@@ -263,6 +269,42 @@ export const PER_METER_TUNING: Field[] = [
 //   'homeassistant' native HA sensor    'mqtt' native mqtt_subscribe
 //   'sml' native sml component          'modbus' native modbus_controller
 //   'http' generic http_request poll    'unsupported' no ESP path yet
+
+/**
+ * Parse a CHANNELS value into positive decimal integers.
+ * Matches the Python Refoss parser (`int(token)` after strip, channel >= 1):
+ * rejects floats (`1.0`), scientific (`1e2`), signs, and other non-decimal tokens.
+ * Returns null if the string is empty, any token is empty (leading / trailing /
+ * repeated commas), any token is signed, or any token is invalid.
+ */
+export function parseChannels(raw: unknown): number[] | null {
+  if (typeof raw !== "string" || !raw.trim()) return null;
+  const parts = raw.split(",").map((s) => s.trim());
+  // Reject leading / trailing / repeated commas (e.g. "1,", ",1", "1,,2").
+  if (!parts.length || parts.some((part) => !part)) return null;
+  const ids: number[] = [];
+  for (const part of parts) {
+    // Decimal digits only — same rejection set as Python int() for "1.0" / "1e2".
+    if (!/^\d+$/.test(part)) return null;
+    const n = Number.parseInt(part, 10);
+    if (!Number.isSafeInteger(n) || n < 1) return null;
+    ids.push(n);
+  }
+  return ids;
+}
+
+/** Join channel ids as a comma-separated CHANNELS value. */
+export function formatChannels(ids: number[]): string {
+  return ids.join(",");
+}
+
+/** Resolve CHANNELS for ESPHome / defaults: exact id count, else fallback. */
+export function refossChannelIds(raw: FieldValue, fallback: number[]): number[] {
+  const ids = parseChannels(raw);
+  if (!ids || ids.length !== fallback.length) return fallback;
+  return ids;
+}
+
 export const POWERMETERS: Powermeter[] = [
   {
     id: "shelly",
@@ -692,6 +734,39 @@ export const POWERMETERS: Powermeter[] = [
     },
   },
   {
+    id: "refoss",
+    label: "Refoss / Meross energy monitor",
+    section: "REFOSS",
+    blurb:
+      "A Refoss or Meross EM01P / EM06P / EM16P via the local Open API (Em.Status.Get). Same hardware under either brand. Cleartext HTTP — trusted LAN only.",
+    docPython: "docs/powermeters.md#refoss--meross-energy-monitor",
+    fields: [
+      { key: "IP", label: "Device IP", type: "text", placeholder: "192.168.1.150", required: true, help: "Prefer a numeric IP — Docker bridge often cannot resolve *.local mDNS names. Device API is cleartext HTTP; keep it on a trusted LAN." },
+      { key: "CHANNELS", label: "CT channel(s)", type: "text", default: "1", placeholder: "1", help: "One channel id for single-phase (e.g. 1). For three-phase use three ids for L1/L2/L3 (e.g. 1,2,3 or 4,5,6)." },
+    ],
+    // Default only when three-phase is on and CHANNELS is not already three ids.
+    phaseChannelsValue: "1,2,3",
+    esphome: {
+      kind: "http",
+      tier: "generic",
+      note: "Polls Em.Status.Get?id=65535 over cleartext HTTP (trusted LAN only) and reads status[N].power (channel id minus one). Prefer a numeric IP.",
+      url1: (f) => `http://${f.IP || "192.168.1.150"}/rpc/Em.Status.Get?id=65535`,
+      url3: (f) => `http://${f.IP || "192.168.1.150"}/rpc/Em.Status.Get?id=65535`,
+      lambda1: (f) => {
+        const channel = refossChannelIds(f.CHANNELS, [1])[0];
+        return `id(grid_l1).publish_state(root["status"][${channel - 1}]["power"]);`;
+      },
+      lambda3: (f) => {
+        const [a, b, c] = refossChannelIds(f.CHANNELS, [1, 2, 3]);
+        return (
+          `id(grid_l1).publish_state(root["status"][${a - 1}]["power"]);\n` +
+          `                    id(grid_l2).publish_state(root["status"][${b - 1}]["power"]);\n` +
+          `                    id(grid_l3).publish_state(root["status"][${c - 1}]["power"]);`
+        );
+      },
+    },
+  },
+  {
     id: "tibber_pulse",
     label: "Tibber Pulse (local Bridge)",
     section: "TIBBER_PULSE",
@@ -761,6 +836,7 @@ export const PHASE_CAPABLE: Set<string> = new Set([
   "json_http",
   "sml",
   "fronius",
+  "refoss",
   "tibber_pulse",
 ]);
 


### PR DESCRIPTION
Support EM01P, EM06P, and EM16P over the local Open API (`Em.Status.Get`), with `[REFOSS]` / `[MEROSS]` config for single- or three-phase CT channels.

## Why

Marstek batteries need a grid power reading. Refoss/Meross EM*P meters already sit on many LANs and speak a simple local HTTP Open API, but AstraMeter only offered them via a hand-rolled `[JSON_HTTP]` recipe. That is easy to get wrong (paths, channel order, sign) and is not discoverable in the config UI. Adding `[REFOSS]` / `[MEROSS]` as a first-class source lets you point at the meter IP and CT `CHANNELS` directly.

## Checklist

- [x] Base branch is `develop`, not `main`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest`
- [x] Python ↔ ESPHome parity held for shared CT002 behaviour, or does not apply ([CONTRIBUTING.md](https://github.com/tomquist/AstraMeter/blob/develop/CONTRIBUTING.md)) — does not apply (new powermeter source; ESPHome YAML generated via existing HTTP helper)
- [x] `web/` changes: rebuilt the dashboard bundle (`cd web && npm run build:dashboard`) and committed it — does not apply (schema / config generator only; no dashboard UI changes)
- [x] User-visible change: one bullet under `## Next` in [CHANGELOG.md](https://github.com/tomquist/AstraMeter/blob/develop/CHANGELOG.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Refoss/Meross EM01P, EM06P, and EM16P energy monitors as local power-meter sources.
  * Supports configurable single- and three-phase channels, signed readings, sign correction, and ESPHome generation with validation and defaults.
* **Documentation**
  * Updated setup guides, configuration examples, supported-source lists, and security guidance for local HTTP polling.
* **Tests**
  * Added coverage for channel parsing, validation, readings, and configuration generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->