### PR TITLE
Don't let MIN_DC_OUTPUT lower the saturation gate below the hardware floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Fixed** a B2500 written off as unable to deliver after being handed a share too small to switch it on, which made every later share smaller still — leaving it at 0 W indefinitely while the house imported ([#624](https://github.com/tomquist/astrameter/issues/624), [#629](https://github.com/tomquist/astrameter/pull/629)).
 
-- **Fixed** B2500 batteries sitting at 0 W under active control while the whole house load was imported: the command they were sent could never exceed what the battery needs to start, and a battery that never starts was never sent more ([#600](https://github.com/tomquist/astrameter/issues/600), [#614](https://github.com/tomquist/astrameter/pull/614)).
+- **Fixed** B2500 batteries sitting at 0 W under active control while the whole house load was imported: the command they were sent could never exceed what the battery needs to start, and a battery that never starts was never sent more ([#600](https://github.com/tomquist/astrameter/issues/600), [#614](https://github.com/tomquist/astrameter/pull/614), [#631](https://github.com/tomquist/astrameter/pull/631)).
 
 - **Added** Refoss / Meross energy monitors (EM01P, EM06P, EM16P) as a power source (`[REFOSS]` or `[MEROSS]`) ([#598](https://github.com/tomquist/astrameter/pull/598)).
 

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -102,21 +102,21 @@ float min_actionable_output(const std::string &device_type) {
 
 float saturation_floor(const BalancerConsumerState &state, const ConsumerReport &report,
                        float configured_floor) {
-  // Three sources, most authoritative first: what the owner configured (they
-  // are stating what their inverter needs, and it is the floor we park them
-  // at), then a command this unit was seen to answer — opportunistic only,
-  // since pacing records it just while its clamp is active and clears it on
-  // reversal — then the model's nominal figure. Mirrors balancer.py
-  // saturation_floor; see it for why the asymmetry favours the battery.
-  // The configured floor is checked first because a per-device override
-  // applies to any battery, including one whose family has no nominal floor:
-  // for such a unit the override is the only thing that knows it is held above
-  // its deadband.
-  if (configured_floor > 0.0f) return configured_floor;
-  const float nominal = min_actionable_output(report.device_type);
-  if (nominal <= 0.0f) return 0.0f;
-  const float observed = state.pace_responded_at;
-  return observed > 0.0f ? std::min(nominal, observed) : nominal;
+  // The higher of two lower bounds, each ruling out a different command as
+  // evidence: the configured MIN_DC_OUTPUT (the floor we park the unit at, so
+  // a command at or below it may be our own doing rather than a share the
+  // battery was asked for), and what the family can physically execute —
+  // lowered to a command this unit was seen to answer, which is opportunistic
+  // only, since pacing records it just while its clamp is active and clears it
+  // on reversal. Taking the configured floor *instead of* the model's is what
+  // left issue #600 open after #624. Mirrors balancer.py saturation_floor; see
+  // it for why the asymmetry favours the battery.
+  float nominal = min_actionable_output(report.device_type);
+  if (nominal > 0.0f) {
+    const float observed = state.pace_responded_at;
+    if (observed > 0.0f) nominal = std::min(nominal, observed);
+  }
+  return std::max(configured_floor, nominal);
 }
 
 std::string format_steer_log(const SteerLog &entry) {

--- a/esphome/components/ct002/balancer.h
+++ b/esphome/components/ct002/balancer.h
@@ -364,9 +364,9 @@ struct ConsumerReport {
 };
 
 using ReportMap = std::unordered_map<std::string, ConsumerReport>;
-// Smallest command worth judging a consumer by: the configured MIN_DC_OUTPUT
-// for this battery if its owner set one, else a command it was seen to answer,
-// else the model's nominal floor. Mirrors balancer.py saturation_floor.
+// Smallest command worth judging a consumer by: the higher of the configured
+// MIN_DC_OUTPUT for this battery and the model's floor (itself lowered to a
+// command the unit was seen to answer). Mirrors balancer.py saturation_floor.
 float saturation_floor(const BalancerConsumerState &state, const ConsumerReport &report,
                        float configured_floor);
 

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -330,36 +330,43 @@ def saturation_floor(
 ) -> float:
     """Smallest command worth judging this consumer by (W).
 
-    Three sources, most authoritative first:
+    The gate is the *higher* of two lower bounds, because each rules out a
+    different command as evidence:
 
     * *configured_floor* — the effective MIN_DC_OUTPUT for this battery
-      (global or per-device override).  An owner who set it is stating what
-      their inverter needs, which beats any figure of ours; it also keeps this
-      gate consistent with the floor ``_apply_min_dc_output`` parks them at, and
-      with the MIN_DC_OUTPUT/MIN_TARGET_FOR_SATURATION advice in ``main.py``.
-      It is checked *before* the model's own floor because a per-device
-      override applies to any battery, including one whose family has no
-      nominal floor at all — for such a unit the override is the only thing
-      that knows it is being held above its deadband, and discarding it left
-      the gate at ``min_target`` while the command sat at the override.
-    * ``pace_responded_at`` — a command this unit was actually seen to answer.
-      Opportunistic only: ramp pacing records it just while its clamp is active
-      and clears it on every direction reversal, so treat its absence as "no
-      evidence", never as "cannot go lower".
-    * the model's nominal floor, as the fallback prior.
+      (global or per-device override).  It is the floor
+      ``_apply_min_dc_output`` parks the unit at, so any command at or below it
+      may be one this balancer imposed rather than a share the battery was
+      genuinely asked for; judging the battery by our own parking command is
+      circular.  It also applies to a battery whose family has no nominal floor
+      at all, where it is the only thing that knows the unit is being held
+      above its deadband.
+    * the model's floor — what the family can physically execute, lowered to
+      ``pace_responded_at`` when this unit has been seen to answer something
+      smaller.  That evidence is opportunistic: ramp pacing records it just
+      while its clamp is active and clears it on every direction reversal, so
+      treat its absence as "no evidence", never as "cannot go lower".
+
+    Taking the configured floor *instead of* the model's is what left issue
+    #600 open after #624: an owner whose MIN_DC_OUTPUT sits below their
+    battery's start floor (20 W on a B2500 that needs ~80 W) parks it at a
+    command it cannot execute, and scoring that command re-opened exactly the
+    lock-out #624 closed — the unit is starved because it looks saturated, and
+    looks saturated because the starvation command is unanswerable.  A
+    configured floor still raises the gate above the model's; it just cannot
+    lower it below what the hardware can do.
 
     Too high a floor costs a genuinely full or empty battery some detection
     delay, bounded by the floor itself — it keeps its share only while that
     share stays under a command it could not have answered anyway.  Too low
     costs the battery entirely (issue #624), so the asymmetry is deliberate.
     """
-    if configured_floor > 0.0:
-        return configured_floor
     nominal = min_actionable_output(report.get("device_type", ""))
-    if nominal <= 0.0:
-        return 0.0
-    observed = state.pace_responded_at
-    return min(nominal, observed) if observed > 0.0 else nominal
+    if nominal > 0.0:
+        observed = state.pace_responded_at
+        if observed > 0.0:
+            nominal = min(nominal, observed)
+    return max(configured_floor, nominal)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/components/ct002/host_balancer_test.cpp
+++ b/tests/components/ct002/host_balancer_test.cpp
@@ -140,13 +140,16 @@ TEST(SaturationTrackerDcFloor, FloorPrefersEvidenceOverTheNominalFigure) {
   ConsumerReport report;
   report.device_type = "HMJ-2";
   EXPECT_FLOAT_EQ(saturation_floor(state, report, 0.0f), DC_MIN_ACTIONABLE_OUTPUT_W);
-  // A configured MIN_DC_OUTPUT outranks our figure, in both directions.
-  EXPECT_FLOAT_EQ(saturation_floor(state, report, 30.0f), 30.0f);
+  // A configured MIN_DC_OUTPUT raises the gate above our figure ...
   EXPECT_FLOAT_EQ(saturation_floor(state, report, 150.0f), 150.0f);
-  // Otherwise a smaller command this unit answered lowers it; a large one says
-  // nothing about small ones.
+  // ... but cannot lower it below what the hardware can do: MIN_DC_OUTPUT is
+  // where we park the unit, not a claim about what it can start on (#600).
+  EXPECT_FLOAT_EQ(saturation_floor(state, report, 30.0f), DC_MIN_ACTIONABLE_OUTPUT_W);
+  // A smaller command this unit answered lowers the model's half of it; a
+  // large one says nothing about small ones.
   state.pace_responded_at = 30.0f;
   EXPECT_FLOAT_EQ(saturation_floor(state, report, 0.0f), 30.0f);
+  EXPECT_FLOAT_EQ(saturation_floor(state, report, 50.0f), 50.0f);
   state.pace_responded_at = 250.0f;
   EXPECT_FLOAT_EQ(saturation_floor(state, report, 0.0f), DC_MIN_ACTIONABLE_OUTPUT_W);
   // A per-device MIN_DC_OUTPUT override applies to any battery, including a

--- a/tests/test_balancer_dc_start_floor.py
+++ b/tests/test_balancer_dc_start_floor.py
@@ -98,12 +98,16 @@ def test_the_floor_prefers_evidence_over_the_nominal_figure() -> None:
     state = BalancerConsumerState()
 
     assert saturation_floor(state, B2500, 0.0) == DC_MIN_ACTIONABLE_OUTPUT_W
-    # An owner who configured a floor outranks our figure, in both directions.
-    assert saturation_floor(state, B2500, 30.0) == 30.0
+    # A configured floor raises the gate above our figure ...
     assert saturation_floor(state, B2500, 150.0) == 150.0
-    # Otherwise a smaller command this unit answered lowers it.
+    # ... but cannot lower it below what the hardware can do: MIN_DC_OUTPUT is
+    # where we park the unit, not a claim about what it can start on (#600).
+    assert saturation_floor(state, B2500, 30.0) == DC_MIN_ACTIONABLE_OUTPUT_W
+    # A smaller command this unit answered lowers the model's half of it.
     state.pace_responded_at = 30.0
     assert saturation_floor(state, B2500, 0.0) == 30.0
+    # ... and the configured floor still wins where it is the higher of the two.
+    assert saturation_floor(state, B2500, 50.0) == 50.0
     # A large command answered says nothing about small ones: stay conservative.
     state.pace_responded_at = 250.0
     assert saturation_floor(state, B2500, 0.0) == DC_MIN_ACTIONABLE_OUTPUT_W
@@ -158,3 +162,66 @@ def test_compute_target_supplies_each_consumer_its_floor() -> None:
 
     assert seen[b2500] == DC_MIN_ACTIONABLE_OUTPUT_W
     assert seen[venus] == 0.0
+
+
+def test_a_configured_floor_below_the_start_floor_does_not_lock_a_unit_out() -> None:
+    """Regression for issue #600.
+
+    Two B2500 on one phase, ``MIN_DC_OUTPUT = 20`` -- below the ~80 W the
+    family needs to energize a channel pair.  The second unit is parked at that
+    20 W floor, cannot execute it, and used to be scored for the miss: its
+    saturation pinned at 1.0, its share of every correction cut to a hundredth,
+    and the first unit left carrying the whole house.  The reporter's recorder
+    trace shows exactly that -- 230 W against 4 W, saturation 0% against 89%,
+    and ``reported + last_target == 20`` on two thirds of the replies.
+
+    The floor MIN_DC_OUTPUT parks a unit at is not a statement that the unit
+    can start there, so it must not lower the gate below what the hardware can
+    do.  Here that is the difference between the second unit taking half the
+    load and sitting at 0 W for good.
+    """
+    house, start_floor = 460.0, DC_MIN_ACTIONABLE_OUTPUT_W
+    clock = _FakeClock()
+    lb = LoadBalancer(
+        config=BalancerConfig(
+            fair_distribution=True,
+            min_efficient_power=0.0,
+            min_dc_output=20.0,
+            balance_deadband=25,
+            max_correction_per_step=80,
+        ),
+        saturation_alpha=0.15,
+        saturation_min_target=20,
+        saturation_decay_factor=0.995,
+        saturation_grace_seconds=90,
+        saturation_stall_timeout_seconds=180,
+        clock=clock,
+    )
+    mode = ConsumerMode("auto", None)
+    # A carries the house; B idles, as in the reporter's trace.
+    power = {"aaaaaaaaaaaa": 230.0, "bbbbbbbbbbbb": 4.0}
+    for step in range(400):
+        reports = {
+            cid: {"device_type": "HMJ-2", "phase": "A", "power": round(w)}
+            for cid, w in power.items()
+        }
+        grid = house - sum(power.values())
+        commands = {
+            cid: sum(
+                lb.compute_target(
+                    cid, mode, reports, grid, frozenset(), frozenset(), (step, grid)
+                )
+            )
+            for cid in power
+        }
+        for cid, delta in commands.items():
+            # A B2500 channel pair is a hard on/off: below its start floor the
+            # unit stays in standby, above it the setpoint is executed.
+            want = power[cid] + delta
+            power[cid] = 0.0 if want < start_floor else min(want, 800.0)
+        clock.advance(1.0)
+
+    assert power["bbbbbbbbbbbb"] > start_floor
+    assert lb.get_saturation("bbbbbbbbbbbb") < 0.5
+    # And the pair actually shares the house rather than one unit carrying it.
+    assert abs(power["aaaaaaaaaaaa"] - power["bbbbbbbbbbbb"]) < house / 2


### PR DESCRIPTION
## Why

#624 stopped scoring a B2500 against a command below the ~80 W its channel pair needs to start. **Issue #600 survives that fix**, because `saturation_floor` takes a configured `MIN_DC_OUTPUT` *instead of* the model's floor rather than as well as it — and the reporter's config sets it to 20 W.

That reopens the same lock-out one layer down:

1. `_apply_min_dc_output` parks the unit at 20 W.
2. 20 W is now also the saturation gate, so the parking command is scored.
3. The unit cannot execute 20 W, so it is recorded as unable to follow its target.
4. Its share of every later correction is cut to a hundredth — which leaves the parking command as the only thing it is ever sent.

The reporter's recorder trace is exactly this: two HMJ-2 on one phase at 230 W against 4 W, saturation 0% against 89%, and `reported + last_target == 20` on two thirds of the replies.

Replaying that config through the balancer reproduces it — the second unit sits at 0 W with saturation pinned at 1.0 for the whole run while the first carries all 460 W:

| `MIN_DC_OUTPUT` | before | after |
|---|---|---|
| 0 W | 210 W, saturation 0.08 | 210 W, saturation 0.08 |
| **20 W** | **0 W, saturation 1.00** | **210 W, saturation 0.08** |
| 100 W | 210 W, saturation 0.00 | 210 W, saturation 0.00 |

Only a configured floor *below* the hardware's was broken, which is the shape of the bug.

`MIN_DC_OUTPUT` says where to park a battery, not what it can start on, so it can raise the gate above the model's figure but not lower it below.

**Detection is not weakened.** A genuinely empty unit under the same config still scores 0.90, against 0.4 for the rotation threshold — a real share clears the floor even when the parking command does not. Before the change it scored 1.00, so the only samples that stop counting are the ones the balancer imposed on itself.

## Notes for review

- One assertion in `test_balancer_dc_start_floor.py` (and its C++ twin) said "an owner who configured a floor outranks our figure, **in both directions**". That is the behaviour being changed, so both are rewritten rather than adjusted around.
- The startup warning in `main.py` about `MIN_DC_OUTPUT < MIN_TARGET_FOR_SATURATION` is left alone: its statement stays true for every family, and it never fired for #600's config anyway (20 vs 20).

## Verification

- Reproduction and fix confirmed by replaying #600's exact configuration through the real balancer; the new regression test fails without the fix and passes with it.
- Full Python suite green with the ESPHome CLI installed (parity e2e runs for real, not skipped); all host gtests pass, built against a local googletest since the sandbox proxy 403s the GitHub tarball.

### Steering evaluation

Before #632 this change was byte-identical across all 32 scenarios × 5 seeds — nothing in the suite set `MIN_DC_OUTPUT`, so the branch being changed was dead code under evaluation, and the absence of movement said nothing either way. #632 added `b2500_pair_dc_floor` and is now on `develop`, so CI measures the fix directly:

> **Overall: 10 improved, 3 regressed, 2 unchanged across 15 metrics — mean −6.8% (better).**
> **Priority: priority-weighted −10.3% (better) — ✅ no do-no-harm guardrail regressions.**

Aggregate across 33 scenarios: `cost_regret_ct` 1.0 → 0.76 (−24%), `avoidable_import_wh` −23%, `share_imbalance_w` −17%, `steady_rms_w` −9%, `settle_p95_s` −8%, `grid_p2p_w` −8%. **Every scenario other than `b2500_pair_dc_floor` is unchanged**, which is the expected blast radius: this only alters behaviour when a configured floor sits below the hardware's.

On that scenario (5 seeds):

| Metric | base | head | Δ |
|---|---:|---:|---:|
| `cost_regret_ct` | 8.63 | 0.71 | **−92%** |
| `avoidable_import_wh` | 376.4 | 37.6 | −90% |
| `share_imbalance_w` | 472.5 | 55.1 | −88% |
| `steady_rms_w` | 511.2 | 155.8 | −70% |
| `mean_abs_grid_w` | 386.8 | 136.5 | −65% |
| `grid_p2p_w` | 1468.4 | 666.3 | −55% |
| `settle_p95_s` | 442.0 | 247.5 | −44% |
| `band_crossings_per_h` | 27.4 | 17.4 | −36% |
| `overshoot_max_w` | 65.2 | 102.1 | **+57%** |
| `battery_travel_w_per_h` | 9702 | 16917 | **+74%** |

**The two increases are not a control-quality regression, and there is nothing to tune away.** Two measurements:

- **The travel is not churn.** Tracing the second unit over three seeds: it starts **once** and never stops (`starts=1, stops=0`), at 83% duty and a 352 W mean alongside the first unit's 381 W. The extra travel is a battery that was pinned at 0 W now carrying half the house. Reducing it means undoing the fix.
- **The fixed run is identical to a healthy baseline.** Re-running the same scenario with `--set min_dc_output=0` — where #624's gate already worked and this lock-out never existed — gives **the same value on all 15 metrics**, `overshoot_max_w` and `battery_travel_w_per_h` included. (`--set min_dc_output=200` moves them substantially, so the override is genuinely applied.)

  So the base column is a house running on one battery because the bug switched the other off, and a one-battery house cannot overshoot or travel as much. The fix restores exactly the behaviour the pair has when no configured floor is in the way. At aggregate level both land at +1%, well inside the guardrail.

## Checklist

- [x] Base branch is `develop`, not `main`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest`
- [x] Python ↔ ESPHome parity held for shared CT002 behaviour — mirrored in `esphome/components/ct002/balancer.{h,cpp}` with the host gtest updated
- [x] `web/` changes: none
- [x] User-visible change: this PR's reference was added to the existing `## Next` bullet for #600 (from #614), rather than a second bullet for the same change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JyoX3XXSUeF3gwitUNML2