### PR TITLE
Poll each simulated battery at its own cadence in the e2e harness

### DIFF
--- a/tests/_ct002_e2e_backend.py
+++ b/tests/_ct002_e2e_backend.py
@@ -81,6 +81,64 @@ class HarnessClock:
             self._on_change(self._now)
 
 
+# Below this, a difference between two poll times is treated as zero. The
+# schedule is walked in relative offsets (never absolute timestamps) so the
+# error stays near the float epsilon of the intervals themselves, not of a
+# ~1.7e9 wall-clock value, where an ulp is already ~2.4e-7 s.
+_POLL_EPS = 1e-9
+
+
+class PollScheduler:
+    """Deliver each battery's polls at its own cadence.
+
+    ``step()`` advances simulated time by the *slowest* battery's poll
+    interval and delivers every poll that falls due inside that window, in
+    time order -- so a battery polling three times as fast sends three
+    requests per step, as it would on a real network.
+
+    Polling every battery exactly once per step and then advancing the clock
+    by the slowest interval, which is what the harnesses did before, gets two
+    things wrong whenever the intervals differ: the fast battery is silently
+    throttled to the slow one's rate, and it is stepped with its own (small)
+    ``poll_interval`` as the physics ``dt`` while the clock moves by the large
+    one, so its ramp and SoC integrate several times too slowly. With every
+    battery on the same interval the two are identical -- one poll each, then
+    one advance -- which is why this went unnoticed.
+    """
+
+    def __init__(self, batteries, clock, step_one) -> None:
+        self._batteries = batteries
+        self._clock = clock
+        self._step_one = step_one
+        # Everything is due immediately, so a step polls at its starting
+        # timestamp and advances afterwards -- the ordering the suites' timing
+        # assertions were written against.
+        self._to_next = [0.0] * len(batteries)
+
+    def _advance(self, dt: float) -> None:
+        if dt > 0:
+            self._clock.advance(dt)
+        for i in range(len(self._to_next)):
+            self._to_next[i] -= dt
+
+    async def step(self, n: int = 1) -> None:
+        for _ in range(n):
+            remaining = max(b.poll_interval for b in self._batteries)
+            while True:
+                wait = min(self._to_next)
+                # A poll falling exactly on the window's end belongs to the
+                # next step, not this one, or the slowest battery polls twice.
+                if wait >= remaining - _POLL_EPS:
+                    break
+                self._advance(wait)
+                remaining -= wait
+                for i, b in enumerate(self._batteries):
+                    if self._to_next[i] <= _POLL_EPS:
+                        await self._step_one(b)
+                        self._to_next[i] = b.poll_interval
+            self._advance(remaining)
+
+
 class EsphomeSim:
     """Spawns the test-hooks host binary and drives it via the control channel."""
 

--- a/tests/_ct002_e2e_backend.py
+++ b/tests/_ct002_e2e_backend.py
@@ -104,6 +104,15 @@ class PollScheduler:
     one, so its ramp and SoC integrate several times too slowly. With every
     battery on the same interval the two are identical -- one poll each, then
     one advance -- which is why this went unnoticed.
+
+    ``_to_next`` holds each battery's time *remaining* until its next poll,
+    never an absolute timestamp. Two things follow. Accumulation error stays at
+    the float epsilon of the intervals rather than of a ~1.7e9 wall-clock value.
+    And a test that jumps the clock by hand (``h.clock.advance(8)``, to reach a
+    rotation deadline without polling through it) cannot desynchronise the
+    schedule: the skipped polls are skipped, which is the point of such a jump,
+    and each battery keeps its place in its own cycle across it. See
+    ``test_sim_harness_cadence.py``.
     """
 
     def __init__(self, batteries, clock, step_one) -> None:

--- a/tests/test_e2e_probe_lockup.py
+++ b/tests/test_e2e_probe_lockup.py
@@ -21,7 +21,12 @@ import socket
 
 import _ct002_e2e_backend as be
 import pytest
-from _ct002_e2e_backend import E2E_UDP_PORT, EsphomeSim, HarnessClock
+from _ct002_e2e_backend import (
+    E2E_UDP_PORT,
+    EsphomeSim,
+    HarnessClock,
+    PollScheduler,
+)
 
 from astrameter.ct002.ct002 import CT002
 from astrameter.simulator.battery import BatterySimulator
@@ -196,6 +201,8 @@ class _Harness:
         else:
             self.ct002 = None
 
+        self._scheduler = PollScheduler(self.batteries, self.clock, self._step_battery)
+
     def freeze_meter_at_current_reading(self) -> None:
         """Simulate a push-based powermeter going stale.  From this
         call onward the CT002 emulator sees a frozen snapshot of the
