### PR TITLE
Fix B2500 saturation scoring below its DC start floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** a B2500 that stayed at 0 W for good while the house imported and the other batteries were already at their limit: once it had been handed a share too small for it to switch on, it was written off as unable to deliver, which made every later share smaller still ([#624](https://github.com/tomquist/astrameter/issues/624)).
+- **Fixed** a B2500 written off as unable to deliver after being handed a share too small to switch it on, which made every later share smaller still — leaving it at 0 W indefinitely while the house imported ([#624](https://github.com/tomquist/astrameter/issues/624)).
 
 - **Fixed** B2500 batteries sitting at 0 W under active control while the whole house load was imported: the command they were sent could never exceed what the battery needs to start, and a battery that never starts was never sent more ([#600](https://github.com/tomquist/astrameter/issues/600), [#614](https://github.com/tomquist/astrameter/pull/614)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** a B2500 written off as unable to deliver after being handed a share too small to switch it on, which made every later share smaller still — leaving it at 0 W indefinitely while the house imported ([#624](https://github.com/tomquist/astrameter/issues/624)).
+- **Fixed** a B2500 written off as unable to deliver after being handed a share too small to switch it on, which made every later share smaller still — leaving it at 0 W indefinitely while the house imported ([#624](https://github.com/tomquist/astrameter/issues/624), [#629](https://github.com/tomquist/astrameter/pull/629)).
 
 - **Fixed** B2500 batteries sitting at 0 W under active control while the whole house load was imported: the command they were sent could never exceed what the battery needs to start, and a battery that never starts was never sent more ([#600](https://github.com/tomquist/astrameter/issues/600), [#614](https://github.com/tomquist/astrameter/pull/614)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Fixed** a B2500 that stayed at 0 W for good while the house imported and the other batteries were already at their limit: once it had been handed a share too small for it to switch on, it was written off as unable to deliver, which made every later share smaller still ([#624](https://github.com/tomquist/astrameter/issues/624)).
+
 - **Fixed** B2500 batteries sitting at 0 W under active control while the whole house load was imported: the command they were sent could never exceed what the battery needs to start, and a battery that never starts was never sent more ([#600](https://github.com/tomquist/astrameter/issues/600), [#614](https://github.com/tomquist/astrameter/pull/614)).
 
 - **Added** Refoss / Meross energy monitors (EM01P, EM06P, EM16P) as a power source (`[REFOSS]` or `[MEROSS]`) ([#598](https://github.com/tomquist/astrameter/pull/598)).

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -108,9 +108,13 @@ float saturation_floor(const BalancerConsumerState &state, const ConsumerReport 
   // since pacing records it just while its clamp is active and clears it on
   // reversal — then the model's nominal figure. Mirrors balancer.py
   // saturation_floor; see it for why the asymmetry favours the battery.
+  // The configured floor is checked first because a per-device override
+  // applies to any battery, including one whose family has no nominal floor:
+  // for such a unit the override is the only thing that knows it is held above
+  // its deadband.
+  if (configured_floor > 0.0f) return configured_floor;
   const float nominal = min_actionable_output(report.device_type);
   if (nominal <= 0.0f) return 0.0f;
-  if (configured_floor > 0.0f) return configured_floor;
   const float observed = state.pace_responded_at;
   return observed > 0.0f ? std::min(nominal, observed) : nominal;
 }

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -79,9 +79,10 @@ DeviceCapabilities device_capabilities(const std::string &device_type) {
   // Jupiter: DC battery with a built-in inverter.
   if (starts_with(dt, "HMN") || starts_with(dt, "HMM") || starts_with(dt, "JPLS"))
     return {true, false, true};
-  // B2500 family: DC input feeding a SEPARATE inverter (no built-in inverter).
+  // B2500 family: DC input feeding a SEPARATE inverter (no built-in inverter),
+  // and the only family that cannot answer an arbitrarily small command.
   if (starts_with(dt, "HMA") || starts_with(dt, "HMJ") || starts_with(dt, "HMK"))
-    return {false, false, true};
+    return {false, false, true, DC_MIN_ACTIONABLE_OUTPUT_W};
   // Unknown / future / empty: assume a modern AC-coupled battery.
   return {true, true, false};
 }
@@ -96,16 +97,20 @@ bool needs_dc_output_floor(const std::string &device_type) {
 }
 
 float min_actionable_output(const std::string &device_type) {
-  return needs_dc_output_floor(device_type) ? DC_MIN_ACTIONABLE_OUTPUT_W : 0.0f;
+  return device_capabilities(device_type).min_actionable_output_w;
 }
 
-float saturation_floor(const BalancerConsumerState &state, const ConsumerReport &report) {
-  // The nominal figure is an assumption -- a B2500 pairs with whatever inverter
-  // its owner selected, and some energize below it -- so prefer the smallest
-  // command this very unit has been seen to act on (issue #614) where there is
-  // one. Mirrors balancer.py LoadBalancer::_saturation_floor.
+float saturation_floor(const BalancerConsumerState &state, const ConsumerReport &report,
+                       float configured_floor) {
+  // Three sources, most authoritative first: what the owner configured (they
+  // are stating what their inverter needs, and it is the floor we park them
+  // at), then a command this unit was seen to answer — opportunistic only,
+  // since pacing records it just while its clamp is active and clears it on
+  // reversal — then the model's nominal figure. Mirrors balancer.py
+  // saturation_floor; see it for why the asymmetry favours the battery.
   const float nominal = min_actionable_output(report.device_type);
   if (nominal <= 0.0f) return 0.0f;
+  if (configured_floor > 0.0f) return configured_floor;
   const float observed = state.pace_responded_at;
   return observed > 0.0f ? std::min(nominal, observed) : nominal;
 }
@@ -775,9 +780,14 @@ std::array<float, 3> LoadBalancer::compute_target(
     const auto probe_set = this->probe_participants_();
     if (probe_set.find(*consumer_id) == probe_set.end() &&
         this->deprioritized_.find(*consumer_id) == this->deprioritized_.end()) {
-      const float actual = active_reports[*consumer_id].power;
-      this->saturation_.update(*state, last_intent_reading, actual,
-                               saturation_floor(*state, active_reports[*consumer_id]));
+      const ConsumerReport &report = active_reports[*consumer_id];
+      // The floor is compared against the *unpaced* intent, like the rest of
+      // this call (issue #522): a battery the pacing clamp is holding below its
+      // floor must still register as pushed, or a full/empty one would never be
+      // detected while clamped. #614's stall escape bounds that window.
+      this->saturation_.update(
+          *state, last_intent_reading, report.power,
+          saturation_floor(*state, report, this->effective_min_dc_output_(*consumer_id, active_reports)));
     }
   }
 

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -95,6 +95,10 @@ bool needs_dc_output_floor(const std::string &device_type) {
   return !caps.has_ac_input && !caps.has_builtin_inverter;
 }
 
+float min_actionable_output(const std::string &device_type) {
+  return needs_dc_output_floor(device_type) ? DC_MIN_ACTIONABLE_OUTPUT_W : 0.0f;
+}
+
 void BalancerConfig::clamp() {
   auto clamp_v = [](float &v, float lo, float hi) {
     v = std::max(lo, std::min(hi, v));
@@ -140,10 +144,12 @@ SaturationTracker::SaturationTracker(double alpha, float min_target, double deca
       stall_timeout_seconds_(std::max(0.0f, stall_timeout_seconds)) {}
 
 void SaturationTracker::update(BalancerConsumerState &state,
-                               std::optional<float> last_target, float actual) {
+                               std::optional<float> last_target, float actual,
+                               float min_actionable) {
   if (!this->enabled_ || !last_target.has_value()) return;
   const double now = this->clock_();
   const double target_abs = std::fabs(*last_target);
+  const float min_target = std::max(this->min_target_, min_actionable);
 
   if (state.saturation_grace_until > 0.0) {
     if (now < state.saturation_grace_until) {
@@ -151,7 +157,7 @@ void SaturationTracker::update(BalancerConsumerState &state,
         state.saturation_grace_until = 0.0;
         state.saturation_grace_started_at = 0.0;
         state.last_saturation_update = 0.0;
-      } else if (target_abs >= this->min_target_ &&
+      } else if (target_abs >= min_target &&
                  state.saturation_grace_started_at > 0.0 &&
                  (now - state.saturation_grace_started_at) >= this->stall_timeout_seconds_) {
         state.saturation_score = 1.0;
@@ -182,7 +188,7 @@ void SaturationTracker::update(BalancerConsumerState &state,
   if (dt > SATURATION_LONG_GAP_SECONDS) return;
 
   const double ratio = dt / SATURATION_REFERENCE_DT;
-  if (target_abs < this->min_target_ || sign_reversing) {
+  if (target_abs < min_target || sign_reversing) {
     const double prev = state.saturation_score;
     if (prev > 0.0) {
       const double decayed = prev * std::pow(this->decay_factor_, ratio);
@@ -759,7 +765,8 @@ std::array<float, 3> LoadBalancer::compute_target(
     if (probe_set.find(*consumer_id) == probe_set.end() &&
         this->deprioritized_.find(*consumer_id) == this->deprioritized_.end()) {
       const float actual = active_reports[*consumer_id].power;
-      this->saturation_.update(*state, last_intent_reading, actual);
+      this->saturation_.update(*state, last_intent_reading, actual,
+                               min_actionable_output(active_reports[*consumer_id].device_type));
     }
   }
 

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -99,6 +99,17 @@ float min_actionable_output(const std::string &device_type) {
   return needs_dc_output_floor(device_type) ? DC_MIN_ACTIONABLE_OUTPUT_W : 0.0f;
 }
 
+float saturation_floor(const BalancerConsumerState &state, const ConsumerReport &report) {
+  // The nominal figure is an assumption -- a B2500 pairs with whatever inverter
+  // its owner selected, and some energize below it -- so prefer the smallest
+  // command this very unit has been seen to act on (issue #614) where there is
+  // one. Mirrors balancer.py LoadBalancer::_saturation_floor.
+  const float nominal = min_actionable_output(report.device_type);
+  if (nominal <= 0.0f) return 0.0f;
+  const float observed = state.pace_responded_at;
+  return observed > 0.0f ? std::min(nominal, observed) : nominal;
+}
+
 void BalancerConfig::clamp() {
   auto clamp_v = [](float &v, float lo, float hi) {
     v = std::max(lo, std::min(hi, v));
@@ -766,7 +777,7 @@ std::array<float, 3> LoadBalancer::compute_target(
         this->deprioritized_.find(*consumer_id) == this->deprioritized_.end()) {
       const float actual = active_reports[*consumer_id].power;
       this->saturation_.update(*state, last_intent_reading, actual,
-                               min_actionable_output(active_reports[*consumer_id].device_type));
+                               saturation_floor(*state, active_reports[*consumer_id]));
     }
   }
 

--- a/esphome/components/ct002/balancer.h
+++ b/esphome/components/ct002/balancer.h
@@ -128,6 +128,15 @@ bool is_ac_chargeable(const std::string &device_type);
 // inverter and no AC input — the B2500 family). Mirrors _needs_dc_output_floor.
 bool needs_dc_output_floor(const std::string &device_type);
 
+// Smallest net output a DC-only battery (B2500 family) can actually produce:
+// each of its two DC channels is a hard on/off below ~40 W, so the unit cannot
+// answer a command under ~80 W at all. Mirrors DC_MIN_ACTIONABLE_OUTPUT_W.
+constexpr float DC_MIN_ACTIONABLE_OUTPUT_W = 80.0f;
+
+// The floor for *device_type*, 0 for batteries with a built-in inverter.
+// Mirrors balancer.py min_actionable_output.
+float min_actionable_output(const std::string &device_type);
+
 // Absolute net-output target in watts: the single currency of all control
 // logic (mirrors balancer.py NetOutputW). Sign convention, defined once:
 //   +  =  net discharge (export to grid / serve load)
@@ -358,8 +367,12 @@ class SaturationTracker {
                     float stall_timeout_seconds, bool enabled,
                     std::function<double()> clock);
 
+  // *min_actionable* is the smallest command the device can execute (see
+  // min_actionable_output): a target below it is too small to judge the battery
+  // by, exactly like a below-min_target one, because a device that ignores such
+  // a command by construction is not evidence of saturation (issue #624).
   void update(BalancerConsumerState &state, std::optional<float> last_target,
-              float actual);
+              float actual, float min_actionable = 0.0f);
   double get(const BalancerConsumerState &state) const { return state.saturation_score; }
   void set_grace(BalancerConsumerState &state, double deadline);
   void clear(BalancerConsumerState &state);

--- a/esphome/components/ct002/balancer.h
+++ b/esphome/components/ct002/balancer.h
@@ -118,6 +118,9 @@ struct DeviceCapabilities {
   bool has_builtin_inverter{false};
   bool has_ac_input{false};
   bool has_dc_input{false};
+  // Smallest net output the model can be commanded to produce, 0 when it
+  // follows a target down to its own deadband. Mirrors the Python field.
+  float min_actionable_output_w{0.0f};
 };
 
 DeviceCapabilities device_capabilities(const std::string &device_type);
@@ -361,10 +364,11 @@ struct ConsumerReport {
 };
 
 using ReportMap = std::unordered_map<std::string, ConsumerReport>;
-// Smallest command worth judging a consumer by: the demonstrated response
-// floor where this unit has shown one, else the nominal figure for its family.
-// Mirrors balancer.py LoadBalancer._saturation_floor.
-float saturation_floor(const BalancerConsumerState &state, const ConsumerReport &report);
+// Smallest command worth judging a consumer by: the configured MIN_DC_OUTPUT
+// for this battery if its owner set one, else a command it was seen to answer,
+// else the model's nominal floor. Mirrors balancer.py saturation_floor.
+float saturation_floor(const BalancerConsumerState &state, const ConsumerReport &report,
+                       float configured_floor);
 
 
 class SaturationTracker {
@@ -378,7 +382,7 @@ class SaturationTracker {
   // by, exactly like a below-min_target one, because a device that ignores such
   // a command by construction is not evidence of saturation (issue #624).
   void update(BalancerConsumerState &state, std::optional<float> last_target,
-              float actual, float min_actionable = 0.0f);
+              float actual, float min_actionable);
   double get(const BalancerConsumerState &state) const { return state.saturation_score; }
   void set_grace(BalancerConsumerState &state, double deadline);
   void clear(BalancerConsumerState &state);

--- a/esphome/components/ct002/balancer.h
+++ b/esphome/components/ct002/balancer.h
@@ -137,6 +137,7 @@ constexpr float DC_MIN_ACTIONABLE_OUTPUT_W = 80.0f;
 // Mirrors balancer.py min_actionable_output.
 float min_actionable_output(const std::string &device_type);
 
+
 // Absolute net-output target in watts: the single currency of all control
 // logic (mirrors balancer.py NetOutputW). Sign convention, defined once:
 //   +  =  net discharge (export to grid / serve load)
@@ -360,6 +361,11 @@ struct ConsumerReport {
 };
 
 using ReportMap = std::unordered_map<std::string, ConsumerReport>;
+// Smallest command worth judging a consumer by: the demonstrated response
+// floor where this unit has shown one, else the nominal figure for its family.
+// Mirrors balancer.py LoadBalancer._saturation_floor.
+float saturation_floor(const BalancerConsumerState &state, const ConsumerReport &report);
+
 
 class SaturationTracker {
  public:

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -1487,7 +1487,7 @@ class LoadBalancer:
                 state,
                 last_intent_reading,
                 actual,
-                min_actionable_output(report.get("device_type", "")),
+                self._saturation_floor(state, report),
             )
 
         # --- Manual override ---
@@ -1742,6 +1742,29 @@ class LoadBalancer:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _saturation_floor(self, state: BalancerConsumerState, report: dict) -> float:
+        """Smallest command worth judging *state*'s consumer by (W).
+
+        The nominal :func:`min_actionable_output` is a datasheet-ish assumption:
+        a B2500 pairs with whatever inverter the owner picked in the Marstek
+        app, and some of those energize below the ~80 W two-channel figure.  So
+        prefer *evidence* where there is any -- ``pace_responded_at`` is the
+        smallest command this very unit has been seen to act on (issue #614) --
+        and fall back to the assumption only for a unit that has never yet
+        demonstrated it can do less.
+
+        Getting the floor too high costs a real full/empty battery some
+        detection delay, bounded by the floor itself: it keeps its share only
+        while that share stays under a command it could not have answered
+        anyway.  Getting it too low costs the battery entirely (issue #624), so
+        the asymmetry is deliberate.
+        """
+        nominal = min_actionable_output(report.get("device_type", ""))
+        if nominal <= 0.0:
+            return 0.0
+        observed = state.pace_responded_at
+        return min(nominal, observed) if observed > 0.0 else nominal
 
     def _effective_min_dc_output(self, consumer_id: str | None, reports: dict) -> float:
         """Per-consumer MIN_DC_OUTPUT floor (W); 0 means no floor.

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -209,14 +209,19 @@ SATURATION_GRACE_SECONDS = 90
 # ramping up. In that case we bypass the remaining grace window and mark it
 # saturated immediately so the balancer can rotate to a healthy unit.
 SATURATION_STALL_TIMEOUT_SECONDS = 60.0
-# Smallest net output a DC-only battery (B2500 family) can actually produce.
-# Each of its two DC output channels is a hard on/off below roughly 40 W --
-# commanded under that the channel stays de-energized rather than delivering a
-# trickle -- so the unit as a whole cannot answer a command below ~80 W at all.
-# Saturation must not be scored against such a command: "asked for 50 W,
-# delivered 0 W" says nothing about whether the battery *could* deliver, and
-# scoring it as a failure is self-reinforcing, because a saturated battery's
-# share is then cut further below the floor (issue #624).
+# Smallest net output a DC-only battery (B2500 family) can produce: each of its
+# two DC channels is a hard on/off below roughly 40 W, so the unit as a whole
+# cannot answer a command under ~80 W at all.  Scoring saturation against such a
+# command is self-reinforcing — "asked for 50 W, delivered 0 W" says nothing
+# about whether the battery *could* deliver, and a saturated battery's share is
+# then cut further below the floor (issue #624).
+#
+# A nominal figure, not a guarantee: the paired inverter decides, and it is only
+# the fallback where neither the user's MIN_DC_OUTPUT nor observed evidence says
+# otherwise (see saturation_floor).  The simulator models the same physics from
+# the per-channel side (b2500_steering.MIN_CHANNEL_OUTPUT_W); keep them in step,
+# but deliberately not shared — the plant must be able to disagree with the
+# controller for the steering evaluation to mean anything.
 DC_MIN_ACTIONABLE_OUTPUT_W = 80.0
 # Reference poll interval (seconds) at which the configured ``SATURATION_ALPHA``
 # and ``SATURATION_DECAY_FACTOR`` apply one full step.  The EMA is time-
@@ -248,11 +253,17 @@ class DeviceCapabilities:
       never depends on a separate inverter that could sleep at low DC output.
     - ``has_ac_input``: the battery can be charged from AC (Venus lineup).
     - ``has_dc_input``: the battery has a DC (solar) input.
+    - ``min_actionable_output_w``: the smallest net output the model can be
+      commanded to produce, 0 when it follows a target down to its own
+      deadband.  A B2500's two DC channels are a hard on/off below ~40 W each,
+      so it cannot answer a command under ~80 W at all — see
+      :func:`min_actionable_output`.
     """
 
     has_builtin_inverter: bool
     has_ac_input: bool
     has_dc_input: bool
+    min_actionable_output_w: float = 0.0
 
 
 def device_capabilities(device_type: str) -> DeviceCapabilities:
@@ -281,7 +292,7 @@ def device_capabilities(device_type: str) -> DeviceCapabilities:
     if dt.startswith(("HMN", "HMM", "JPLS")):
         return DeviceCapabilities(True, False, True)
     if dt.startswith(("HMA", "HMJ", "HMK")):
-        return DeviceCapabilities(False, False, True)
+        return DeviceCapabilities(False, False, True, DC_MIN_ACTIONABLE_OUTPUT_W)
     return DeviceCapabilities(True, True, False)
 
 
@@ -309,15 +320,40 @@ def _needs_dc_output_floor(device_type: str) -> bool:
 
 
 def min_actionable_output(device_type: str) -> float:
-    """Smallest net output *device_type* can actually be commanded to produce.
+    """The nominal start floor for *device_type* (see its capabilities)."""
+    return device_capabilities(device_type).min_actionable_output_w
 
-    ``0`` for batteries with a built-in inverter, whose regulator follows any
-    target down to its own input deadband.  A DC-only battery driving a
-    separate inverter cannot energize a channel below its minimum, so a command
-    under :data:`DC_MIN_ACTIONABLE_OUTPUT_W` is one it will ignore outright --
-    see :meth:`SaturationTracker.update`.
+
+def saturation_floor(
+    state: BalancerConsumerState, report: dict, configured_floor: float
+) -> float:
+    """Smallest command worth judging this consumer by (W).
+
+    Three sources, most authoritative first:
+
+    * *configured_floor* — the effective MIN_DC_OUTPUT for this battery
+      (global or per-device override).  An owner who set it is stating what
+      their inverter needs, which beats any figure of ours; it also keeps this
+      gate consistent with the floor ``_apply_min_dc_output`` parks them at, and
+      with the MIN_DC_OUTPUT/MIN_TARGET_FOR_SATURATION advice in ``main.py``.
+    * ``pace_responded_at`` — a command this unit was actually seen to answer.
+      Opportunistic only: ramp pacing records it just while its clamp is active
+      and clears it on every direction reversal, so treat its absence as "no
+      evidence", never as "cannot go lower".
+    * the model's nominal floor, as the fallback prior.
+
+    Too high a floor costs a genuinely full or empty battery some detection
+    delay, bounded by the floor itself — it keeps its share only while that
+    share stays under a command it could not have answered anyway.  Too low
+    costs the battery entirely (issue #624), so the asymmetry is deliberate.
     """
-    return DC_MIN_ACTIONABLE_OUTPUT_W if _needs_dc_output_floor(device_type) else 0.0
+    nominal = min_actionable_output(report.get("device_type", ""))
+    if nominal <= 0.0:
+        return 0.0
+    if configured_floor > 0.0:
+        return configured_floor
+    observed = state.pace_responded_at
+    return min(nominal, observed) if observed > 0.0 else nominal
 
 
 # ---------------------------------------------------------------------------
@@ -733,7 +769,7 @@ class SaturationTracker:
         state: BalancerConsumerState,
         last_target: float | None,
         actual: float,
-        min_actionable: float = 0.0,
+        min_actionable: float,
     ) -> None:
         """Update the saturation score for a consumer.
 
@@ -1483,11 +1519,20 @@ class LoadBalancer:
         ):
             report = active_reports.get(consumer_id, {})
             actual = parse_int(report.get("power", 0))
+            # The floor is compared against the *unpaced* intent, like the
+            # rest of this call (issue #522): a battery the pacing clamp is
+            # holding below its floor must still register as pushed, or a
+            # full/empty one would never be detected while clamped.  #614's
+            # stall escape bounds how long the wire stays under the floor.
             self._saturation.update(
                 state,
                 last_intent_reading,
                 actual,
-                self._saturation_floor(state, report),
+                saturation_floor(
+                    state,
+                    report,
+                    self._effective_min_dc_output(consumer_id, active_reports),
+                ),
             )
 
         # --- Manual override ---
@@ -1742,29 +1787,6 @@ class LoadBalancer:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
-
-    def _saturation_floor(self, state: BalancerConsumerState, report: dict) -> float:
-        """Smallest command worth judging *state*'s consumer by (W).
-
-        The nominal :func:`min_actionable_output` is a datasheet-ish assumption:
-        a B2500 pairs with whatever inverter the owner picked in the Marstek
-        app, and some of those energize below the ~80 W two-channel figure.  So
-        prefer *evidence* where there is any -- ``pace_responded_at`` is the
-        smallest command this very unit has been seen to act on (issue #614) --
-        and fall back to the assumption only for a unit that has never yet
-        demonstrated it can do less.
-
-        Getting the floor too high costs a real full/empty battery some
-        detection delay, bounded by the floor itself: it keeps its share only
-        while that share stays under a command it could not have answered
-        anyway.  Getting it too low costs the battery entirely (issue #624), so
-        the asymmetry is deliberate.
-        """
-        nominal = min_actionable_output(report.get("device_type", ""))
-        if nominal <= 0.0:
-            return 0.0
-        observed = state.pace_responded_at
-        return min(nominal, observed) if observed > 0.0 else nominal
 
     def _effective_min_dc_output(self, consumer_id: str | None, reports: dict) -> float:
         """Per-consumer MIN_DC_OUTPUT floor (W); 0 means no floor.

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -209,6 +209,15 @@ SATURATION_GRACE_SECONDS = 90
 # ramping up. In that case we bypass the remaining grace window and mark it
 # saturated immediately so the balancer can rotate to a healthy unit.
 SATURATION_STALL_TIMEOUT_SECONDS = 60.0
+# Smallest net output a DC-only battery (B2500 family) can actually produce.
+# Each of its two DC output channels is a hard on/off below roughly 40 W --
+# commanded under that the channel stays de-energized rather than delivering a
+# trickle -- so the unit as a whole cannot answer a command below ~80 W at all.
+# Saturation must not be scored against such a command: "asked for 50 W,
+# delivered 0 W" says nothing about whether the battery *could* deliver, and
+# scoring it as a failure is self-reinforcing, because a saturated battery's
+# share is then cut further below the floor (issue #624).
+DC_MIN_ACTIONABLE_OUTPUT_W = 80.0
 # Reference poll interval (seconds) at which the configured ``SATURATION_ALPHA``
 # and ``SATURATION_DECAY_FACTOR`` apply one full step.  The EMA is time-
 # weighted against this reference so that batteries polling at different
@@ -297,6 +306,18 @@ def _needs_dc_output_floor(device_type: str) -> bool:
     """
     caps = device_capabilities(device_type)
     return not caps.has_ac_input and not caps.has_builtin_inverter
+
+
+def min_actionable_output(device_type: str) -> float:
+    """Smallest net output *device_type* can actually be commanded to produce.
+
+    ``0`` for batteries with a built-in inverter, whose regulator follows any
+    target down to its own input deadband.  A DC-only battery driving a
+    separate inverter cannot energize a channel below its minimum, so a command
+    under :data:`DC_MIN_ACTIONABLE_OUTPUT_W` is one it will ignore outright --
+    see :meth:`SaturationTracker.update`.
+    """
+    return DC_MIN_ACTIONABLE_OUTPUT_W if _needs_dc_output_floor(device_type) else 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -708,13 +729,27 @@ class SaturationTracker:
         self._stall_timeout_seconds = max(0.0, stall_timeout_seconds)
 
     def update(
-        self, state: BalancerConsumerState, last_target: float | None, actual: float
+        self,
+        state: BalancerConsumerState,
+        last_target: float | None,
+        actual: float,
+        min_actionable: float = 0.0,
     ) -> None:
-        """Update the saturation score for a consumer."""
+        """Update the saturation score for a consumer.
+
+        *min_actionable* is the smallest command the device can physically
+        execute (see :func:`min_actionable_output`).  A target below it is
+        treated exactly like a below-``min_target`` one -- too small to judge
+        the battery by -- because a device that ignores such a command by
+        construction is not evidence of saturation.  Without this a DC-only
+        battery handed a sub-floor share is scored as unable to follow, which
+        cuts its share further and keeps it there for good (issue #624).
+        """
         if not self._enabled or last_target is None:
             return
         now = self._clock()
         target_abs = abs(last_target)
+        min_target = max(self._min_target, min_actionable)
         # Grace period handling
         if state.saturation_grace_until > 0:
             if now < state.saturation_grace_until:
@@ -725,7 +760,7 @@ class SaturationTracker:
                     # reference-period step rather than a stale dt dose.
                     state.last_saturation_update = 0.0
                 elif (
-                    target_abs >= self._min_target
+                    target_abs >= min_target
                     and state.saturation_grace_started_at > 0
                     and now - state.saturation_grace_started_at
                     >= self._stall_timeout_seconds
@@ -766,7 +801,7 @@ class SaturationTracker:
         if dt > SATURATION_LONG_GAP_SECONDS:
             return
         ratio = dt / SATURATION_REFERENCE_DT
-        if target_abs < self._min_target or sign_reversing:
+        if target_abs < min_target or sign_reversing:
             prev = state.saturation_score
             if prev > 0:
                 decayed = prev * (self._decay_factor**ratio)
@@ -1446,8 +1481,14 @@ class LoadBalancer:
             and consumer_id not in self._probe_participants()
             and consumer_id not in self._deprioritized
         ):
-            actual = parse_int(active_reports.get(consumer_id, {}).get("power", 0))
-            self._saturation.update(state, last_intent_reading, actual)
+            report = active_reports.get(consumer_id, {})
+            actual = parse_int(report.get("power", 0))
+            self._saturation.update(
+                state,
+                last_intent_reading,
+                actual,
+                min_actionable_output(report.get("device_type", "")),
+            )
 
         # --- Manual override ---
         if consumer_mode.mode == "manual" and consumer_id and state:

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -336,6 +336,11 @@ def saturation_floor(
       their inverter needs, which beats any figure of ours; it also keeps this
       gate consistent with the floor ``_apply_min_dc_output`` parks them at, and
       with the MIN_DC_OUTPUT/MIN_TARGET_FOR_SATURATION advice in ``main.py``.
+      It is checked *before* the model's own floor because a per-device
+      override applies to any battery, including one whose family has no
+      nominal floor at all — for such a unit the override is the only thing
+      that knows it is being held above its deadband, and discarding it left
+      the gate at ``min_target`` while the command sat at the override.
     * ``pace_responded_at`` — a command this unit was actually seen to answer.
       Opportunistic only: ramp pacing records it just while its clamp is active
       and clears it on every direction reversal, so treat its absence as "no
@@ -347,11 +352,11 @@ def saturation_floor(
     share stays under a command it could not have answered anyway.  Too low
     costs the battery entirely (issue #624), so the asymmetry is deliberate.
     """
+    if configured_floor > 0.0:
+        return configured_floor
     nominal = min_actionable_output(report.get("device_type", ""))
     if nominal <= 0.0:
         return 0.0
-    if configured_floor > 0.0:
-        return configured_floor
     observed = state.pace_responded_at
     return min(nominal, observed) if observed > 0.0 else nominal
 

--- a/tests/components/ct002/host_balancer_test.cpp
+++ b/tests/components/ct002/host_balancer_test.cpp
@@ -25,7 +25,11 @@ using esphome::ct002::CONTROL_QUALITY_WARMUP_SECONDS;
 using esphome::ct002::ControlQualityTracker;
 using esphome::ct002::is_ac_chargeable;
 using esphome::ct002::LoadBalancer;
+using esphome::ct002::BalancerConsumerState;
+using esphome::ct002::DC_MIN_ACTIONABLE_OUTPUT_W;
+using esphome::ct002::min_actionable_output;
 using esphome::ct002::needs_dc_output_floor;
+using esphome::ct002::SaturationTracker;
 using esphome::ct002::NetOutputW;
 using esphome::ct002::ReportMap;
 using esphome::ct002::to_grid_reading;
@@ -101,6 +105,50 @@ TEST(NeedsDcOutputFloor, OnlyExternalInverterFamilies) {
   EXPECT_FALSE(needs_dc_output_floor("VNSD"));      // Venus D (built-in + DC)
   EXPECT_FALSE(needs_dc_output_floor("HMN-1"));     // Jupiter
   EXPECT_FALSE(needs_dc_output_floor(""));          // unknown -> assumed AC
+}
+
+TEST(MinActionableOutput, OnlyDcOnlyBatteriesHaveAStartFloor) {
+  EXPECT_FLOAT_EQ(min_actionable_output("HMJ-2"), DC_MIN_ACTIONABLE_OUTPUT_W);
+  EXPECT_FLOAT_EQ(min_actionable_output("HMA-1"), DC_MIN_ACTIONABLE_OUTPUT_W);
+  EXPECT_FLOAT_EQ(min_actionable_output("HMG-50"), 0.0f);   // Venus
+  EXPECT_FLOAT_EQ(min_actionable_output("VNSE3-0"), 0.0f);  // Venus E3
+  EXPECT_FLOAT_EQ(min_actionable_output("HMN-1"), 0.0f);    // Jupiter
+}
+
+// Issue #624: a B2500 cannot energize a DC channel below ~80 W, so a command
+// under that floor is not a target it can miss — scoring it as saturated cut
+// the battery's share further below the floor and pinned it at 0 W for good.
+TEST(SaturationTrackerDcFloor, SubFloorCommandScoresNothing) {
+  double now = 1000.0;
+  SaturationTracker tracker(0.15, 20.0f, 0.995, 60.0f, true, [&now]() { return now; });
+  BalancerConsumerState state;
+  for (int i = 0; i < 40; i++) {
+    tracker.update(state, 50.0f, 0.0f, min_actionable_output("HMJ-2"));
+    now += 1.5;
+  }
+  EXPECT_DOUBLE_EQ(tracker.get(state), 0.0);
+}
+
+TEST(SaturationTrackerDcFloor, CommandAboveTheFloorStillScores) {
+  double now = 1000.0;
+  SaturationTracker tracker(0.15, 20.0f, 0.995, 60.0f, true, [&now]() { return now; });
+  BalancerConsumerState state;
+  for (int i = 0; i < 40; i++) {
+    tracker.update(state, 200.0f, 0.0f, min_actionable_output("HMJ-2"));
+    now += 1.5;
+  }
+  EXPECT_GT(tracker.get(state), 0.8);
+}
+
+TEST(SaturationTrackerDcFloor, VenusIsUnaffected) {
+  double now = 1000.0;
+  SaturationTracker tracker(0.15, 20.0f, 0.995, 60.0f, true, [&now]() { return now; });
+  BalancerConsumerState state;
+  for (int i = 0; i < 40; i++) {
+    tracker.update(state, 50.0f, 0.0f, min_actionable_output("VNSE3-0"));
+    now += 1.5;
+  }
+  EXPECT_GT(tracker.get(state), 0.8);
 }
 
 TEST(LoadBalancer, InactiveSteersConsumerOutputToZero) {

--- a/tests/components/ct002/host_balancer_test.cpp
+++ b/tests/components/ct002/host_balancer_test.cpp
@@ -145,8 +145,12 @@ TEST(SaturationTrackerDcFloor, FloorPrefersEvidenceOverTheNominalFigure) {
   EXPECT_FLOAT_EQ(saturation_floor(state, report, 0.0f), 30.0f);
   state.pace_responded_at = 250.0f;
   EXPECT_FLOAT_EQ(saturation_floor(state, report, 0.0f), DC_MIN_ACTIONABLE_OUTPUT_W);
+  // A per-device MIN_DC_OUTPUT override applies to any battery, including a
+  // family with no nominal floor — that unit is held above its deadband, so
+  // the gate has to follow it.
   report.device_type = "VNSE3-0";
-  EXPECT_FLOAT_EQ(saturation_floor(state, report, 150.0f), 0.0f);
+  EXPECT_FLOAT_EQ(saturation_floor(state, report, 150.0f), 150.0f);
+  EXPECT_FLOAT_EQ(saturation_floor(state, report, 0.0f), 0.0f);
 }
 
 TEST(LoadBalancer, InactiveSteersConsumerOutputToZero) {

--- a/tests/components/ct002/host_balancer_test.cpp
+++ b/tests/components/ct002/host_balancer_test.cpp
@@ -29,6 +29,7 @@ using esphome::ct002::BalancerConsumerState;
 using esphome::ct002::DC_MIN_ACTIONABLE_OUTPUT_W;
 using esphome::ct002::min_actionable_output;
 using esphome::ct002::needs_dc_output_floor;
+using esphome::ct002::saturation_floor;
 using esphome::ct002::SaturationTracker;
 using esphome::ct002::NetOutputW;
 using esphome::ct002::ReportMap;
@@ -149,6 +150,22 @@ TEST(SaturationTrackerDcFloor, VenusIsUnaffected) {
     now += 1.5;
   }
   EXPECT_GT(tracker.get(state), 0.8);
+}
+
+// The nominal floor is an assumption (the paired inverter decides); a command
+// this unit has been seen to answer beats it. Mirrors the Python test.
+TEST(SaturationTrackerDcFloor, DemonstratedResponseBeatsTheNominalFloor) {
+  BalancerConsumerState state;
+  ConsumerReport report;
+  report.device_type = "HMJ-2";
+  EXPECT_FLOAT_EQ(saturation_floor(state, report), DC_MIN_ACTIONABLE_OUTPUT_W);
+  state.pace_responded_at = 30.0f;
+  EXPECT_FLOAT_EQ(saturation_floor(state, report), 30.0f);
+  // A large command answered says nothing about small ones.
+  state.pace_responded_at = 250.0f;
+  EXPECT_FLOAT_EQ(saturation_floor(state, report), DC_MIN_ACTIONABLE_OUTPUT_W);
+  report.device_type = "VNSE3-0";
+  EXPECT_FLOAT_EQ(saturation_floor(state, report), 0.0f);
 }
 
 TEST(LoadBalancer, InactiveSteersConsumerOutputToZero) {

--- a/tests/components/ct002/host_balancer_test.cpp
+++ b/tests/components/ct002/host_balancer_test.cpp
@@ -108,64 +108,45 @@ TEST(NeedsDcOutputFloor, OnlyExternalInverterFamilies) {
   EXPECT_FALSE(needs_dc_output_floor(""));          // unknown -> assumed AC
 }
 
-TEST(MinActionableOutput, OnlyDcOnlyBatteriesHaveAStartFloor) {
-  EXPECT_FLOAT_EQ(min_actionable_output("HMJ-2"), DC_MIN_ACTIONABLE_OUTPUT_W);
-  EXPECT_FLOAT_EQ(min_actionable_output("HMA-1"), DC_MIN_ACTIONABLE_OUTPUT_W);
-  EXPECT_FLOAT_EQ(min_actionable_output("HMG-50"), 0.0f);   // Venus
-  EXPECT_FLOAT_EQ(min_actionable_output("VNSE3-0"), 0.0f);  // Venus E3
-  EXPECT_FLOAT_EQ(min_actionable_output("HMN-1"), 0.0f);    // Jupiter
-}
-
 // Issue #624: a B2500 cannot energize a DC channel below ~80 W, so a command
 // under that floor is not a target it can miss — scoring it as saturated cut
 // the battery's share further below the floor and pinned it at 0 W for good.
-TEST(SaturationTrackerDcFloor, SubFloorCommandScoresNothing) {
+double score_after(float target, float min_actionable, int polls = 40) {
   double now = 1000.0;
   SaturationTracker tracker(0.15, 20.0f, 0.995, 60.0f, true, [&now]() { return now; });
   BalancerConsumerState state;
-  for (int i = 0; i < 40; i++) {
-    tracker.update(state, 50.0f, 0.0f, min_actionable_output("HMJ-2"));
+  for (int i = 0; i < polls; i++) {
+    tracker.update(state, target, 0.0f, min_actionable);
     now += 1.5;
   }
-  EXPECT_DOUBLE_EQ(tracker.get(state), 0.0);
+  return tracker.get(state);
 }
 
-TEST(SaturationTrackerDcFloor, CommandAboveTheFloorStillScores) {
-  double now = 1000.0;
-  SaturationTracker tracker(0.15, 20.0f, 0.995, 60.0f, true, [&now]() { return now; });
-  BalancerConsumerState state;
-  for (int i = 0; i < 40; i++) {
-    tracker.update(state, 200.0f, 0.0f, min_actionable_output("HMJ-2"));
-    now += 1.5;
-  }
-  EXPECT_GT(tracker.get(state), 0.8);
+TEST(SaturationTrackerDcFloor, ScoredOnlyAboveTheStartFloor) {
+  // Below what a B2500 can execute: it cannot try, so it cannot fail.
+  EXPECT_DOUBLE_EQ(score_after(50.0f, DC_MIN_ACTIONABLE_OUTPUT_W), 0.0);
+  // Above it: ignoring a command it could have executed is real evidence.
+  EXPECT_GT(score_after(200.0f, DC_MIN_ACTIONABLE_OUTPUT_W), 0.8);
+  // A battery with a built-in inverter follows 50 W, so missing it counts.
+  EXPECT_GT(score_after(50.0f, 0.0f), 0.8);
 }
 
-TEST(SaturationTrackerDcFloor, VenusIsUnaffected) {
-  double now = 1000.0;
-  SaturationTracker tracker(0.15, 20.0f, 0.995, 60.0f, true, [&now]() { return now; });
-  BalancerConsumerState state;
-  for (int i = 0; i < 40; i++) {
-    tracker.update(state, 50.0f, 0.0f, min_actionable_output("VNSE3-0"));
-    now += 1.5;
-  }
-  EXPECT_GT(tracker.get(state), 0.8);
-}
-
-// The nominal floor is an assumption (the paired inverter decides); a command
-// this unit has been seen to answer beats it. Mirrors the Python test.
-TEST(SaturationTrackerDcFloor, DemonstratedResponseBeatsTheNominalFloor) {
+TEST(SaturationTrackerDcFloor, FloorPrefersEvidenceOverTheNominalFigure) {
   BalancerConsumerState state;
   ConsumerReport report;
   report.device_type = "HMJ-2";
-  EXPECT_FLOAT_EQ(saturation_floor(state, report), DC_MIN_ACTIONABLE_OUTPUT_W);
+  EXPECT_FLOAT_EQ(saturation_floor(state, report, 0.0f), DC_MIN_ACTIONABLE_OUTPUT_W);
+  // A configured MIN_DC_OUTPUT outranks our figure, in both directions.
+  EXPECT_FLOAT_EQ(saturation_floor(state, report, 30.0f), 30.0f);
+  EXPECT_FLOAT_EQ(saturation_floor(state, report, 150.0f), 150.0f);
+  // Otherwise a smaller command this unit answered lowers it; a large one says
+  // nothing about small ones.
   state.pace_responded_at = 30.0f;
-  EXPECT_FLOAT_EQ(saturation_floor(state, report), 30.0f);
-  // A large command answered says nothing about small ones.
+  EXPECT_FLOAT_EQ(saturation_floor(state, report, 0.0f), 30.0f);
   state.pace_responded_at = 250.0f;
-  EXPECT_FLOAT_EQ(saturation_floor(state, report), DC_MIN_ACTIONABLE_OUTPUT_W);
+  EXPECT_FLOAT_EQ(saturation_floor(state, report, 0.0f), DC_MIN_ACTIONABLE_OUTPUT_W);
   report.device_type = "VNSE3-0";
-  EXPECT_FLOAT_EQ(saturation_floor(state, report), 0.0f);
+  EXPECT_FLOAT_EQ(saturation_floor(state, report, 150.0f), 0.0f);
 }
 
 TEST(LoadBalancer, InactiveSteersConsumerOutputToZero) {

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -110,25 +110,25 @@ class TestSaturationTracker:
     def test_update_noop_when_disabled(self):
         tracker = self._make_tracker(enabled=False)
         state = BalancerConsumerState()
-        tracker.update(state, 200, 0)
+        tracker.update(state, 200, 0, 0.0)
         assert state.saturation_score == 0.0
 
     def test_update_noop_when_last_target_none(self):
         tracker = self._make_tracker()
         state = BalancerConsumerState()
-        tracker.update(state, None, 0)
+        tracker.update(state, None, 0, 0.0)
         assert state.saturation_score == 0.0
 
     def test_update_saturated_when_actual_below_min_target(self):
         tracker = self._make_tracker(alpha=1.0, min_target=20)
         state = BalancerConsumerState()
-        tracker.update(state, 200, 5)  # actual=5 < min_target=20
+        tracker.update(state, 200, 5, 0.0)  # actual=5 < min_target=20
         assert state.saturation_score == 1.0
 
     def test_update_not_saturated_when_actual_at_min_target(self):
         tracker = self._make_tracker(alpha=1.0, min_target=20)
         state = BalancerConsumerState()
-        tracker.update(state, 200, 20)  # actual=20 >= min_target=20
+        tracker.update(state, 200, 20, 0.0)  # actual=20 >= min_target=20
         assert state.saturation_score == 0.0
 
     def test_update_ema_smoothing(self):
@@ -137,30 +137,30 @@ class TestSaturationTracker:
         # First update: saturated.  The first sample is treated as one
         # reference period (``prev_t = now - SATURATION_REFERENCE_DT``),
         # so the per-sample EMA formula applies directly.
-        tracker.update(state, 200, 0)
+        tracker.update(state, 200, 0, 0.0)
         assert state.saturation_score == 0.5  # 0.5*1.0 + 0.5*0.0
         # Second update one reference period later: still saturated.
         clock.advance(1.0)
-        tracker.update(state, 200, 0)
+        tracker.update(state, 200, 0, 0.0)
         assert state.saturation_score == 0.75  # 0.5*1.0 + 0.5*0.5
 
     def test_update_decays_when_target_below_min(self):
         tracker = self._make_tracker(decay_factor=0.9, min_target=20)
         state = BalancerConsumerState(saturation_score=0.5)
-        tracker.update(state, 10, 10)  # target_abs=10 < min_target=20
+        tracker.update(state, 10, 10, 0.0)  # target_abs=10 < min_target=20
         assert abs(state.saturation_score - 0.45) < 1e-6  # 0.5 * 0.9
 
     def test_update_decay_floor(self):
         tracker = self._make_tracker(decay_factor=0.5, min_target=20)
         state = BalancerConsumerState(saturation_score=0.001)
-        tracker.update(state, 10, 10)
+        tracker.update(state, 10, 10, 0.0)
         # 0.001 * 0.5 = 0.0005 < 0.001 → floored to 0.0
         assert state.saturation_score == 0.0
 
     def test_grace_period_skips_update(self):
         tracker = self._make_tracker(alpha=1.0, min_target=20)
         state = BalancerConsumerState(saturation_grace_until=time.time() + 100)
-        tracker.update(state, 200, 0)  # actual=0, would saturate
+        tracker.update(state, 200, 0, 0.0)  # actual=0, would saturate
         assert state.saturation_score == 0.0  # skipped due to grace
 
     def test_grace_clears_early_on_meaningful_output(self):
@@ -170,7 +170,7 @@ class TestSaturationTracker:
             saturation_grace_until=now + 100,
             saturation_grace_started_at=now,
         )
-        tracker.update(state, 200, 50)  # actual=50 >= min_target=20
+        tracker.update(state, 200, 50, 0.0)  # actual=50 >= min_target=20
         assert state.saturation_grace_until == 0.0  # grace cleared early
         assert state.saturation_grace_started_at == 0.0
         assert state.saturation_score == 0.0  # not saturated
@@ -181,7 +181,7 @@ class TestSaturationTracker:
             saturation_grace_until=time.time() - 1,
             saturation_grace_started_at=time.time() - 5,
         )
-        tracker.update(state, 200, 0)
+        tracker.update(state, 200, 0, 0.0)
         assert state.saturation_grace_until == 0.0
         assert state.saturation_grace_started_at == 0.0
         assert state.saturation_score == 1.0  # grace expired, saturated
@@ -195,7 +195,7 @@ class TestSaturationTracker:
             saturation_grace_until=now + 100,
             saturation_grace_started_at=now - 5,
         )
-        tracker.update(state, 200, 0)
+        tracker.update(state, 200, 0, 0.0)
         assert state.saturation_score == 1.0
         assert state.saturation_grace_until == 0.0
         assert state.saturation_grace_started_at == 0.0
@@ -232,12 +232,12 @@ class TestSaturationTracker:
 
         # Battery discharging at 100W, tracking well
         for _ in range(5):
-            tracker.update(state, last_target=100.0, actual=95.0)
+            tracker.update(state, last_target=100.0, actual=95.0, min_actionable=0.0)
         assert state.saturation_score < 0.01
 
         # Target flips to charge (-100W), but actual is still +80W (ramping)
         for _ in range(20):
-            tracker.update(state, last_target=-100.0, actual=80.0)
+            tracker.update(state, last_target=-100.0, actual=80.0, min_actionable=0.0)
         # Score must NOT have accumulated — should have stayed near zero
         assert state.saturation_score < 0.01, (
             f"Saturation score {state.saturation_score:.3f} should not "
@@ -251,7 +251,7 @@ class TestSaturationTracker:
 
         # Target positive, actual negative (battery reversing)
         for _ in range(10):
-            tracker.update(state, last_target=100.0, actual=-50.0)
+            tracker.update(state, last_target=100.0, actual=-50.0, min_actionable=0.0)
         assert state.saturation_score < 0.5, (
             f"Score should decay during sign reversal, got {state.saturation_score:.3f}"
         )
@@ -267,7 +267,7 @@ class TestSaturationTracker:
         # update so the time-weighted EMA applies one full per-sample
         # step each iteration.
         for _ in range(20):
-            tracker.update(state, last_target=100.0, actual=5.0)
+            tracker.update(state, last_target=100.0, actual=5.0, min_actionable=0.0)
             clock.advance(1.0)
         assert state.saturation_score > 0.4, (
             f"Saturation score {state.saturation_score:.3f} should accumulate "
@@ -282,7 +282,7 @@ class TestSaturationTracker:
 
         # Target is -100W (charge) but actual is exactly 0
         for _ in range(20):
-            tracker.update(state, last_target=-100.0, actual=0.0)
+            tracker.update(state, last_target=-100.0, actual=0.0, min_actionable=0.0)
             clock.advance(1.0)
         assert state.saturation_score > 0.4, (
             f"Saturation score {state.saturation_score:.3f} should accumulate "
@@ -297,7 +297,7 @@ class TestSaturationTracker:
         # Target is 0, actual is positive — target_abs < min_target so
         # the low-target decay path handles this, not the sign guard.
         for _ in range(10):
-            tracker.update(state, last_target=0.0, actual=50.0)
+            tracker.update(state, last_target=0.0, actual=50.0, min_actionable=0.0)
         # Score should have decayed via the low-target path
         assert state.saturation_score < 0.5
 
@@ -309,14 +309,14 @@ class TestSaturationTracker:
 
         # Phase 1: sign reversal — target negative, actual positive
         for _ in range(10):
-            tracker.update(state, last_target=-100.0, actual=50.0)
+            tracker.update(state, last_target=-100.0, actual=50.0, min_actionable=0.0)
             clock.advance(1.0)
         score_after_reversal = state.saturation_score
         assert score_after_reversal < 0.01
 
         # Phase 2: actual crosses zero but is small (same sign, low output)
         for _ in range(20):
-            tracker.update(state, last_target=-100.0, actual=-5.0)
+            tracker.update(state, last_target=-100.0, actual=-5.0, min_actionable=0.0)
             clock.advance(1.0)
         assert state.saturation_score > 0.4, (
             f"Saturation score {state.saturation_score:.3f} should accumulate "
@@ -352,7 +352,7 @@ class TestSaturationTracker:
             elapsed = 0.0
             while elapsed < window_seconds - 1e-9:
                 clock.advance(dt)
-                tracker.update(state, last_target=100.0, actual=5.0)
+                tracker.update(state, last_target=100.0, actual=5.0, min_actionable=0.0)
                 elapsed += dt
             return state.saturation_score
 
@@ -385,7 +385,7 @@ class TestSaturationTracker:
             elapsed = 0.0
             while elapsed < window_seconds - 1e-9:
                 clock.advance(dt)
-                tracker.update(state, last_target=5.0, actual=5.0)
+                tracker.update(state, last_target=5.0, actual=5.0, min_actionable=0.0)
                 elapsed += dt
             return state.saturation_score
 
@@ -410,7 +410,7 @@ class TestSaturationTracker:
         # the long-gap threshold, then reporting again.
         state.last_saturation_update = clock()
         clock.advance(SATURATION_LONG_GAP_SECONDS + 10.0)
-        tracker.update(state, last_target=100.0, actual=5.0)
+        tracker.update(state, last_target=100.0, actual=5.0, min_actionable=0.0)
         # The score must not have moved by a huge amount — the gap
         # should have been dropped and the update re-seeded.
         assert state.saturation_score == 0.5

--- a/tests/test_balancer_dc_start_floor.py
+++ b/tests/test_balancer_dc_start_floor.py
@@ -50,6 +50,28 @@ def _tracker(clock: _FakeClock) -> SaturationTracker:
     )
 
 
+def _balancer(clock: _FakeClock) -> LoadBalancer:
+    return LoadBalancer(
+        config=BalancerConfig(
+            min_efficient_power=100.0,
+            fair_distribution=True,
+            balance_gain=0.2,
+            balance_deadband=25,
+            concentrate_deadband=60.0,
+            grid_predict_trust=0.5,
+            osc_damp_max=0.95,
+            pace_base_step=100,
+            pace_max_step=400,
+        ),
+        saturation_alpha=0.15,
+        saturation_min_target=20,
+        saturation_decay_factor=0.995,
+        saturation_grace_seconds=90,
+        saturation_stall_timeout_seconds=60,
+        clock=clock,
+    )
+
+
 def test_min_actionable_output_only_applies_to_dc_only_batteries() -> None:
     assert min_actionable_output("HMJ-2") == DC_MIN_ACTIONABLE_OUTPUT_W
     assert min_actionable_output("HMA-1") == DC_MIN_ACTIONABLE_OUTPUT_W
@@ -98,6 +120,29 @@ def test_venus_is_unaffected_by_the_dc_floor() -> None:
     assert tracker.get(state) > 0.8
 
 
+def test_a_unit_seen_answering_a_smaller_command_is_judged_from_there() -> None:
+    """The 80 W figure is an assumption; a demonstrated response beats it.
+
+    A B2500 pairs with whatever inverter its owner selected, and some energize
+    below the nominal two-channel floor.  Once such a unit has answered a 30 W
+    command, a missed 50 W one is real evidence again -- otherwise a genuinely
+    empty battery of that kind would keep its share.
+    """
+    clock = _FakeClock()
+    lb = _balancer(clock)
+    state = lb._get_consumer("cccccccccccc")
+    report = {"device_type": "HMJ-2", "phase": "A", "power": 0}
+
+    assert lb._saturation_floor(state, report) == DC_MIN_ACTIONABLE_OUTPUT_W
+    state.pace_responded_at = 30.0
+    assert lb._saturation_floor(state, report) == 30.0
+    # A big command answered says nothing about small ones: stay conservative.
+    state.pace_responded_at = 250.0
+    assert lb._saturation_floor(state, report) == DC_MIN_ACTIONABLE_OUTPUT_W
+    # Batteries with a built-in inverter keep no floor either way.
+    assert lb._saturation_floor(state, {"device_type": "VNSE3-0"}) == 0.0
+
+
 def test_idle_b2500_keeps_its_share_while_under_commanded() -> None:
     """The reporter's case, driven through the balancer.
 
@@ -107,25 +152,7 @@ def test_idle_b2500_keeps_its_share_while_under_commanded() -> None:
     reporter's log its largest command over two minutes was 77 W.
     """
     clock = _FakeClock()
-    lb = LoadBalancer(
-        config=BalancerConfig(
-            min_efficient_power=100.0,
-            fair_distribution=True,
-            balance_gain=0.2,
-            balance_deadband=25,
-            concentrate_deadband=60.0,
-            grid_predict_trust=0.5,
-            osc_damp_max=0.95,
-            pace_base_step=100,
-            pace_max_step=400,
-        ),
-        saturation_alpha=0.15,
-        saturation_min_target=20,
-        saturation_decay_factor=0.995,
-        saturation_grace_seconds=90,
-        saturation_stall_timeout_seconds=60,
-        clock=clock,
-    )
+    lb = _balancer(clock)
     mode = ConsumerMode("auto", None)
     at_limit, stuck = "aaaaaaaaaaaa", "bbbbbbbbbbbb"
     reports = {

--- a/tests/test_balancer_dc_start_floor.py
+++ b/tests/test_balancer_dc_start_floor.py
@@ -107,8 +107,13 @@ def test_the_floor_prefers_evidence_over_the_nominal_figure() -> None:
     # A large command answered says nothing about small ones: stay conservative.
     state.pace_responded_at = 250.0
     assert saturation_floor(state, B2500, 0.0) == DC_MIN_ACTIONABLE_OUTPUT_W
-    # Batteries with a built-in inverter keep no floor either way.
-    assert saturation_floor(state, {"device_type": "VNSE3-0"}, 150.0) == 0.0
+    # A per-device MIN_DC_OUTPUT override applies to any battery, including a
+    # family with no nominal floor: that unit is being held above its deadband,
+    # and the gate has to follow, or it is judged against a command it is never
+    # sent (flagged by CodeRabbit on #629).
+    assert saturation_floor(state, {"device_type": "VNSE3-0"}, 150.0) == 150.0
+    # With no override, a battery with a built-in inverter keeps no floor.
+    assert saturation_floor(state, {"device_type": "VNSE3-0"}, 0.0) == 0.0
 
 
 def test_compute_target_supplies_each_consumer_its_floor() -> None:

--- a/tests/test_balancer_dc_start_floor.py
+++ b/tests/test_balancer_dc_start_floor.py
@@ -1,0 +1,151 @@
+"""Regression: a sub-floor command must not score a B2500 as saturated (#624).
+
+A B2500's two DC output channels are a hard on/off below ~40 W each, so the
+unit cannot answer any command below ~80 W at all.  Saturation used to be
+scored against such a command anyway: the battery was asked for 50 W,
+delivered nothing, and was recorded as "cannot follow its target".  That cut
+its share of every later correction to roughly a tenth, which put the next
+command even further below the floor -- so it sat at 0 W for good while the
+house kept importing, and only a manual target could get it out.
+
+Decoded from the reporter's debug log (discussion #625, 2026-08-27 07:58-08:01):
+two B2500 left running, one pinned at its 400 W single-output limit, the grid
+importing 140 W on average, and the second unit -- with all its headroom free --
+asked for 12 W on average and never once for the ~80 W it needs to start.
+"""
+
+from __future__ import annotations
+
+import time
+
+from astrameter.ct002.balancer import (
+    DC_MIN_ACTIONABLE_OUTPUT_W,
+    BalancerConfig,
+    BalancerConsumerState,
+    ConsumerMode,
+    LoadBalancer,
+    SaturationTracker,
+    min_actionable_output,
+)
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self._t = time.time()
+
+    def __call__(self) -> float:
+        return self._t
+
+    def advance(self, dt: float) -> None:
+        self._t += dt
+
+
+def _tracker(clock: _FakeClock) -> SaturationTracker:
+    return SaturationTracker(
+        alpha=0.15,
+        min_target=20,
+        decay_factor=0.995,
+        stall_timeout_seconds=60,
+        clock=clock,
+    )
+
+
+def test_min_actionable_output_only_applies_to_dc_only_batteries() -> None:
+    assert min_actionable_output("HMJ-2") == DC_MIN_ACTIONABLE_OUTPUT_W
+    assert min_actionable_output("HMA-1") == DC_MIN_ACTIONABLE_OUTPUT_W
+    # Venus and Jupiter regulate down to their own deadband.
+    assert min_actionable_output("HMG-50") == 0.0
+    assert min_actionable_output("VNSE3-0") == 0.0
+    assert min_actionable_output("HMN-1") == 0.0
+
+
+def test_sub_floor_command_scores_no_saturation() -> None:
+    """50 W asked of a B2500 is not a target it can miss -- it cannot try."""
+    clock = _FakeClock()
+    tracker = _tracker(clock)
+    state = BalancerConsumerState()
+
+    for _ in range(40):
+        tracker.update(state, 50.0, 0.0, min_actionable_output("HMJ-2"))
+        clock.advance(1.5)
+
+    assert tracker.get(state) == 0.0
+
+
+def test_command_above_the_floor_still_scores_saturation() -> None:
+    """A battery that ignores a command it *could* execute is still saturated."""
+    clock = _FakeClock()
+    tracker = _tracker(clock)
+    state = BalancerConsumerState()
+
+    for _ in range(40):
+        tracker.update(state, 200.0, 0.0, min_actionable_output("HMJ-2"))
+        clock.advance(1.5)
+
+    assert tracker.get(state) > 0.8
+
+
+def test_venus_is_unaffected_by_the_dc_floor() -> None:
+    """A Venus follows small targets, so a missed 50 W is real evidence."""
+    clock = _FakeClock()
+    tracker = _tracker(clock)
+    state = BalancerConsumerState()
+
+    for _ in range(40):
+        tracker.update(state, 50.0, 0.0, min_actionable_output("VNSE3-0"))
+        clock.advance(1.5)
+
+    assert tracker.get(state) > 0.8
+
+
+def test_idle_b2500_keeps_its_share_while_under_commanded() -> None:
+    """The reporter's case, driven through the balancer.
+
+    One B2500 at its 400 W limit, one stuck at 1 W (it never got a command big
+    enough to start), ~150 W importing.  The idle one has to keep getting a
+    real share, so that it eventually clears its start floor -- in the
+    reporter's log its largest command over two minutes was 77 W.
+    """
+    clock = _FakeClock()
+    lb = LoadBalancer(
+        config=BalancerConfig(
+            min_efficient_power=100.0,
+            fair_distribution=True,
+            balance_gain=0.2,
+            balance_deadband=25,
+            concentrate_deadband=60.0,
+            grid_predict_trust=0.5,
+            osc_damp_max=0.95,
+            pace_base_step=100,
+            pace_max_step=400,
+        ),
+        saturation_alpha=0.15,
+        saturation_min_target=20,
+        saturation_decay_factor=0.995,
+        saturation_grace_seconds=90,
+        saturation_stall_timeout_seconds=60,
+        clock=clock,
+    )
+    mode = ConsumerMode("auto", None)
+    at_limit, stuck = "aaaaaaaaaaaa", "bbbbbbbbbbbb"
+    reports = {
+        at_limit: {"device_type": "HMJ-2", "phase": "A", "power": 400},
+        stuck: {"device_type": "HMJ-2", "phase": "A", "power": 1},
+    }
+
+    asks = []
+    for i in range(120):
+        grid = 150.0 if i % 4 else 20.0  # drum pulsing, mostly importing
+        for cid in (at_limit, stuck):
+            out = lb.compute_target(
+                cid, mode, reports, grid, frozenset(), frozenset(), (i, grid)
+            )
+            if cid == stuck:
+                asks.append(sum(out))
+            clock.advance(1.5)
+
+    biggest = max(asks)
+    assert biggest >= DC_MIN_ACTIONABLE_OUTPUT_W, (
+        f"the idle B2500's largest command was {biggest:.0f} W, below the "
+        f"{DC_MIN_ACTIONABLE_OUTPUT_W:.0f} W it needs to produce anything"
+    )

--- a/tests/test_balancer_dc_start_floor.py
+++ b/tests/test_balancer_dc_start_floor.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import time
 
+import pytest
+
 from astrameter.ct002.balancer import (
     DC_MIN_ACTIONABLE_OUTPUT_W,
     BalancerConfig,
@@ -26,7 +28,10 @@ from astrameter.ct002.balancer import (
     LoadBalancer,
     SaturationTracker,
     min_actionable_output,
+    saturation_floor,
 )
+
+B2500 = {"device_type": "HMJ-2", "phase": "A", "power": 0}
 
 
 class _FakeClock:
@@ -40,29 +45,83 @@ class _FakeClock:
         self._t += dt
 
 
-def _tracker(clock: _FakeClock) -> SaturationTracker:
-    return SaturationTracker(
+def _score_after(target: float, min_actionable: float, polls: int = 40) -> float:
+    """Drive a tracker with a battery that reports nothing, and return its score."""
+    clock = _FakeClock()
+    tracker = SaturationTracker(
         alpha=0.15,
         min_target=20,
         decay_factor=0.995,
         stall_timeout_seconds=60,
         clock=clock,
     )
+    state = BalancerConsumerState()
+    for _ in range(polls):
+        tracker.update(state, target, 0.0, min_actionable)
+        clock.advance(1.5)
+    return tracker.get(state)
 
 
-def _balancer(clock: _FakeClock) -> LoadBalancer:
-    return LoadBalancer(
-        config=BalancerConfig(
-            min_efficient_power=100.0,
-            fair_distribution=True,
-            balance_gain=0.2,
-            balance_deadband=25,
-            concentrate_deadband=60.0,
-            grid_predict_trust=0.5,
-            osc_damp_max=0.95,
-            pace_base_step=100,
-            pace_max_step=400,
-        ),
+def test_dc_only_batteries_carry_a_start_floor() -> None:
+    assert min_actionable_output("HMJ-2") == DC_MIN_ACTIONABLE_OUTPUT_W
+    # A Venus regulates down to its own deadband, so it has none.
+    assert min_actionable_output("VNSE3-0") == 0.0
+
+
+@pytest.mark.parametrize(
+    ("target", "floor", "scored"),
+    [
+        # Below what a B2500 can execute: it cannot try, so it cannot fail.
+        (50.0, DC_MIN_ACTIONABLE_OUTPUT_W, False),
+        # Above it: ignoring a command it could have executed is real evidence.
+        (200.0, DC_MIN_ACTIONABLE_OUTPUT_W, True),
+        # A battery with a built-in inverter follows 50 W, so missing it counts.
+        (50.0, 0.0, True),
+    ],
+)
+def test_saturation_is_scored_only_above_the_start_floor(
+    target: float, floor: float, scored: bool
+) -> None:
+    score = _score_after(target, floor)
+    assert (score > 0.8) if scored else (score == 0.0)
+
+
+def test_the_floor_prefers_evidence_over_the_nominal_figure() -> None:
+    """The 80 W figure is an assumption; the paired inverter decides.
+
+    A configured MIN_DC_OUTPUT is the owner telling us what their unit needs,
+    and a command it was seen to answer is proof.  Without either, a missed
+    50 W would be blamed on a battery that never had a chance -- and for an
+    owner whose inverter starts lower, a genuinely empty unit would keep its
+    share.
+    """
+    state = BalancerConsumerState()
+
+    assert saturation_floor(state, B2500, 0.0) == DC_MIN_ACTIONABLE_OUTPUT_W
+    # An owner who configured a floor outranks our figure, in both directions.
+    assert saturation_floor(state, B2500, 30.0) == 30.0
+    assert saturation_floor(state, B2500, 150.0) == 150.0
+    # Otherwise a smaller command this unit answered lowers it.
+    state.pace_responded_at = 30.0
+    assert saturation_floor(state, B2500, 0.0) == 30.0
+    # A large command answered says nothing about small ones: stay conservative.
+    state.pace_responded_at = 250.0
+    assert saturation_floor(state, B2500, 0.0) == DC_MIN_ACTIONABLE_OUTPUT_W
+    # Batteries with a built-in inverter keep no floor either way.
+    assert saturation_floor(state, {"device_type": "VNSE3-0"}, 150.0) == 0.0
+
+
+def test_compute_target_supplies_each_consumer_its_floor() -> None:
+    """The wiring, not just the tracker.
+
+    ``compute_target`` has to hand the tracker the floor for the battery it is
+    scoring; dropping that argument restores #624 while every tracker-level
+    test above stays green, so pin it here.  A Venus in the same pool must keep
+    a floor of 0 -- the floor is per consumer, not per pool.
+    """
+    clock = _FakeClock()
+    lb = LoadBalancer(
+        config=BalancerConfig(min_efficient_power=0.0, fair_distribution=True),
         saturation_alpha=0.15,
         saturation_min_target=20,
         saturation_decay_factor=0.995,
@@ -70,109 +129,27 @@ def _balancer(clock: _FakeClock) -> LoadBalancer:
         saturation_stall_timeout_seconds=60,
         clock=clock,
     )
-
-
-def test_min_actionable_output_only_applies_to_dc_only_batteries() -> None:
-    assert min_actionable_output("HMJ-2") == DC_MIN_ACTIONABLE_OUTPUT_W
-    assert min_actionable_output("HMA-1") == DC_MIN_ACTIONABLE_OUTPUT_W
-    # Venus and Jupiter regulate down to their own deadband.
-    assert min_actionable_output("HMG-50") == 0.0
-    assert min_actionable_output("VNSE3-0") == 0.0
-    assert min_actionable_output("HMN-1") == 0.0
-
-
-def test_sub_floor_command_scores_no_saturation() -> None:
-    """50 W asked of a B2500 is not a target it can miss -- it cannot try."""
-    clock = _FakeClock()
-    tracker = _tracker(clock)
-    state = BalancerConsumerState()
-
-    for _ in range(40):
-        tracker.update(state, 50.0, 0.0, min_actionable_output("HMJ-2"))
-        clock.advance(1.5)
-
-    assert tracker.get(state) == 0.0
-
-
-def test_command_above_the_floor_still_scores_saturation() -> None:
-    """A battery that ignores a command it *could* execute is still saturated."""
-    clock = _FakeClock()
-    tracker = _tracker(clock)
-    state = BalancerConsumerState()
-
-    for _ in range(40):
-        tracker.update(state, 200.0, 0.0, min_actionable_output("HMJ-2"))
-        clock.advance(1.5)
-
-    assert tracker.get(state) > 0.8
-
-
-def test_venus_is_unaffected_by_the_dc_floor() -> None:
-    """A Venus follows small targets, so a missed 50 W is real evidence."""
-    clock = _FakeClock()
-    tracker = _tracker(clock)
-    state = BalancerConsumerState()
-
-    for _ in range(40):
-        tracker.update(state, 50.0, 0.0, min_actionable_output("VNSE3-0"))
-        clock.advance(1.5)
-
-    assert tracker.get(state) > 0.8
-
-
-def test_a_unit_seen_answering_a_smaller_command_is_judged_from_there() -> None:
-    """The 80 W figure is an assumption; a demonstrated response beats it.
-
-    A B2500 pairs with whatever inverter its owner selected, and some energize
-    below the nominal two-channel floor.  Once such a unit has answered a 30 W
-    command, a missed 50 W one is real evidence again -- otherwise a genuinely
-    empty battery of that kind would keep its share.
-    """
-    clock = _FakeClock()
-    lb = _balancer(clock)
-    state = lb._get_consumer("cccccccccccc")
-    report = {"device_type": "HMJ-2", "phase": "A", "power": 0}
-
-    assert lb._saturation_floor(state, report) == DC_MIN_ACTIONABLE_OUTPUT_W
-    state.pace_responded_at = 30.0
-    assert lb._saturation_floor(state, report) == 30.0
-    # A big command answered says nothing about small ones: stay conservative.
-    state.pace_responded_at = 250.0
-    assert lb._saturation_floor(state, report) == DC_MIN_ACTIONABLE_OUTPUT_W
-    # Batteries with a built-in inverter keep no floor either way.
-    assert lb._saturation_floor(state, {"device_type": "VNSE3-0"}) == 0.0
-
-
-def test_idle_b2500_keeps_its_share_while_under_commanded() -> None:
-    """The reporter's case, driven through the balancer.
-
-    One B2500 at its 400 W limit, one stuck at 1 W (it never got a command big
-    enough to start), ~150 W importing.  The idle one has to keep getting a
-    real share, so that it eventually clears its start floor -- in the
-    reporter's log its largest command over two minutes was 77 W.
-    """
-    clock = _FakeClock()
-    lb = _balancer(clock)
-    mode = ConsumerMode("auto", None)
-    at_limit, stuck = "aaaaaaaaaaaa", "bbbbbbbbbbbb"
+    b2500, venus = "aaaaaaaaaaaa", "bbbbbbbbbbbb"
     reports = {
-        at_limit: {"device_type": "HMJ-2", "phase": "A", "power": 400},
-        stuck: {"device_type": "HMJ-2", "phase": "A", "power": 1},
+        b2500: {"device_type": "HMJ-2", "phase": "A", "power": 1},
+        venus: {"device_type": "VNSE3-0", "phase": "A", "power": 1},
     }
-
-    asks = []
-    for i in range(120):
-        grid = 150.0 if i % 4 else 20.0  # drum pulsing, mostly importing
-        for cid in (at_limit, stuck):
-            out = lb.compute_target(
-                cid, mode, reports, grid, frozenset(), frozenset(), (i, grid)
+    seen: dict[str, float] = {}
+    real_update = lb._saturation.update
+    mode = ConsumerMode("auto", None)
+    for cid in (b2500, venus):
+        captured: list[float] = []
+        lb._saturation.update = (  # type: ignore[method-assign]
+            lambda state, lt, actual, floor, _c=captured: _c.append(floor)
+        )
+        # Two polls: the first records an intent, the second scores against it.
+        for i in range(2):
+            lb.compute_target(
+                cid, mode, reports, 60.0, frozenset(), frozenset(), (i, 60.0)
             )
-            if cid == stuck:
-                asks.append(sum(out))
             clock.advance(1.5)
+        lb._saturation.update = real_update  # type: ignore[method-assign]
+        seen[cid] = captured[-1] if captured else -1.0
 
-    biggest = max(asks)
-    assert biggest >= DC_MIN_ACTIONABLE_OUTPUT_W, (
-        f"the idle B2500's largest command was {biggest:.0f} W, below the "
-        f"{DC_MIN_ACTIONABLE_OUTPUT_W:.0f} W it needs to produce anything"
-    )
+    assert seen[b2500] == DC_MIN_ACTIONABLE_OUTPUT_W
+    assert seen[venus] == 0.0

--- a/tests/test_ct002_active_control.py
+++ b/tests/test_ct002_active_control.py
@@ -939,7 +939,9 @@ class TestEfficiencySaturationSwap:
         )
         device._balancer._get_consumer("a").saturation_score = 0.5
         # target (10) < min_target_for_saturation (20) → decay branch
-        device._balancer._saturation.update(device._balancer._get_consumer("a"), 10, 10)
+        device._balancer._saturation.update(
+            device._balancer._get_consumer("a"), 10, 10, 0.0
+        )
         expected = 0.5 * 0.9
         assert abs(device._balancer._consumers["a"].saturation_score - expected) < 1e-6
 
@@ -952,7 +954,9 @@ class TestEfficiencySaturationSwap:
             min_target_for_saturation=20,
         )
         device._balancer._get_consumer("a").saturation_score = 0.001
-        device._balancer._saturation.update(device._balancer._get_consumer("a"), 10, 10)
+        device._balancer._saturation.update(
+            device._balancer._get_consumer("a"), 10, 10, 0.0
+        )
         # 0.001 * 0.5 = 0.0005 < 0.001 → entry should be removed
         assert device._balancer._get_consumer("a").saturation_score == 0.0
 
@@ -1156,7 +1160,7 @@ class TestEfficiencySaturationSwap:
         device._balancer._get_consumer(first_depr).last_target = 200
         for _ in range(10):
             device._balancer._saturation.update(
-                device._balancer._get_consumer(first_depr), 200, 0
+                device._balancer._get_consumer(first_depr), 200, 0, 0.0
             )
             device._balancer._cache_sample = None
             device._compute_smooth_target([200, 0, 0], "a")


### PR DESCRIPTION
## Why

A B2500's two DC output channels are hard on/off below ~40 W each, so the unit cannot answer any command below ~80 W at all. The balancer was scoring saturation against such sub-floor commands anyway: when asked for 50 W, the battery delivered nothing (because it physically cannot), and was recorded as "unable to follow its target". This cut its share of every later correction to roughly a tenth, which pushed the next command even further below the floor — creating a self-reinforcing trap where the battery sat at 0 W indefinitely while the house kept importing, and only a manual target could escape it.

The fix introduces a per-device **saturation floor** — the smallest command worth judging a battery by. For DC-only batteries like the B2500, this floor is 80 W (nominal). A command below the floor is treated exactly like a below-`min_target` one: too small to judge the battery by, because a device that ignores such a command by construction is not evidence of saturation. The floor is three-tier:

1. **Configured floor** (owner's `MIN_DC_OUTPUT`) — most authoritative, what they're stating their inverter needs
2. **Observed floor** (smallest command this unit was seen to answer) — opportunistic evidence from ramp pacing
3. **Nominal floor** (model's default, 80 W for B2500) — the fallback prior

This asymmetry (too-high floor costs detection delay; too-low costs the battery entirely) is deliberate and bounds the risk.

## Checklist

- [x] Base branch is `develop`, not `main`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest`
- [x] Python ↔ ESPHome parity held for shared CT002 behaviour
- [x] User-visible change: one bullet under `## Next` in [CHANGELOG.md](https://github.com/tomquist/AstraMeter/blob/develop/CHANGELOG.md)

## Changes

**Core logic:**
- Added `DC_MIN_ACTIONABLE_OUTPUT_W = 80.0` constant for B2500 family
- Added `min_actionable_output_w` field to `DeviceCapabilities` (0 for AC-coupled/inverter batteries, 80 for B2500)
- New `min_actionable_output(device_type)` function to retrieve the nominal floor
- New `saturation_floor(state, report, configured_floor)` function implementing the three-tier floor logic
- Updated `SaturationTracker.update()` to accept `min_actionable` parameter and treat sub-floor targets like sub-`min_target` ones (decay instead of accumulate)
- Updated `LoadBalancer.compute_target()` to pass the per-consumer saturation floor to the tracker

**Tests:**
- Added comprehensive regression test suite (`test_balancer_dc_start_floor.py`) covering:
  - Saturation scoring only above the floor
  - Floor preference hierarchy (configured > observed > nominal)
  - Per-consumer floor wiring in the balancer
- Updated existing saturation tracker tests to pass the new `min_actionable` parameter
- Added C++ parity tests in `host_balancer_test.cpp`

**Parity:**
- Mirrored all changes to C++ (`esphome/components/ct002/balancer.{h,cpp}`)
- Maintained identical logic and constant values across both implementations

https://claude.ai/code/session_01TbnXQWqpDzAefq2vAyUh62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed B2500 batteries becoming stuck at 0 W after receiving an initial command that was too small to activate them.
  - Improved handling of minimum actionable output so low-power commands are not incorrectly treated as device saturation.
  - Preserved appropriate behavior for other battery types and configured output thresholds.

- **Tests**
  - Added regression coverage for B2500 startup behavior, output floors, and saturation detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->