### PR TITLE
Cover the MIN_DC_OUTPUT start floor in the steering evaluation

### DIFF
--- a/src/astrameter/simulator/evaluation.py
+++ b/src/astrameter/simulator/evaluation.py
@@ -63,7 +63,7 @@ import socket
 import sys
 from collections.abc import Callable, Sequence
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from astrameter.ct002.balancer import device_capabilities
@@ -828,6 +828,18 @@ _B2500 = BatterySpec(
     capacity_wh=2240.0,
     max_dc_input=1000,
     initial_soc=0.5,
+)
+
+# A B2500 in a same-phase pair, sized to serve a household on its own charge
+# for the run: no DC input, so the only thing deciding its output is what the
+# balancer commands.  Matches the pair in issue #600 (two HMJ-2 on phase A).
+_B2500_PAIR = BatterySpec(
+    device_type="HMJ-2",
+    phase="A",
+    max_charge_power=0,
+    max_discharge_power=800,
+    capacity_wh=5120.0,
+    initial_soc=0.8,
 )
 
 # Efficiency-optimization mode knobs (mirrors a typical multi-battery setup).
@@ -1647,6 +1659,37 @@ def build_scenarios() -> dict[str, Scenario]:
                 "saturation_alpha": 0.9,
             },
             meter_latency_s=0.5,
+        )
+    )
+
+    # Two B2500 on one phase with MIN_DC_OUTPUT set *below* the ~80 W a
+    # channel pair needs to start -- the configuration issue #600 reports.
+    # The floor is where the balancer parks a starved unit, so a value under
+    # the start floor parks it at a command it cannot execute; whether that
+    # counts as evidence of saturation decides if the second unit ever gets a
+    # real share or sits at 0 W while the first carries the house.  Nothing
+    # else in the suite sets MIN_DC_OUTPUT, so this is the only scenario that
+    # exercises the floor at all.
+    dur_floor = 3600.0
+    add(
+        Scenario(
+            name="b2500_pair_dc_floor",
+            description="Two DC-only B2500 on one phase, MIN_DC_OUTPUT below "
+            "their start floor",
+            batteries=[
+                # One unit already carrying the house, the other at rest --
+                # the state a restart leaves behind, and the one the reporter
+                # captured (230 W against 4 W).  Starting both from zero would
+                # split the first correction evenly and neither would ever be
+                # starved.
+                replace(_B2500_PAIR, initial_power=250.0),
+                _B2500_PAIR,
+            ],
+            duration_s=dur_floor,
+            base_load=[250.0, 0.0, 0.0],
+            loads=list(_HOUSEHOLD_LOADS),
+            build_events=lambda rng: _household_steps(rng, dur_floor),
+            ct_kwargs={"min_dc_output": 20.0},
         )
     )
 


### PR DESCRIPTION
## Why

Nothing in the suite set `MIN_DC_OUTPUT`, so **no scenario exercised the DC start floor at all**. `_effective_min_dc_output` returned 0 for every consumer in all 32 scenarios, which made `saturation_floor`'s configured-floor branch dead code under evaluation — a change to it could not move a single metric, and the absence of movement said nothing either way.

This adds the configuration issue #600 reports: two B2500 on one phase with `MIN_DC_OUTPUT` at 20 W, below the ~80 W a channel pair needs to start.

### The entry condition matters as much as the floor

A first attempt at this scenario moved nothing, and the reason is worth recording: starting both units from zero splits the first correction evenly, both clear their start floor, and neither is ever starved. The trap needs one unit already ahead.

The reporter's trace is asymmetric — 230 W against 4 W, captured after a restart — so the scenario starts one unit carrying the house and the other at rest, with a base load one unit can serve alone.

## What it measures

On `develop` the scenario reports one battery carrying everything while the other sits at a floor it cannot execute:

| Metric | value on `develop` | suite mean |
|---|---:|---:|
| `share_imbalance_w` | 470.1 | 60.9 |
| `avoidable_import_wh` | 372.6 | 33.5 |
| `cost_regret_ct` | **8.53** | 0.76 |

Against the fix in #631 (measured by cherry-picking it onto this branch, 3 seeds):

| Metric | broken | fixed | Δ |
|---|---:|---:|---:|
| `cost_regret_ct` | 8.53 | 0.70 | **−92%** |
| `avoidable_import_wh` | 372.6 | 37.4 | −90% |
| `share_imbalance_w` | 470.1 | 53.6 | −89% |
| `steady_rms_w` | 506.6 | 155.6 | −69% |
| `mean_abs_grid_w` | 383.0 | 135.7 | −65% |
| `settle_p95_s` | 440.2 | 241.6 | −45% |
| `overshoot_max_w` | 65.0 | 94.1 | **+45%** |
| `battery_travel_w_per_h` | 9627 | 17079 | **+77%** |

### Reading the two increases

They are **not** a control-quality regression, and this scenario is built in a way that makes that checkable:

- Tracing the second unit over three seeds, it starts **once** and never stops (`starts=1, stops=0`), at 83% duty and a 352 W mean beside the first unit's 381 W. The extra travel is a battery that was pinned at 0 W now carrying half the house — not hunting across its start floor.
- Re-running with `--set min_dc_output=0`, where #624's gate already worked and the lock-out never existed, gives **the same value on all 15 metrics** as the fixed run, `overshoot_max_w` and `battery_travel_w_per_h` included. (`--set min_dc_output=200` moves them substantially, so the override does apply.)

So the baseline column is a house running on one battery because the bug switched the other off, and a one-battery house cannot overshoot or travel as much. Worth keeping in mind when this scenario appears in a future PR's guardrail numbers.

## Notes

- This PR changes **only** `evaluation.py` — no controller behaviour, so every existing scenario is untouched (confirmed by its own CI eval: 32 unchanged, 1 new).
- It adds a 33rd scenario, which costs two more CI runners on any PR that triggers `steering-eval`.
- #631 is stacked on this branch so its evaluation runs against a suite that can actually see the fix.

## Checklist

- [x] Base branch is `develop`, not `main`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest`
- [x] Python ↔ ESPHome parity: simulator-only, does not apply
- [x] `web/` changes: none
- [x] User-visible change: none — test/evaluation coverage only, so no `CHANGELOG.md` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JyoX3XXSUeF3gwitUNML2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of paired DC-only batteries when configured minimum output falls below their startup threshold.
  * Simulation results now more accurately reflect battery activation and discharge behavior in this edge case.

* **Tests**
  * Added coverage for paired battery configurations operating on a single phase with low minimum DC output settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->