@@ -288,10 +295,7 @@ class _Harness:
         await b._send_request()
 
     async def step(self, n: int = 1) -> None:
-        for _ in range(n):
-            for b in self.batteries:
-                await self._step_battery(b)
-            self.clock.advance(max(b.poll_interval for b in self.batteries))
+        await self._scheduler.step(n)
 
     def battery_powers(self) -> list[float]:
         return [b.current_power for b in self.batteries]

--- a/tests/test_efficiency_e2e.py
+++ b/tests/test_efficiency_e2e.py
@@ -463,8 +463,9 @@ class TestEfficiencyE2E:
             # physically produce. The candidate can reach its own
             # ``max_discharge_power`` while the incumbent has not finished
             # ramping down, so with a 200 W house the export floor is
-            # 200 - (800 + 200) = -800 W. Past that, something is being
-            # commanded that the plant cannot explain.
+            # 200 - (800 + 200) = -800 W, which is attainable, so the
+            # ceiling itself passes. Past it, something is being commanded
+            # that the plant cannot explain.
             #
             # The old bound was 500 W, calibrated when ``_SimHarness.step()``
             # polled every battery once per step and advanced the clock by the
@@ -476,7 +477,7 @@ class TestEfficiencyE2E:
             # not a new one -- the same handoff overshoots to 680 W of battery
             # output on the old harness too.
             single_unit_limit = float(h.batteries[0].max_discharge_power)
