### PR TITLE
Gate steering evaluation to relevant PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,11 +350,69 @@ jobs:
   # PR comment. Purely informational — thresholds that must hold live in
   # pytest regressions, not here.
   #
-  # The suite is split across three jobs so every scenario runs in its own
+  # The suite is split across four jobs so every scenario runs in its own
   # matrix worker in parallel, cutting wall time from ~(N_scenarios * seeds)
   # sequential minutes down to roughly one scenario's worth.
+  #
+  # That parallelism costs one runner per scenario, twice over (base + head),
+  # and the whole point of the run is the PR comment — so the gate below keeps
+  # it off every push and off any PR whose diff cannot move the numbers.
+  steering-eval-gate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          # The base commit has to be present to diff against it.
+          fetch-depth: 0
+
+      - name: Decide whether the evaluation is needed
+        id: decide
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          # Escape hatch for a change that moves steering from somewhere the
+          # paths below don't cover (a new dependency, a refactor elsewhere in
+          # the loop): label the PR `steering-eval` to force a run.
+          FORCED: ${{ contains(github.event.pull_request.labels.*.name, 'steering-eval') }}
+          # What the simulation actually reads: the controller under test, the
+          # simulated plant and the harness itself — plus this workflow, so a
+          # change to the eval jobs is exercised by the PR that makes it.
+          RELEVANT: '^(src/astrameter/(ct002|simulator)/|\.github/workflows/ci\.yml$)'
+        run: |
+          decide() {
+            echo "run=$1" >> "$GITHUB_OUTPUT"
+            echo "$2"
+            if [ "$1" = "false" ]; then
+              echo "Steering evaluation skipped — $2" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          }
+          if [ "$FORCED" = "true" ]; then
+            decide true "forced by the 'steering-eval' label."
+            exit 0
+          fi
+          # Fail open: if the base commit is somehow unreachable, run the suite
+          # rather than silently dropping the comparison.
+          if ! changed=$(git diff --name-only "$BASE_SHA...HEAD"); then
+            decide true "could not diff against $BASE_SHA; running anyway."
+            exit 0
+          fi
+          echo "Changed files:"
+          echo "$changed"
+          # Tests next to the code can't move the metrics — the harness never
+          # imports them — so a test-only edit under those paths still skips.
+          changed=$(printf '%s\n' "$changed" | grep -vE '_test\.py$' || true)
+          if printf '%s\n' "$changed" | grep -qE "$RELEVANT"; then
+            decide true "the diff touches the active-control loop."
+          else
+            decide false "the diff touches nothing the simulation reads."
+          fi
+
   steering-eval-discover:
-    needs: [ lint ]
+    needs: [ lint, steering-eval-gate ]
+    if: needs.steering-eval-gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.list.outputs.matrix }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,12 @@ single-seed run, and `--seed N` to set the starting seed — seeds run are
 else in the active-control loop), capture a baseline first (`--json base.json`
 on the unchanged code), re-run after the change, and compare with `--input
 head.json --compare base.json`. CI runs the same suite on PR base + head (job
-`steering-eval`) and posts the comparison as a sticky PR comment. The
+`steering-eval`) and posts the comparison as a sticky PR comment. It costs a
+runner per scenario twice over, so `steering-eval-gate` keeps it off pushes
+entirely and off any PR whose diff touches neither `src/astrameter/ct002/`
+nor `src/astrameter/simulator/` (`*_test.py` under those paths doesn't count)
+nor `.github/workflows/ci.yml` — label a PR `steering-eval` to force a run
+when a change steers from somewhere else. The
 comparison leads with an **aggregate roll-up** (per-metric mean across all
 scenarios plus a one-line overall verdict — how many metrics
 improved/regressed and the mean relative change), so an across-the-board


### PR DESCRIPTION
## Why

The steering evaluation suite (`steering-eval`) is expensive: it runs multiple scenarios across multiple seeds on both the PR base and head, costing a runner per scenario twice over. Currently it runs on every push and every PR, even when the diff touches nothing that could affect steering behavior (e.g., test-only changes, unrelated refactors, or documentation updates).

This change adds a gating job (`steering-eval-gate`) that skips the evaluation when:
- The PR diff touches only test files (`*_test.py`) under the active-control paths
- The diff touches nothing in `src/astrameter/ct002/`, `src/astrameter/simulator/`, or `.github/workflows/ci.yml`
- The change is a push (not a PR)

The gate can be overridden by labeling a PR `steering-eval` to force a run when steering changes from an unexpected location (e.g., a new dependency or refactor elsewhere in the loop).

This reduces CI wall time and runner cost for the majority of PRs while keeping the evaluation available for changes that matter.

## Checklist

- [x] Base branch is `develop`, not `main`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest` — no Python changes
- [x] Python ↔ ESPHome parity held for shared CT002 behaviour, or does not apply — workflow-only change
- [x] `web/` changes: rebuilt the dashboard bundle (`cd web && npm run build:dashboard`) and committed it — not applicable
- [x] User-visible change: one bullet under `## Next` in [CHANGELOG.md](https://github.com/tomquist/AstraMeter/blob/develop/CHANGELOG.md) — documented in `AGENTS.md` (workflow/tooling change, no user-facing feature)

https://claude.ai/code/session_01F9QTPXScmpVc8AUZtfr4Kr