### PR TITLE
Free a stalled battery from the ramp-pacing clamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Fixed** B2500 batteries sitting at 0 W under active control while the whole house load was imported: the command they were sent could never exceed what the battery needs to start, and a battery that never starts was never sent more ([#600](https://github.com/tomquist/astrameter/issues/600), [#614](https://github.com/tomquist/astrameter/pull/614)).
+
 - **Added** Refoss / Meross energy monitors (EM01P, EM06P, EM16P) as a power source (`[REFOSS]` or `[MEROSS]`) ([#598](https://github.com/tomquist/astrameter/pull/598)).
 
 - **Breaking:** **removed** the per-battery **Last Seen** sensor — it changed on every poll and buried the Home Assistant logbook under one entry per second. Automations that used it should switch to the battery's entities going *unavailable*, or to `last_reported`; see [docs/mqtt-insights.md](docs/mqtt-insights.md#is-a-battery-still-reporting-home-assistant) ([#576](https://github.com/tomquist/astrameter/issues/576), [#597](https://github.com/tomquist/astrameter/pull/597)).

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -821,6 +821,9 @@ void LoadBalancer::reset_consumer(const std::string &consumer_id) {
   state.pace_sign = 0;
   state.pace_prev_reported.reset();
   state.pace_last_at = 0.0;
+  state.pace_stall_polls = 0;
+  state.pace_responded_at = 0.0f;
+  state.pace_last_sent = 0.0f;
   state.osc_score = 0.0f;
   state.osc_last_sign = 0;
   state.saturation_score = 0.0;
@@ -1343,8 +1346,13 @@ float LoadBalancer::pace_reading_(const std::string &consumer_id, float reading,
   // minimum reading to clear their input hold window at all; the cadence
   // scale still bounds the grown cap (mirrors balancer.py).
   float limit = std::max(base, cap * dt_ratio);
+  bool stalled = false;
   if (sign == 0 || sign != state.pace_sign) {
     cap = base;
+    state.pace_stall_polls = 0;
+    // A reversal re-opens the question of what this device responds to in the
+    // new direction; nothing learned going one way carries over.
+    state.pace_responded_at = 0.0f;
   } else if (std::fabs(reading) > limit) {
     float moved = 0.0f;
     if (state.pace_prev_reported.has_value())
@@ -1352,10 +1360,26 @@ float LoadBalancer::pace_reading_(const std::string &consumer_id, float reading,
     // The tracking threshold and growth rate scale with the same cadence
     // ratio: a fast poller is expected to have moved less between polls,
     // and its cap doubles per reference second, not per poll.
-    if (moved >= PACE_TRACKING_DELTA_W * dt_ratio)
+    if (moved >= PACE_TRACKING_DELTA_W * dt_ratio) {
       cap = std::min(cap * std::pow(PACE_GROWTH_FACTOR, dt_ratio), this->cfg_.pace_max_step);
+      state.pace_stall_polls = 0;
+      // It moved, so last poll's command was one this device can execute.
+      // Remember it: clamping back under that level would switch a hysteresis
+      // regulator straight off again.
+      if (state.pace_last_sent > 0.0f) state.pace_responded_at = state.pace_last_sent;
+    } else {
+      // Held below what the device can act on: grow anyway once the stall has
+      // persisted, or the clamp is self-sustaining (see PACE_STALL_ESCAPE_POLLS).
+      stalled = true;
+      state.pace_stall_polls++;
+      if (state.pace_stall_polls >= PACE_STALL_ESCAPE_POLLS) {
+        cap = std::min(cap * std::pow(PACE_GROWTH_FACTOR, dt_ratio), this->cfg_.pace_max_step);
+        state.pace_stall_polls = 0;
+      }
+    }
   } else {
     cap = std::max(base, std::fabs(reading) / dt_ratio);
+    state.pace_stall_polls = 0;
   }
   // Enforce the pace_max_step contract: the grow branch already clamps, but the
   // else branch back-computes cap as fabs(reading) / dt_ratio, which a fast poll
@@ -1365,8 +1389,21 @@ float LoadBalancer::pace_reading_(const std::string &consumer_id, float reading,
   state.pace_cap = cap;
   state.pace_sign = sign;
   state.pace_prev_reported = reported;
-  limit = std::max(base, cap * dt_ratio);
-  return std::max(-limit, std::min(limit, reading));
+  // The cadence scale exists so a fast poller cannot integrate the same
+  // per-poll reading into a higher W/s slew. A stalled device integrates
+  // nothing, so there is no slew to bound — and scaling a fast poller's clamp
+  // back down to base is precisely what keeps it stalled (max(base, cap *
+  // dt_ratio) stays at base until cap reaches base / dt_ratio, so growing the
+  // cap alone never frees a 0.3 s poller).
+  limit = std::max(base, stalled ? cap : cap * dt_ratio);
+  // Never clamp under a level this device has demonstrably responded to: for a
+  // hysteresis regulator a smaller command is not a gentler one but an *off*
+  // one, so the unit would switch off, stop moving, and need lifting again
+  // indefinitely. Still bounded by pace_max_step.
+  limit = std::min(std::max(limit, state.pace_responded_at), this->cfg_.pace_max_step);
+  const float out = std::max(-limit, std::min(limit, reading));
+  state.pace_last_sent = std::fabs(out);
+  return out;
 }
 
 // True iff every battery in conc_ids already sits within balance_deadband of

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -1399,7 +1399,9 @@ float LoadBalancer::pace_reading_(const std::string &consumer_id, float reading,
   // Never clamp under a level this device has demonstrably responded to: for a
   // hysteresis regulator a smaller command is not a gentler one but an *off*
   // one, so the unit would switch off, stop moving, and need lifting again
-  // indefinitely. Still bounded by pace_max_step.
+  // indefinitely. Still bounded by pace_max_step. This costs worst-case
+  // overshoot — the command that starts the device is one it responds to hard —
+  // and the trade is against it not starting at all (mirrors balancer.py).
   limit = std::min(std::max(limit, state.pace_responded_at), this->cfg_.pace_max_step);
   const float out = std::max(-limit, std::min(limit, reading));
   state.pace_last_sent = std::fabs(out);

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -687,7 +687,7 @@ std::array<float, 3> LoadBalancer::steer_to_zero_(
     }
   }
   float reading = to_grid_reading(NetOutputW(0.0f), reported);
-  if (paced && consumer_id) reading = this->pace_reading_(*consumer_id, reading, reported);
+  if (paced && consumer_id) reading = this->pace_reading_(*consumer_id, reading, reported, reports);
   if (consumer_id) {
     auto &stz_state = this->get_consumer_(*consumer_id);
     stz_state.last_target = paced ? reading : 0.0f;
@@ -1036,7 +1036,7 @@ std::array<float, 3> LoadBalancer::compute_auto_target_(
     const double desired = (total_fade > 0.0) ? demand * fade_w / total_fade : 0.0;
     float reading = to_grid_reading(NetOutputW(desired), reported);
     const float unpaced_reading = reading;
-    reading = this->pace_reading_(*consumer_id, reading, reported);
+    reading = this->pace_reading_(*consumer_id, reading, reported, reports);
     state.last_target = reading;
     state.last_intent = desired;
     state.last_intent_reading = unpaced_reading;
@@ -1168,7 +1168,7 @@ std::array<float, 3> LoadBalancer::compute_auto_target_(
   float reading = to_grid_reading(NetOutputW(reported + residual), reported);
   const float unpaced_reading = reading;
   if (consumer_id) {
-    reading = this->pace_reading_(*consumer_id, reading, reported);
+    reading = this->pace_reading_(*consumer_id, reading, reported, reports);
     auto &auto_state = this->get_consumer_(*consumer_id);
     auto_state.last_target = reading;
     auto_state.last_intent = reported + residual;
@@ -1323,8 +1323,8 @@ bool LoadBalancer::cannot_absorb_(const ReportMap &reports) const {
 // manual / inactive steer-to-zero bypass it (see balancer.py for the
 // rationale). Caps are W per PACE_REFERENCE_DT; the per-poll clamp scales
 // with the consumer's observed inter-poll time, clamped at 1.0.
-float LoadBalancer::pace_reading_(const std::string &consumer_id, float reading,
-                                  float reported) {
+float LoadBalancer::pace_reading_(const std::string &consumer_id, float reading, float reported,
+                                  const ReportMap &reports) {
   const float base = this->cfg_.pace_base_step;
   if (base <= 0.0f) return reading;
   auto &state = this->get_consumer_(consumer_id);
@@ -1346,6 +1346,15 @@ float LoadBalancer::pace_reading_(const std::string &consumer_id, float reading,
   // minimum reading to clear their input hold window at all; the cadence
   // scale still bounds the grown cap (mirrors balancer.py).
   float limit = std::max(base, cap * dt_ratio);
+  // The stall escape and the response floor below only apply to devices that
+  // actually have a minimum actionable command — the DC-output family, whose
+  // channels are a hard on/off below their minimum. Every other battery can
+  // execute an arbitrarily small command, so it can never be deadlocked by the
+  // clamp; leaving it on the unmodified path keeps its behaviour bit-for-bit
+  // and confines the overshoot cost to the devices that need it.
+  const auto report_it = reports.find(consumer_id);
+  const bool can_stall =
+      report_it != reports.end() && needs_dc_output_floor(report_it->second.device_type);
   bool stalled = false;
   if (sign == 0 || sign != state.pace_sign) {
     cap = base;
@@ -1366,13 +1375,22 @@ float LoadBalancer::pace_reading_(const std::string &consumer_id, float reading,
       // It moved, so last poll's command was one this device can execute.
       // Remember it: clamping back under that level would switch a hysteresis
       // regulator straight off again.
-      if (state.pace_last_sent > 0.0f) state.pace_responded_at = state.pace_last_sent;
+      // Keep the *lowest* command seen to work, not the latest: the floor's job
+      // is "the least this device needs", so during a successful ramp — where
+      // the commands grow — overwriting would ratchet it up to the largest and
+      // hold every later same-direction correction there. It does not move the
+      // measured overshoot (the first command a stalled device responds to is
+      // already the escalated one); it matters when a smaller command later
+      // succeeds (mirrors balancer.py).
+      if (state.pace_last_sent > 0.0f &&
+          (state.pace_responded_at <= 0.0f || state.pace_last_sent < state.pace_responded_at))
+        state.pace_responded_at = state.pace_last_sent;
     } else {
       // Held below what the device can act on: grow anyway once the stall has
       // persisted, or the clamp is self-sustaining (see PACE_STALL_ESCAPE_POLLS).
-      stalled = true;
+      stalled = can_stall;
       state.pace_stall_polls++;
-      if (state.pace_stall_polls >= PACE_STALL_ESCAPE_POLLS) {
+      if (can_stall && state.pace_stall_polls >= PACE_STALL_ESCAPE_POLLS) {
         cap = std::min(cap * std::pow(PACE_GROWTH_FACTOR, dt_ratio), this->cfg_.pace_max_step);
         state.pace_stall_polls = 0;
       }
@@ -1401,8 +1419,10 @@ float LoadBalancer::pace_reading_(const std::string &consumer_id, float reading,
   // one, so the unit would switch off, stop moving, and need lifting again
   // indefinitely. Still bounded by pace_max_step. This costs worst-case
   // overshoot — the command that starts the device is one it responds to hard —
-  // and the trade is against it not starting at all (mirrors balancer.py).
-  limit = std::min(std::max(limit, state.pace_responded_at), this->cfg_.pace_max_step);
+  // and the trade is against it not starting at all, so it is confined to the
+  // devices that can fail to start (mirrors balancer.py).
+  if (can_stall)
+    limit = std::min(std::max(limit, state.pace_responded_at), this->cfg_.pace_max_step);
   const float out = std::max(-limit, std::min(limit, reading));
   state.pace_last_sent = std::fabs(out);
   return out;

--- a/esphome/components/ct002/balancer.h
+++ b/esphome/components/ct002/balancer.h
@@ -527,7 +527,8 @@ class LoadBalancer {
                             float fair_share);
   bool concentration_pool_balanced_(const ReportMap &reports,
                                     const std::vector<const std::string *> &conc_ids);
-  float pace_reading_(const std::string &consumer_id, float reading, float reported);
+  float pace_reading_(const std::string &consumer_id, float reading, float reported,
+                      const ReportMap &reports);
   float damp_oscillation_(const std::string &consumer_id, float residual);
   float predict_control_grid_(const ReportMap &reports, float grid_total,
                               const std::vector<float> &sample_id);

--- a/esphome/components/ct002/balancer.h
+++ b/esphome/components/ct002/balancer.h
@@ -29,6 +29,12 @@ namespace ct002 {
 // into a higher W/s slew. Mirrors balancer.py.
 inline constexpr float PACE_TRACKING_DELTA_W = 5.0f;
 inline constexpr float PACE_GROWTH_FACTOR = 2.0f;
+// Consecutive clamped polls with no movement after which the cap grows anyway.
+// "Grow only while tracking" deadlocks against any actuator whose minimum
+// actionable command exceeds pace_base_step: the clamp holds the command below
+// what the device can execute, so it never moves, and never moving is exactly
+// what withholds the bigger command (mirrors balancer.py).
+inline constexpr int PACE_STALL_ESCAPE_POLLS = 3;
 inline constexpr double PACE_REFERENCE_DT = 1.0;
 
 // Adaptive grid-state predictor (see BalancerConfig::grid_predict_trust and
@@ -242,6 +248,12 @@ struct BalancerConsumerState {
   int pace_sign{0};
   std::optional<float> pace_prev_reported{};
   double pace_last_at{0.0};
+  int pace_stall_polls{0};
+  // Smallest command this consumer has been observed to respond to in the
+  // current direction; 0 = nothing learned yet.
+  float pace_responded_at{0.0f};
+  // The reading put on the wire last poll, to attribute observed movement.
+  float pace_last_sent{0.0f};
   // Oscillation-gated damping (see BalancerConfig::osc_damp_max): accumulated
   // reversal score and the sign of the last non-zero residual that fed it.
   float osc_score{0.0f};

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -1791,7 +1791,7 @@ class LoadBalancer:
         )
         reading = to_grid_reading(NetOutputW(0), reported)
         if paced and consumer_id:
-            reading = self._pace_reading(consumer_id, reading, reported)
+            reading = self._pace_reading(consumer_id, reading, reported, reports)
         if consumer_id:
             state = self._get_consumer(consumer_id)
             state.last_target = reading if paced else 0
@@ -1984,7 +1984,7 @@ class LoadBalancer:
             desired = demand * fade_w / total_fade if total_fade > 0 else 0.0
             reading = to_grid_reading(NetOutputW(desired), reported)
             unpaced_reading = reading
-            reading = self._pace_reading(consumer_id, reading, reported)
+            reading = self._pace_reading(consumer_id, reading, reported, reports)
 
             state.last_target = reading
             state.last_intent = desired
@@ -2113,7 +2113,7 @@ class LoadBalancer:
         unpaced_reading = reading
 
         if consumer_id:
-            reading = self._pace_reading(consumer_id, reading, reported)
+            reading = self._pace_reading(consumer_id, reading, reported, reports)
             state = self._get_consumer(consumer_id)
             state.last_target = reading
             state.last_intent = reported + residual
@@ -2245,7 +2245,9 @@ class LoadBalancer:
             state.osc_last_sign = sign
         return residual * (1.0 - cfg.osc_damp_max * state.osc_score)
 
-    def _pace_reading(self, consumer_id: str, reading: float, reported: float) -> float:
+    def _pace_reading(
+        self, consumer_id: str, reading: float, reported: float, reports: dict
+    ) -> float:
         """Clamp the auto-path *reading* to the consumer's ramp-pacing cap.
 
         The battery integrates the reading with its own accelerating ramp,
@@ -2310,6 +2312,16 @@ class LoadBalancer:
         # cadence scale still bounds the *grown* cap, which is where the
         # fast-poller overshoot lived.
         limit = max(base, cap * dt_ratio)
+        # The stall escape and the response floor below only apply to devices
+        # that actually have a minimum actionable command — the DC-output
+        # family, whose channels are a hard on/off below their minimum. Every
+        # other battery can execute an arbitrarily small command, so it can
+        # never be deadlocked by the clamp and gains nothing here; leaving it on
+        # the unmodified path keeps its behaviour bit-for-bit and confines the
+        # overshoot cost (see the response floor) to the devices that need it.
+        can_stall = _needs_dc_output_floor(
+            (reports.get(consumer_id) or {}).get("device_type", "")
+        )
         stalled = False
         if sign == 0 or sign != state.pace_sign:
             cap = base
@@ -2333,15 +2345,28 @@ class LoadBalancer:
                 # It moved, so last poll's command was one this device can
                 # execute. Remember it: clamping back under that level would
                 # switch a hysteresis regulator straight off again.
-                if state.pace_last_sent > 0:
+                #
+                # Keep the *lowest* command seen to work, not the latest: the
+                # floor's job is "the least this device needs", so during a
+                # successful ramp — where the commands grow — overwriting would
+                # ratchet it up to the largest and hold every later
+                # same-direction correction there. It does not move the measured
+                # overshoot on the mixed Venus/B2500 scenarios, because the first
+                # command a stalled device responds to is already the escalated
+                # one and nothing smaller is ever seen to work; it matters when a
+                # smaller command does later succeed.
+                if state.pace_last_sent > 0 and (
+                    state.pace_responded_at <= 0
+                    or state.pace_last_sent < state.pace_responded_at
+                ):
                     state.pace_responded_at = state.pace_last_sent
             else:
                 # Held below what the device can act on: grow anyway once the
                 # stall has persisted, or the clamp is self-sustaining (see
                 # PACE_STALL_ESCAPE_POLLS).
-                stalled = True
+                stalled = can_stall
                 state.pace_stall_polls += 1
-                if state.pace_stall_polls >= PACE_STALL_ESCAPE_POLLS:
+                if can_stall and state.pace_stall_polls >= PACE_STALL_ESCAPE_POLLS:
                     cap = min(
                         cap * PACE_GROWTH_FACTOR**dt_ratio, self._cfg.pace_max_step
                     )
@@ -2378,8 +2403,10 @@ class LoadBalancer:
         # by definition one it responds to hard, and gating the floor on the
         # reported output does not recover it (the overshoot happens during the
         # ramp, while the output is still under the floor — measured, not
-        # assumed). The trade is against the device not starting at all.
-        limit = min(max(limit, state.pace_responded_at), self._cfg.pace_max_step)
+        # assumed). The trade is against the device not starting at all, so it
+        # is confined to the devices that can fail to start.
+        if can_stall:
+            limit = min(max(limit, state.pace_responded_at), self._cfg.pace_max_step)
         out = max(-limit, min(limit, reading))
         state.pace_last_sent = abs(out)
         return out

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -96,6 +96,20 @@ def _efficiency_window_weight(report: dict) -> float:
 # whole step response — while still rejecting a genuinely stalled battery.
 PACE_TRACKING_DELTA_W = 5.0
 PACE_GROWTH_FACTOR = 2.0
+# Consecutive clamped polls with no movement after which the cap grows anyway.
+#
+# "Grow only while tracking" deadlocks against any actuator whose *minimum
+# actionable command* exceeds pace_base_step: the clamp holds the command below
+# what the device can execute, the device therefore never moves, and never
+# moving is exactly what withholds the bigger command. A B2500 is the concrete
+# case — its DC channels cannot energize below roughly 40 W each, so a 30 W base
+# step leaves it parked at 0 W forever while the whole load is imported.
+#
+# Escaping on a stall costs nothing in overshoot: a device that is not moving
+# cannot overshoot, and the escalation is still bounded by pace_max_step — the
+# same ceiling a tracking device reaches. A genuinely full/empty battery is
+# handled by saturation detection, not by starving its command.
+PACE_STALL_ESCAPE_POLLS = 3
 # Reference poll interval the pace caps are defined against: pace_base_step /
 # pace_max_step are watts per reference second, scaled by the consumer's observed
 # inter-poll time so a fast poller can't integrate the same per-poll reading into
@@ -469,6 +483,15 @@ class BalancerConsumerState:
     pace_sign: int = 0
     pace_prev_reported: float | None = None
     pace_last_at: float = 0.0
+    # Consecutive clamped polls this consumer has not moved for (see
+    # PACE_STALL_ESCAPE_POLLS).
+    pace_stall_polls: int = 0
+    # Smallest command this consumer has actually been observed to respond to,
+    # in the current direction (see ``_pace_reading``). 0 = nothing learned yet.
+    pace_responded_at: float = 0.0
+    # The reading put on the wire last poll, used to attribute the movement
+    # observed this poll to the command that caused it.
+    pace_last_sent: float = 0.0
     # Oscillation-gated damping (see BalancerConfig.osc_damp_max): accumulated
     # reversal score (1.0 = sustained hunting, 0.0 = steady) and the sign of the
     # last non-zero residual that fed it.
@@ -1478,6 +1501,9 @@ class LoadBalancer:
         state.pace_sign = 0
         state.pace_prev_reported = None
         state.pace_last_at = 0.0
+        state.pace_stall_polls = 0
+        state.pace_responded_at = 0.0
+        state.pace_last_sent = 0.0
         state.osc_score = 0.0
         state.osc_last_sign = 0
         state.saturation_score = 0.0
@@ -2284,8 +2310,13 @@ class LoadBalancer:
         # cadence scale still bounds the *grown* cap, which is where the
         # fast-poller overshoot lived.
         limit = max(base, cap * dt_ratio)
+        stalled = False
         if sign == 0 or sign != state.pace_sign:
             cap = base
+            state.pace_stall_polls = 0
+            # A reversal re-opens the question of what this device responds to
+            # in the new direction; nothing learned going one way carries over.
+            state.pace_responded_at = 0.0
         elif abs(reading) > limit:
             moved = (
                 (reported - state.pace_prev_reported) * sign
@@ -2298,8 +2329,26 @@ class LoadBalancer:
             # per poll.
             if moved >= PACE_TRACKING_DELTA_W * dt_ratio:
                 cap = min(cap * PACE_GROWTH_FACTOR**dt_ratio, self._cfg.pace_max_step)
+                state.pace_stall_polls = 0
+                # It moved, so last poll's command was one this device can
+                # execute. Remember it: clamping back under that level would
+                # switch a hysteresis regulator straight off again.
+                if state.pace_last_sent > 0:
+                    state.pace_responded_at = state.pace_last_sent
+            else:
+                # Held below what the device can act on: grow anyway once the
+                # stall has persisted, or the clamp is self-sustaining (see
+                # PACE_STALL_ESCAPE_POLLS).
+                stalled = True
+                state.pace_stall_polls += 1
+                if state.pace_stall_polls >= PACE_STALL_ESCAPE_POLLS:
+                    cap = min(
+                        cap * PACE_GROWTH_FACTOR**dt_ratio, self._cfg.pace_max_step
+                    )
+                    state.pace_stall_polls = 0
         else:
             cap = max(base, abs(reading) / dt_ratio)
+            state.pace_stall_polls = 0
         # Enforce the pace_max_step contract: the grow branch already clamps,
         # but the else branch back-computes cap as abs(reading) / dt_ratio,
         # which a fast poll (small dt_ratio) can inflate past the max — and a
@@ -2308,8 +2357,26 @@ class LoadBalancer:
         state.pace_cap = cap
         state.pace_sign = sign
         state.pace_prev_reported = reported
-        limit = max(base, cap * dt_ratio)
-        return max(-limit, min(limit, reading))
+        # The cadence scale exists so a fast poller cannot integrate the same
+        # per-poll reading into a higher W/s slew. A stalled device integrates
+        # nothing, so there is no slew to bound — and scaling a fast poller's
+        # clamp back down to ``base`` is precisely what keeps it stalled
+        # (``max(base, cap * dt_ratio)`` stays at ``base`` until ``cap`` reaches
+        # ``base / dt_ratio``, so growing the cap alone never frees a 0.3 s
+        # poller). While stalled, clamp on the unscaled cap so the command can
+        # actually reach what the device needs to start moving; the cadence
+        # scale resumes on the first poll it does.
+        limit = max(base, cap if stalled else cap * dt_ratio)
+        # Never clamp under a level this device has demonstrably responded to.
+        # The cadence scale otherwise pulls a fast poller's clamp back to
+        # ``base`` the moment the device starts moving, and for a hysteresis
+        # regulator that is not a gentler command but an *off* command — the
+        # unit switches off, stops moving, and the stall escape has to lift it
+        # again, indefinitely. Still bounded by ``pace_max_step``.
+        limit = min(max(limit, state.pace_responded_at), self._cfg.pace_max_step)
+        out = max(-limit, min(limit, reading))
+        state.pace_last_sent = abs(out)
+        return out
 
     def _concentration_pool_balanced(self, reports: dict, conc_ids: list[str]) -> bool:
         """True iff every battery in *conc_ids* already sits at its fair share.

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -2373,6 +2373,12 @@ class LoadBalancer:
         # regulator that is not a gentler command but an *off* command — the
         # unit switches off, stops moving, and the stall escape has to lift it
         # again, indefinitely. Still bounded by ``pace_max_step``.
+        #
+        # This costs worst-case overshoot: the command that starts the device is
+        # by definition one it responds to hard, and gating the floor on the
+        # reported output does not recover it (the overshoot happens during the
+        # ramp, while the output is still under the floor — measured, not
+        # assumed). The trade is against the device not starting at all.
         limit = min(max(limit, state.pace_responded_at), self._cfg.pace_max_step)
         out = max(-limit, min(limit, reading))
         state.pace_last_sent = abs(out)

--- a/src/astrameter/simulator/b2500_steering.py
+++ b/src/astrameter/simulator/b2500_steering.py
@@ -12,6 +12,12 @@ Venus float gain table, ``sqrt`` step, or spike filter apply. It is documented i
 cycle. The loop holds while the measured output is within a ±10 W deadband of the
 setpoint, otherwise nudges ``cmd`` by ±100 — a bounded integrator.
 
+Each channel also has a **minimum output** (``MIN_CHANNEL_OUTPUT_W``): commanded
+below it the channel simply stays off, so the unit cannot deliver less than
+roughly twice that. This makes a small command unexecutable rather than slow —
+a control loop that only ever asks for less than the minimum gets no response at
+all, and reads as a dead battery rather than a lagging one.
+
 The setpoint is **incremental** (``setpoint = output + 0.9 * grid``), so the loop
 integrates the grid toward zero (fixed point ``output = load``); a proportional
 ``0.9 * grid`` would droop and never null it. The constants are firmware-extracted.
@@ -31,6 +37,12 @@ CMD_STEP = 100  # internal command step per cycle (~17 W of output)
 CMD_FLOOR = 5  # output = (cmd - CMD_FLOOR) * CAL_NUM / CAL_DEN
 CAL_NUM, CAL_DEN = 10, 59  # command -> output (watts) calibration
 APPROACH_NUM, APPROACH_DEN = 9, 10  # correct 90% of the residual grid per cycle
+# Minimum output one DC channel can physically deliver (W). The channel is a
+# hard on/off below this: commanded under it, the output stays de-energized
+# rather than delivering a small trickle, so the unit as a whole has a ~2x
+# minimum. The exact figure depends on the inverter model the battery is
+# paired with; this is the common default.
+MIN_CHANNEL_OUTPUT_W = 40
 
 
 @dataclass
@@ -41,6 +53,9 @@ class B2500SteeringController:
     """
 
     cmd: int = 60  # internal command unit (not watts)
+    # Below this the channel cannot be energized at all (see
+    # ``MIN_CHANNEL_OUTPUT_W``). ``0`` models a channel with no such floor.
+    min_output: int = MIN_CHANNEL_OUTPUT_W
     # Output ceiling (W). The command is clamped so its output never runs past
     # this — anti-windup. On real hardware the measured-output feedback
     # saturates at the inverter limit, so the command can't wind up; a
@@ -64,7 +79,18 @@ class B2500SteeringController:
         *power* is the channel's measured output power (W). Holds within the
         ±10 W deadband, else slews ``cmd`` by ±100, clamped so the output stays
         within ``[0, max_output]`` (anti-windup).
+
+        A setpoint below ``min_output`` de-energizes the channel outright: the
+        output goes to 0 and ``cmd`` is reset to the floor rather than left to
+        wind up. Resetting matters as much as the gate does — a held command
+        would keep integrating a sub-minimum setpoint cycle after cycle and
+        eventually cross the threshold on its own, so an under-minimum command
+        would start the channel after a delay instead of never. On the device it
+        never starts, however long the command is repeated.
         """
+        if setpoint < self.min_output:
+            self.cmd = CMD_FLOOR
+            return 0
         if power > setpoint + DEADBAND_W:
             self.cmd = (self.cmd - CMD_STEP) & 0xFFFF
         elif power < setpoint - DEADBAND_W:
@@ -83,6 +109,9 @@ class B2500SteeringController:
         a sustained import winds the output up until the grid is nulled (rather
         than parking at 90% of the residual). The B2500 has no AC input, so the
         setpoint never goes negative: a surplus winds the output down to idle.
+
+        A residual small enough to keep the setpoint under ``min_output`` leaves
+        the channel off, however long it persists.
         """
         setpoint = power + int(grid) * APPROACH_NUM // APPROACH_DEN
         setpoint = max(0, min(setpoint, int(max_power)))

--- a/src/astrameter/simulator/b2500_steering_test.py
+++ b/src/astrameter/simulator/b2500_steering_test.py
@@ -18,7 +18,11 @@ from __future__ import annotations
 
 import pytest
 
-from astrameter.simulator.b2500_steering import B2500SteeringController
+from astrameter.simulator.b2500_steering import (
+    DEADBAND_W,
+    MIN_CHANNEL_OUTPUT_W,
+    B2500SteeringController,
+)
 
 # Closed-loop regulator trajectories: (cmd, output) per cycle, output fed back.
 GOLDEN = [
@@ -203,3 +207,64 @@ def test_step_setpoint_is_incremental() -> None:
     assert c.output() == 100
     out = c.step(grid=200, power=100, max_power=800)
     assert out > 100  # rising toward 280, not parking at an absolute fraction
+
+
+# -- minimum channel output -------------------------------------------------
+
+
+def test_setpoint_below_minimum_leaves_channel_off() -> None:
+    """A channel commanded under its minimum delivers nothing at all — not a
+    reduced trickle."""
+    c = B2500SteeringController()
+    assert c.regulate(MIN_CHANNEL_OUTPUT_W - 1, 0) == 0
+
+
+def test_sub_minimum_command_never_starts_the_channel() -> None:
+    """Repeating an under-minimum command does not eventually start the output.
+
+    The regulator is an integrator, so without resetting ``cmd`` a held
+    sub-minimum setpoint would wind up over successive cycles and cross the
+    threshold on its own — turning "never responds" into "responds after a
+    delay", which is the more forgiving of the two and not what the device
+    does.
+    """
+    c = B2500SteeringController()
+    power = 0
+    for _ in range(500):
+        power = c.regulate(MIN_CHANNEL_OUTPUT_W - 1, power)
+        assert power == 0
+
+
+def test_command_at_the_minimum_starts_the_channel() -> None:
+    """At (not just above) the minimum the channel energizes and ramps."""
+    c = B2500SteeringController()
+    power = 0
+    for _ in range(20):
+        power = c.regulate(MIN_CHANNEL_OUTPUT_W, power)
+    assert power >= MIN_CHANNEL_OUTPUT_W - DEADBAND_W
+
+
+def test_running_channel_shuts_off_when_command_drops_below_minimum() -> None:
+    """A channel already delivering power stops outright once commanded under
+    the minimum, rather than winding down through it."""
+    c = B2500SteeringController()
+    power = 0
+    for _ in range(30):
+        power = c.regulate(300, power)
+    assert power > 200
+    assert c.regulate(MIN_CHANNEL_OUTPUT_W - 1, power) == 0
+
+
+def test_minimum_can_be_disabled() -> None:
+    """``min_output=0`` restores an unfloored channel (a differently-paired
+    inverter, or isolating the regulator in a test)."""
+    c = B2500SteeringController(min_output=0)
+    power = 0
+    for _ in range(20):
+        power = c.regulate(20, power)
+    assert 10 <= power <= 30
+
+
+def test_closed_loop_ignores_a_sub_minimum_load() -> None:
+    """A load one channel could never serve is left entirely unserved."""
+    assert _closed_loop(MIN_CHANNEL_OUTPUT_W - 5) == 0

--- a/src/astrameter/simulator/battery.py
+++ b/src/astrameter/simulator/battery.py
@@ -15,7 +15,7 @@ import time
 from astrameter.ct002.balancer import device_capabilities
 
 from . import protocol
-from .b2500_steering import B2500SteeringController
+from .b2500_steering import MIN_CHANNEL_OUTPUT_W, B2500SteeringController
 from .firmware_steering import FirmwareSteeringController
 from .venus_d_steering import VenusDSteeringController
 
@@ -47,6 +47,7 @@ class BatterySimulator:
         dc_input_power: float = 0.0,
         participates: bool = True,
         initial_power: float = 0.0,
+        min_channel_output: int = MIN_CHANNEL_OUTPUT_W,
     ) -> None:
         if phase not in protocol.PHASE_FIELD_INDEX:
             raise ValueError(
@@ -107,12 +108,19 @@ class BatterySimulator:
             and not caps.has_builtin_inverter
             and not caps.has_ac_input
         )
-        # Two channels, each capped at half the unit's discharge envelope.
+        # Two channels, each capped at half the unit's discharge envelope and
+        # unable to energize below ``min_channel_output`` — so the unit as a
+        # whole has a ~2x minimum output and simply does not respond to a
+        # command below it (``0`` removes the floor).
         _ch_max = max(1, self.max_discharge_power // 2)
         self._b2500_channels = (
             [
-                B2500SteeringController(max_output=_ch_max),
-                B2500SteeringController(max_output=_ch_max),
+                B2500SteeringController(
+                    max_output=_ch_max, min_output=min_channel_output
+                ),
+                B2500SteeringController(
+                    max_output=_ch_max, min_output=min_channel_output
+                ),
             ]
             if self._is_dc_output
             else []

--- a/tests/test_b2500_e2e.py
+++ b/tests/test_b2500_e2e.py
@@ -222,13 +222,17 @@ async def test_mixed_surplus_only_venus_absorbs() -> None:
     await h.start()
     try:
         # Moderate surplus, within the Venus's charge capacity: grid nulls. The
-        # Venus absorbs it (charges); the B2500 never charges, though it may hold
-        # a small discharge in the circulating equilibrium (always >= 0).
+        # Venus absorbs it (charges); the B2500 never charges, and under a
+        # surplus it sits at a clean 0 — its channels cannot energize below their
+        # minimum output, so there is no small discharge left for it to hold.
+        # What remains is the Venus's own ~30 W of over-absorption; the B2500's
+        # sub-minimum trickle used to cancel that out, so this bound is against
+        # the Venus's equilibrium, not against a B2500 contribution.
         h.load_model.base_load = [-400.0, 0.0, 0.0]
         await h.settle(200)
         assert h.b2500.current_power >= -1  # never charges from AC
         assert h.venus.current_power < -250  # Venus absorbs the surplus
-        assert abs(h.grid()) < 30  # grid nulled
+        assert abs(h.grid()) <= 35  # grid nulled
 
         # Surplus beyond the absorb capacity: the Venus caps near its charge
         # limit, the B2500 still never charges, and the excess remains on the

--- a/tests/test_b2500_e2e.py
+++ b/tests/test_b2500_e2e.py
@@ -230,7 +230,7 @@ async def test_mixed_surplus_only_venus_absorbs() -> None:
         # the Venus's equilibrium, not against a B2500 contribution.
         h.load_model.base_load = [-400.0, 0.0, 0.0]
         await h.settle(200)
-        assert h.b2500.current_power >= -1  # never charges from AC
+        assert abs(h.b2500.current_power) <= 1  # off under surplus, never charges
         assert h.venus.current_power < -250  # Venus absorbs the surplus
         assert abs(h.grid()) <= 35  # grid nulled
 


### PR DESCRIPTION
## Why

A B2500 under active control could sit at 0 W indefinitely with the entire house load imported from the grid.

Ramp pacing grows a battery's per-poll command cap only while the battery is observed following its command. That deadlocks against any actuator whose *minimum actionable command* is larger than the starting cap: the clamp holds the command below what the device can physically execute, so the device never moves — and never moving is exactly what withholds a bigger command. A B2500 is the concrete case, because each of its two DC output channels is a hard on/off below roughly 40 W and cannot deliver a small trickle.

Relay mode was unaffected: it passes the raw meter reading straight through, so the clamp never applies.

### The fix, in two parts

The first alone is not enough, which is worth knowing before simplifying it:

1. **Escape the stall.** After a few clamped polls with no movement, grow the cap anyway, and while stalled clamp on the *unscaled* cap. The cadence scale exists so a fast poller cannot integrate one reading into a higher W/s slew — but a stalled device integrates nothing, and scaling its clamp back down is precisely what keeps it stalled. Growing the cap alone never frees a 0.3 s poller, because the scaled limit stays pinned at the starting value until the cap has grown by 1/dt_ratio.
2. **Remember what worked.** Never clamp back under the lowest command the device has demonstrably responded to. For a hysteresis regulator a smaller command is not a gentler one, it is an *off* one — so without this the unit starts, gets clamped back down, switches off, and has to be lifted again, forever. Measured as a limit cycle before this part was added.

### Scoped to devices that can actually stall

Both parts are gated on the DC-output family. A battery with no minimum actionable command can never be deadlocked by the clamp, so it gains nothing here and should not pay the cost — it stays on the unmodified path.

Verified rather than assumed: `single_venus_solar_slow`, `mixed_cadence/fair`, `mixed_cadence_solar/eff`, `single_venus_pv` and `two_venus/fair` report **15 metrics unchanged, 0 regressed** against `develop` over 5 seeds. Before the gating, three of them had moved (band crossings +52% and +20%, settle +22%).

## Simulator fidelity

The simulated B2500 channel had no minimum output, so it followed arbitrarily small commands that real hardware ignores outright — which is why nothing caught this. The channel is now gated on its setpoint, with `cmd` reset when the setpoint is under the minimum (the regulator integrates, so a held sub-minimum setpoint would otherwise wind up and cross the threshold on its own, turning "never responds" into "responds after a delay" — the more forgiving of the two, and not what the device does).

The firmware-extracted golden trajectories are untouched; every one of their setpoints is above the minimum. `min_output=0` restores the old unfloored channel for a differently-paired inverter.

## Steering-eval reading

The bot compares head against `develop`, which for the two B2500 scenarios confounds two changes: the plant got stricter *and* the controller changed. Re-running head against the simulator-only commit separates them:

- **`mixed_venus_b2500/fair`** — byte-identical with the controller fix reverted. Its regression is entirely the stricter plant. With a Venus and a B2500 sharing a phase, fair distribution has no way to express "this unit does 0 or ≥80 W"; that looks like separate work.
- **`mixed_venus_b2500/eff`** — cost regret **2.58 → 1.35** against the same plant (develop: 1.16), mean absolute grid **−37%**, share imbalance **−27%**.

**One cost to weigh explicitly:** on `/eff`, worst-case overshoot goes 175 → 330 W (develop: 222) and settle +44%. The command that starts a stalled device is by definition one it responds to hard. Two attempts to recover it were measured and did **not** work — gating the floor on the reported output (the overshoot happens during the ramp, while the output is still below the floor) and keeping the floor at the lowest responding command (the first command a stalled device responds to is already the escalated one). The first was removed as dead complexity; the second was kept for correct semantics, not for a measured gain. The trade is against the device not starting at all.

## Checklist

- [x] Base branch is `develop`, not `main`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest` — 1433 passed, 98 skipped; all 8 C++ host test binaries green
- [x] Python ↔ ESPHome parity held — the pacing change is mirrored in `esphome/components/ct002/balancer.{h,cpp}`
- [x] `web/` changes: none
- [x] User-visible change: one bullet under `## Next`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdHnJtKbaTq7F2QnzJKG4A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed B2500 batteries remaining at 0 W during active control when the home is importing power.
  * Improved regulation by enforcing a minimum channel output and preventing unwanted small discharges or control wind-up.
  * Improved recovery when output stalls or changes direction, helping devices respond more reliably.
* **Tests**
  * Expanded coverage for minimum-output behavior and end-to-end battery control during mixed-surplus conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->