-            assert max(grid_errors) < single_unit_limit, (
+            assert max(grid_errors) <= single_unit_limit, (
                 f"Mixed poll intervals should not blow up grid error "
                 f"(max={max(grid_errors):.0f}W, limit={single_unit_limit:.0f}W). "
                 f"Powers: {h.battery_powers()}"

--- a/tests/test_efficiency_e2e.py
+++ b/tests/test_efficiency_e2e.py
@@ -15,7 +15,13 @@ from __future__ import annotations
 
 import _ct002_e2e_backend as be
 import pytest
-from _ct002_e2e_backend import E2E_UDP_PORT, EsphomeSim, HarnessClock, find_free_ports
+from _ct002_e2e_backend import (
+    E2E_UDP_PORT,
+    EsphomeSim,
+    HarnessClock,
+    PollScheduler,
+    find_free_ports,
+)
 
 from astrameter.ct002.ct002 import CT002
 from astrameter.simulator.battery import BatterySimulator
@@ -161,6 +167,8 @@ class _SimHarness:
         else:
             self.ct002 = None
 
+        self._scheduler = PollScheduler(self.batteries, self.clock, self._step_battery)
+
     async def start(self):
         await self.powermeter.start()
         if self.backend == "python":
@@ -198,13 +206,13 @@ class _SimHarness:
         await b._send_request()
 
     async def step(self, n: int = 1) -> None:
-        """Step all batteries *n* times.  Advances the clock by each
-        battery's ``poll_interval`` (max across batteries) per step."""
-        for _ in range(n):
-            max_dt = max(b.poll_interval for b in self.batteries)
-            for b in self.batteries:
-                await self._step_battery(b)
-            self.clock.advance(max_dt)
+        """Advance *n* steps, each one the slowest battery's poll interval.
+
+        Every poll falling inside that window is delivered at its own time,
+        so a faster-polling battery sends several requests per step. See
+        :class:`PollScheduler`.
+        """
+        await self._scheduler.step(n)
 
     async def step_until(
         self,
@@ -451,11 +459,27 @@ class TestEfficiencyE2E:
                 f"Demand should remain covered by the pool. "
                 f"Powers: {h.battery_powers()}"
             )
-            # No runaway: the error stays bounded (a true coverage failure grows
-            # without bound, like the stale-meter lockup) ...
-            assert max(grid_errors) < 500, (
+            # No runaway: the excursion stays inside what one handoff can
+            # physically produce. The candidate can reach its own
+            # ``max_discharge_power`` while the incumbent has not finished
+            # ramping down, so with a 200 W house the export floor is
+            # 200 - (800 + 200) = -800 W. Past that, something is being
+            # commanded that the plant cannot explain.
+            #
+            # The old bound was 500 W, calibrated when ``_SimHarness.step()``
+            # polled every battery once per step and advanced the clock by the
+            # slowest interval -- so both units here ran at 0.9 s and this test
+            # never actually exercised a mixed cadence. With the fast unit
+            # polling at its real 0.3 s it takes three corrections per window
+            # and ramps into the handoff harder: the peak is 595 W (Python) /
+            # 680 W (C++), deterministic on both. That is a bigger transient,
+            # not a new one -- the same handoff overshoots to 680 W of battery
+            # output on the old harness too.
+            single_unit_limit = float(h.batteries[0].max_discharge_power)
+            assert max(grid_errors) < single_unit_limit, (
                 f"Mixed poll intervals should not blow up grid error "
-                f"(max={max(grid_errors):.0f}W). Powers: {h.battery_powers()}"
+                f"(max={max(grid_errors):.0f}W, limit={single_unit_limit:.0f}W). "
+                f"Powers: {h.battery_powers()}"
             )
             # ... and every handoff is a *transient*: the grid comes back
             # inside the deadband between rotations and stays there. This is

--- a/tests/test_issue376_pv_passthrough.py
+++ b/tests/test_issue376_pv_passthrough.py
@@ -19,7 +19,13 @@ from __future__ import annotations
 
 import _ct002_e2e_backend as be
 import pytest
-from _ct002_e2e_backend import E2E_UDP_PORT, EsphomeSim, HarnessClock, find_free_ports
+from _ct002_e2e_backend import (
+    E2E_UDP_PORT,
+    EsphomeSim,
+    HarnessClock,
+    PollScheduler,
+    find_free_ports,
+)
 
 from astrameter.ct002.ct002 import CT002
 from astrameter.simulator.battery import BatterySimulator
@@ -121,6 +127,8 @@ class _Issue376Harness:
         else:
             self.ct002 = None
 
+        self._scheduler = PollScheduler(self.batteries, self.clock, self._step_battery)
+
     async def start(self) -> None:
         await self.powermeter.start()
         if self.backend == "python":
@@ -152,11 +160,7 @@ class _Issue376Harness:
         await b._send_request()
 
     async def step(self, n: int = 1) -> None:
-        for _ in range(n):
-            max_dt = max(b.poll_interval for b in self.batteries)
-            for b in self.batteries:
-                await self._step_battery(b)
-            self.clock.advance(max_dt)
+        await self._scheduler.step(n)
 
     # -- backend-agnostic emulator-state accessors -------------------------
 

--- a/tests/test_sim_harness_cadence.py
+++ b/tests/test_sim_harness_cadence.py
@@ -1,0 +1,104 @@
+"""The e2e harness must poll each battery at its own cadence.
+
+``_SimHarness.step()`` used to poll every battery exactly once and then
+advance the clock by the *slowest* battery's interval.  With mixed intervals
+that silently throttled every fast battery to the slow one's rate, so
+``test_probe_handles_mixed_poll_intervals`` -- the one test in the suite that
+sets them -- ran both units at 0.9 s and never exercised what its name says.
+
+It also fed the plant the wrong ``dt``: each battery is stepped with its own
+``poll_interval`` as the physics step, so a 0.3 s battery advanced 0.3 s of
+ramp and SoC per 0.9 s of simulated time, three times too slowly.
+
+These tests drive :class:`PollScheduler` directly with stand-in batteries, so
+they pin the schedule itself rather than any controller behaviour downstream
+of it.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from _ct002_e2e_backend import HarnessClock, PollScheduler
+
+
+class _FakeBattery:
+    """Records the simulated time at which each of its polls was delivered."""
+
+    def __init__(self, poll_interval: float) -> None:
+        self.poll_interval = poll_interval
+        self.poll_times: list[float] = []
+
+
+# HarnessClock stores simulated time as an absolute epoch float, where one
+# ulp is already ~4e-7 s, and the schedule advances it once per poll. Drift is
+# therefore bounded by (advances x ulp) -- ~3e-6 s over the runs here, and
+# ~2e-5 s over 200 steps. It is inherent to the clock, not to the schedule, and
+# is six orders of magnitude below the intervals being asserted on.
+_CLOCK_TOL = 1e-4
+
+
+def _run(intervals: list[float], steps: int):
+    clock = HarnessClock()
+    start = clock()
+    batteries = [_FakeBattery(i) for i in intervals]
+
+    async def step_one(b: _FakeBattery) -> None:
+        b.poll_times.append(clock() - start)
+
+    return clock, start, batteries, PollScheduler(batteries, clock, step_one)
+
+
+@pytest.mark.parametrize(
+    "intervals",
+    [
+        [0.3, 0.3],  # uniform: must be exactly what the old harness did
+        [3.0, 3.0],
+        [0.9, 0.3],  # the ratio test_probe_handles_mixed_poll_intervals uses
+        [1.0, 0.25, 0.5],
+        [0.7, 0.3],  # non-integral ratio: polls straddle the step boundary
+    ],
+)
+async def test_each_battery_polls_at_its_own_interval(intervals: list[float]) -> None:
+    steps = 10
+    clock, start, batteries, sched = _run(intervals, steps)
+    await sched.step(steps)
+
+    window = max(intervals) * steps
+    # The clock advances by the slowest interval per step, whatever the mix.
+    assert clock() - start == pytest.approx(window, abs=_CLOCK_TOL)
+
+    for b in batteries:
+        # Polls land at 0, i, 2i, ... strictly inside [0, window): one at the
+        # start, and none on the closing boundary (that one opens the step
+        # after the last).
+        expected = math.floor((window - 1e-9) / b.poll_interval) + 1
+        assert len(b.poll_times) == expected, (
+            f"battery on {b.poll_interval}s polled {len(b.poll_times)}x "
+            f"in {window}s, expected {expected}"
+        )
+        for k, t in enumerate(b.poll_times):
+            assert t == pytest.approx(k * b.poll_interval, abs=_CLOCK_TOL)
+
+
+async def test_uniform_intervals_are_one_poll_each_per_step() -> None:
+    """The regression guard for everything the fix must NOT change.
+
+    Every other e2e test in the suite runs a uniform cadence and its timing
+    assertions are written against one poll each per step, so this has to stay
+    exactly as it was.
+    """
+    clock, start, batteries, sched = _run([0.3, 0.3], 1)
+    for step in range(1, 6):
+        await sched.step()
+        assert [len(b.poll_times) for b in batteries] == [step, step]
+        assert clock() - start == pytest.approx(step * 0.3, abs=_CLOCK_TOL)
+
+
+async def test_a_faster_battery_polls_proportionally_more() -> None:
+    """The property the old harness got wrong, stated as a ratio."""
+    _, _, batteries, sched = _run([0.9, 0.3], 20)
+    await sched.step(20)
+    slow, fast = batteries
+    assert len(fast.poll_times) == 3 * len(slow.poll_times)

--- a/tests/test_sim_harness_cadence.py
+++ b/tests/test_sim_harness_cadence.py
@@ -18,6 +18,7 @@ of it.
 from __future__ import annotations
 
 import math
+from itertools import pairwise
 
 import pytest
 from _ct002_e2e_backend import HarnessClock, PollScheduler
@@ -102,3 +103,68 @@ async def test_a_faster_battery_polls_proportionally_more() -> None:
     await sched.step(20)
     slow, fast = batteries
     assert len(fast.poll_times) == 3 * len(slow.poll_times)
+
+
+async def test_a_manual_clock_jump_does_not_desynchronise_the_schedule() -> None:
+    """``h.clock.advance(N)`` outside a step must leave the cadence intact.
+
+    ``test_probe_handles_mixed_poll_intervals`` jumps the clock by hand to
+    reach an efficiency-rotation deadline without polling through it, so the
+    scheduler has to survive its clock moving underneath it. It does, because
+    ``_to_next`` holds time *remaining* rather than an absolute timestamp: the
+    jump skips exactly the polls it is meant to skip, and each battery resumes
+    on its own interval afterwards.
+
+    Pinned so a later "fix" that rebases ``_to_next`` against the clock -- and
+    would silently deliver a burst of catch-up polls, or shift a battery off
+    its interval -- has to argue with a test.
+    """
+    intervals = [0.9, 0.3]
+    clock, start, batteries, sched = _run(intervals, 10)
+    await sched.step(10)
+    polled_before = [len(b.poll_times) for b in batteries]
+
+    clock.advance(8.0)  # the manual jump, bypassing the scheduler entirely
+    jumped_to = clock() - start
+
+    await sched.step(5)
+
+    for b, before in zip(batteries, polled_before, strict=True):
+        after = b.poll_times[before:]
+        # No catch-up burst: the jump's 8 s produce no polls at all.
+        window = 5 * max(intervals)
+        expected = math.floor((window - 1e-9) / b.poll_interval) + 1
+        assert len(after) == expected, (
+            f"battery on {b.poll_interval}s delivered {len(after)} polls after "
+            f"the jump, expected {expected} -- a jump must not replay the "
+            f"polls it skipped"
+        )
+        # Resumes immediately (both are at a cycle boundary after 10 steps of
+        # an integral ratio) and then holds its own interval exactly.
+        assert after[0] == pytest.approx(jumped_to, abs=_CLOCK_TOL)
+        for earlier, later in pairwise(after):
+            assert later - earlier == pytest.approx(b.poll_interval, abs=_CLOCK_TOL)
+
+
+async def test_a_manual_jump_preserves_cycle_phase() -> None:
+    """A battery caught mid-cycle by a jump keeps its phase, not a reset.
+
+    With a non-integral ratio a step can end with the fast battery partway
+    through its interval. It should resume that interval where it left off --
+    a real device's poll timer does not restart because the controller's clock
+    moved.
+    """
+    clock, start, batteries, sched = _run([0.7, 0.3], 10)
+    await sched.step(10)
+    fast = batteries[1]
+    assert sched._to_next[1] == pytest.approx(0.2, abs=_CLOCK_TOL), (
+        "expected the 0.3s battery to end this run mid-cycle"
+    )
+    polled_before = len(fast.poll_times)
+
+    clock.advance(8.0)
+    jumped_to = clock() - start
+    await sched.step(5)
+
+    after = fast.poll_times[polled_before:]
+    assert after[0] == pytest.approx(jumped_to + 0.2, abs=_CLOCK_TOL)


### PR DESCRIPTION
## Why

`_SimHarness.step()` polled every battery exactly once and then advanced the clock by the **slowest** battery's interval:

```python
max_dt = max(b.poll_interval for b in self.batteries)
for b in self.batteries:
    await self._step_battery(b)
self.clock.advance(max_dt)
```

With mixed intervals that throttles every fast battery to the slow one's rate. `test_probe_handles_mixed_poll_intervals` sets `[0.9, 0.3]` and got a 1:1 poll ratio instead of 3:1 — so the one test in the suite named for mixed cadence never exercised one.

It also fed the plant the wrong `dt`. Each battery is stepped with its own `poll_interval` as the physics step, so the 0.3 s unit advanced 0.3 s of ramp and SoC per 0.9 s of simulated time — three times too slowly.

## What changed

A `PollScheduler` in `_ct002_e2e_backend.py` advances by the slowest interval and delivers every poll falling due inside that window, in time order. Both errors go away together: a battery stepped exactly at its own interval integrates the right `dt` by construction.

**With a uniform cadence it is exactly one poll each followed by one advance, as before** — which is why this went unnoticed, and why the other two harnesses carrying the same code (`test_e2e_probe_lockup`, `test_issue376_pv_passthrough`, both uniform) were unaffected. All three now share the scheduler so the next mixed-interval test inherits the fix rather than the bug.

## The one assertion that had to move

With the fast unit taking three corrections per window it ramps into the efficiency handoff harder. The grid excursion peaks at **595 W (Python) / 680 W (C++)**, deterministic on both, against a bound of 500 W calibrated when both units ran at 0.9 s.

**The transient is bigger, not new.** Tracing the same handoff on the *old* harness drives a battery to 680 W of output — the overshoot was always there; the fixed cadence changes its magnitude, not its existence.

Rather than relax the bound to taste, it is now the scenario's physical ceiling: one unit's `max_discharge_power`, since the candidate can reach it while the incumbent has not finished ramping down (200 W house − (800 + 200) = −800 W). Past that, something is being commanded the plant cannot explain.

The settle assertions — which the test's own comments call out as what actually separates a working handoff from a hunting one — pass **unchanged**: 31/45 samples settled, longest unsettled run 6–7, against bounds of ≥15 and ≤16.

## Verification

- `test_sim_harness_cadence.py` pins the schedule directly against stand-in batteries: exact poll counts and times for uniform, 3:1, three-way and non-integral ratios. It **fails on the old behaviour** for every mixed-interval case and passes for the uniform ones — checked by reverting the scheduler body and re-running.
- Clock drift is bounded by (advances × ulp) ≈ 3e-6 s over these runs; that is inherent to `HarnessClock` storing simulated time as an absolute epoch float (one ulp ≈ 4e-7 s there), not to the schedule, and six orders of magnitude below the intervals asserted on. The tolerance is derived from a measurement, not guessed.
- Full Python suite green with the ESPHome CLI installed, so the `[esphome]` variants run for real rather than skipping; all host gtests pass.

## Notes

- **Tests-only** — no `src/` or `esphome/` change, so no `CHANGELOG.md` entry and no Python ↔ ESPHome parity work.
- This does not change any controller behaviour, but it does change what the mixed-cadence test measures. That the balancer's ramp pacing is per-poll — so a faster-polling battery gets proportionally more authority per second — is now visible in that test rather than hidden by the harness. Worth knowing; out of scope to change here, since it would be a steering change needing the full evaluation.

## Checklist

- [x] Base branch is `develop`, not `main`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest`
- [x] Python ↔ ESPHome parity: test harness only, does not apply
- [x] `web/` changes: none
- [x] User-visible change: none — test infrastructure only, so no `CHANGELOG.md` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JyoX3XXSUeF3gwitUNML2

---
_Generated by [Claude Code](https://claude.ai/code/session_016JyoX3XXSUeF3gwitUNML2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulated battery polling so devices with different polling intervals are processed at their correct cadence.
  * Ensured faster-polling batteries are no longer limited by slower devices.
  * Corrected simulated time and battery state progression for mixed polling intervals.
  * Updated probe, efficiency, and PV passthrough scenarios to reflect accurate polling behavior.

* **Tests**
  * Added coverage for polling cadence, timing, clock changes, and proportional polling frequency across batteries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->