### PR TITLE
Replace the untyped dicts on the CT002 and balancer paths with named types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ Application code lives under **`src/astrameter/`** (src layout). Notable pieces:
 | `src/astrameter/powermeter/` | Powermeter backends |
 | `src/astrameter/ct002/` | CT002/CT003 UDP emulator |
 | `src/astrameter/shelly/` | Shelly protocol emulation |
+| `src/astrameter/udp_server.py` | The listening socket both emulators serve on |
 | `tests/` | Integration-style tests |
 
 Co-located tests use `*_test.py` next to modules under `src/astrameter/`.

--- a/src/astrameter/ct002/__init__.py
+++ b/src/astrameter/ct002/__init__.py
@@ -1,3 +1,15 @@
-from .ct002 import CT002, UDP_PORT, ReportingConsumerRow, ReportingPhase
+from .ct002 import (
+    CT002,
+    UDP_PORT,
+    CT002Request,
+    ReportingConsumerRow,
+    ReportingPhase,
+)
 
-__all__ = ["CT002", "UDP_PORT", "ReportingConsumerRow", "ReportingPhase"]
+__all__ = [
+    "CT002",
+    "UDP_PORT",
+    "CT002Request",
+    "ReportingConsumerRow",
+    "ReportingPhase",
+]

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -2486,41 +2486,19 @@ class LoadBalancer:
             0, min(len(self._priority), len(self._priority) - len(self._deprioritized))
         )
         previous_active = tuple(self._priority[:prev_slots])
-        probe_resolved = self._resolve_probe_state(reports, now, grid_total)
-        probe_active = self._probe_state is not None
+        # A probe owns the active set while it runs and for the tick that
+        # resolves it, so rotation, saturation swaps and starting the next
+        # probe all stand down until it is over.
+        probing = self._resolve_probe_state(reports, now, grid_total) or (
+            self._probe_state is not None
+        )
 
-        # Rotation check BEFORE cache. The active head holds its slot for
-        # ``efficiency_rotation_interval`` scaled by its efficiency window weight,
-        # so a lower-weight battery rotates out sooner (weight 0 → threshold 0 →
-        # it rotates out on the next tick).
-        if not probe_active and not probe_resolved and self._priority:
-            head_weight = _report_of(
-                reports, self._priority[0]
-            ).efficiency_window_weight
-            if (
-                now - self._last_rotation
-                >= cfg.efficiency_rotation_interval * head_weight
-            ):
-                self._last_rotation = now
-                self._priority.append(self._priority.pop(0))
+        # Both checks run BEFORE the cache lookup, because either can make the
+        # cached active set stale.
+        if not probing:
+            self._rotate_priority_head(reports, now)
+            if self._active_slot_saturated(prev_slots):
                 self._invalidate_efficiency_cache()
-
-        # Saturation swap check BEFORE cache
-        if (
-            not probe_active
-            and not probe_resolved
-            and cfg.efficiency_saturation_threshold > 0
-            and self._cache_sample is not None
-        ):
-            slots_est = len(self._priority) - len(self._deprioritized)
-            for cid in self._priority[:slots_est]:
-                state = self._consumers.get(cid)
-                if (
-                    state
-                    and state.saturation_score >= cfg.efficiency_saturation_threshold
-                ):
-                    self._invalidate_efficiency_cache()
-                    break
 
         cache_key = (sample_id, tuple(self._priority))
         if cache_key == self._cache_sample:
@@ -2533,61 +2511,43 @@ class LoadBalancer:
             was_limiting=len(self._deprioritized) > 0,
             prev_slots=prev_slots,
         )
+        pre_swap_active = set(self._priority[:slots])
+        for cid in self._deprioritized - set(self._priority[slots:]):
+            self._promote_to_active(cid, grace)
+
+        if not probing and self._maybe_force_swap_saturated(self._priority, slots, now):
+            # The swap reordered ``_priority``, so the active set and the cache
+            # key it feeds have to be taken again.
+            cache_key = (sample_id, tuple(self._priority))
+            for cid in set(self._priority[:slots]) - pre_swap_active:
+                self._promote_to_active(cid, grace)
 
         deprioritized = set(self._priority[slots:])
         result: dict[str, float] = {cid: 0.0 for cid in deprioritized}
-        pre_swap_active = set(self._priority[:slots])
-
-        # Reset saturation for consumers transitioning to active
-        for cid in self._deprioritized - deprioritized:
-            state = self._get_consumer(cid)
-            self._saturation.clear(state)
-            self._set_consumer_grace(cid, grace)
-
-        if (
-            not probe_active
-            and not probe_resolved
-            and self._maybe_force_swap_saturated(self._priority, slots, now)
-        ):
-            deprioritized = set(self._priority[slots:])
-            result = {cid: 0.0 for cid in deprioritized}
-            cache_key = (sample_id, tuple(self._priority))
-            for cid in set(self._priority[:slots]) - pre_swap_active:
-                state = self._get_consumer(cid)
-                self._saturation.clear(state)
-                self._set_consumer_grace(cid, grace)
 
         final_active = tuple(self._priority[:slots])
-        if not probe_active and not probe_resolved and previous_active:
+        if not probing and previous_active:
             promoted = [cid for cid in final_active if cid not in previous_active]
             backups = [cid for cid in previous_active if cid not in final_active]
             if promoted and backups:
                 self._begin_probe(
-                    promoted[0],
-                    final_active,
-                    tuple(backups),
-                    previous_active,
-                    now,
+                    promoted[0], final_active, tuple(backups), previous_active, now
                 )
 
         for cid in deprioritized - self._deprioritized:
-            state = self._consumers.get(cid)
-            if state:
-                # Symmetric with the deprioritized -> active clear above: the
-                # score is a memory of the previous role, and a consumer
-                # steered toward zero cannot be judged by it.  Without the
-                # clear, saturation accumulated over the fading window would
-                # bar ``_maybe_force_swap_saturated`` from ever promoting it.
-                self._saturation.clear(state)
+            # Symmetric with the promotion clear above: the score is a memory
+            # of the previous role, and a consumer steered toward zero cannot
+            # be judged by it.  Without the clear, saturation accumulated over
+            # the fading window would bar ``_maybe_force_swap_saturated`` from
+            # ever promoting it back.
+            self._forget_saturation(cid)
+        for cid, verb in (
+            *((cid, "deprioritizing") for cid in deprioritized - self._deprioritized),
+            *((cid, "activating") for cid in self._deprioritized - deprioritized),
+        ):
             logger.info(
-                "Efficiency: deprioritizing consumer %s (demand %.0fW, %d active)",
-                cid[:16],
-                abs_target,
-                slots,
-            )
-        for cid in self._deprioritized - deprioritized:
-            logger.info(
-                "Efficiency: activating consumer %s (demand %.0fW, %d active)",
+                "Efficiency: %s consumer %s (demand %.0fW, %d active)",
+                verb,
                 cid[:16],
                 abs_target,
                 slots,
@@ -2597,6 +2557,56 @@ class LoadBalancer:
         self._cache_sample = cache_key
         self._cache_result = result
         return result
+
+    def _rotate_priority_head(self, reports: Reports, now: float) -> None:
+        """Send the longest-serving active battery to the back of the queue.
+
+        The head holds its slot for ``efficiency_rotation_interval`` scaled by
+        its efficiency window weight, so a lower-weight battery rotates out
+        sooner — weight 0 means a threshold of 0, i.e. out on the next tick.
+        """
+        if not self._priority:
+            return
+        head_weight = _report_of(reports, self._priority[0]).efficiency_window_weight
+        if now - self._last_rotation < self._cfg.efficiency_rotation_interval * (
+            head_weight
+        ):
+            return
+        self._last_rotation = now
+        self._priority.append(self._priority.pop(0))
+        self._invalidate_efficiency_cache()
+
+    def _active_slot_saturated(self, slots_estimate: int) -> bool:
+        """Whether a battery currently holding an active slot is saturated.
+
+        Only meaningful once a set has been cached: without one there is
+        nothing stale to invalidate.
+        """
+        threshold = self._cfg.efficiency_saturation_threshold
+        if threshold <= 0 or self._cache_sample is None:
+            return False
+        return any(
+            (state := self._consumers.get(cid)) is not None
+            and state.saturation_score >= threshold
+            for cid in self._priority[:slots_estimate]
+        )
+
+    def _promote_to_active(self, consumer_id: str, grace: float) -> None:
+        """Give a consumer a clean slate as it takes an active slot.
+
+        Its saturation score is a memory of the deprioritized role — a battery
+        steered toward zero cannot be judged by it — and the grace window keeps
+        the fresh score from being read before the battery has had time to move.
+        """
+        state = self._get_consumer(consumer_id)
+        self._saturation.clear(state)
+        self._saturation.set_grace(state, grace)
+
+    def _forget_saturation(self, consumer_id: str) -> None:
+        """Drop a known consumer's saturation score; unknown ids are ignored."""
+        state = self._consumers.get(consumer_id)
+        if state is not None:
+            self._saturation.clear(state)
 
     def _maybe_force_swap_saturated(
         self, priority: list[str], slots: int, now: float

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -50,9 +50,9 @@ def phase_index(phase: str) -> int:
 class ConsumerReport:
     """One consumer's latest poll, as the balancer sees it.
 
-    Every field is normalized on construction, so the control path reads
-    plain numbers and never re-parses or re-defaults: ``None`` means
-    "neutral" for the two weights and "no override" for ``min_dc_output``.
+    Every field is normalized on construction, so the control path reads plain
+    numbers and never re-parses or re-defaults. Only ``min_dc_output`` is
+    nullable, where ``None`` means "no override".
     """
 
     power: int = 0
@@ -74,16 +74,15 @@ class ConsumerReport:
     """Per-device MIN_DC_OUTPUT override in watts; ``None`` uses the global rule."""
 
     def __post_init__(self) -> None:
-        eww = self.efficiency_window_weight
         floor = self.min_dc_output
         for field, value in (
             ("power", parse_int(self.power)),
             ("phase", (self.phase or "A").upper()),
             ("device_type", self.device_type or ""),
-            ("weight", 1.0 if self.weight is None else float(self.weight)),
+            ("weight", float(self.weight)),
             (
                 "efficiency_window_weight",
-                1.0 if eww is None else max(0.0, min(1.0, float(eww))),
+                max(0.0, min(1.0, float(self.efficiency_window_weight))),
             ),
             ("min_dc_output", None if floor is None else max(0.0, float(floor))),
         ):

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -46,28 +46,68 @@ def phase_index(phase: str) -> int:
     return {"A": 0, "B": 1, "C": 2}.get(phase.upper(), 0)
 
 
-def _report_weight(report: dict) -> float:
-    """Per-battery fair-share weight from a report dict (defaults to 1.0).
+@dataclasses.dataclass(frozen=True)
+class ConsumerReport:
+    """One consumer's latest poll, as the balancer sees it.
 
-    A missing key (or an explicit ``None``) means "neutral" and maps to 1.0;
-    an explicit ``0.0`` is preserved (the battery takes no share). The setter
-    keeps real weights in ``[0, 10]``.
+    Every field is normalized on construction, so the control path reads
+    plain numbers and never re-parses or re-defaults: ``None`` means
+    "neutral" for the two weights and "no override" for ``min_dc_output``.
     """
-    weight = report.get("weight", 1.0)
-    return 1.0 if weight is None else float(weight)
+
+    power: int = 0
+    """Reported net output in watts; positive discharges, negative charges."""
+
+    phase: str = "A"
+    """Steered phase (A/B/C, or D for combined mode); A when unknown."""
+
+    device_type: str = ""
+
+    weight: float = 1.0
+    """Fair-share weight. ``0.0`` parks the battery; the setter bounds it to [0, 10]."""
+
+    efficiency_window_weight: float = 1.0
+    """Fraction of ``efficiency_rotation_interval`` an active slot is held for,
+    clamped to [0, 1]. ``0.0`` rotates out on the next tick."""
+
+    min_dc_output: float | None = None
+    """Per-device MIN_DC_OUTPUT override in watts; ``None`` uses the global rule."""
+
+    def __post_init__(self) -> None:
+        eww = self.efficiency_window_weight
+        floor = self.min_dc_output
+        for field, value in (
+            ("power", parse_int(self.power)),
+            ("phase", (self.phase or "A").upper()),
+            ("device_type", self.device_type or ""),
+            ("weight", 1.0 if self.weight is None else float(self.weight)),
+            (
+                "efficiency_window_weight",
+                1.0 if eww is None else max(0.0, min(1.0, float(eww))),
+            ),
+            ("min_dc_output", None if floor is None else max(0.0, float(floor))),
+        ):
+            object.__setattr__(self, field, value)
 
 
-def _efficiency_window_weight(report: dict) -> float:
-    """Per-battery efficiency-rotation weight from a report dict, clamped to [0, 1].
+# Reports keyed by consumer id — what the balancer is handed every poll.
+Reports = Mapping[str, ConsumerReport]
 
-    ``1.0`` holds an active slot for the whole ``efficiency_rotation_interval``,
-    ``0.0`` is parked while limiting (as long as enough non-zero-weight batteries
-    fill the active slots); a missing key or ``None`` is neutral (1.0).
+NO_REPORT = ConsumerReport()
+"""Stand-in for a consumer that did not report this tick (unknown or just removed)."""
+
+
+def _report_of(reports: Reports, consumer_id: str | None) -> ConsumerReport:
+    """*consumer_id*'s report, or :data:`NO_REPORT` when it did not report.
+
+    A consumer can drop out between the snapshot a caller took and the
+    allocation that reads it (evicted, deprioritized, filtered out of the auto
+    pool), and the neutral report keeps every reader on plain attribute access
+    instead of inventing its own default.
     """
-    weight = report.get("efficiency_window_weight", 1.0)
-    if weight is None:
-        return 1.0
-    return max(0.0, min(1.0, float(weight)))
+    if not consumer_id:
+        return NO_REPORT
+    return reports.get(consumer_id, NO_REPORT)
 
 
 # Ramp pacing (issue #458).  The pace cap grows only once the battery's reported
@@ -247,7 +287,7 @@ def min_actionable_output(device_type: str) -> float:
 
 
 def saturation_floor(
-    state: BalancerConsumerState, report: dict, configured_floor: float
+    state: BalancerConsumerState, report: ConsumerReport, configured_floor: float
 ) -> float:
     """Smallest command worth judging this consumer by (W).
 
@@ -262,7 +302,7 @@ def saturation_floor(
     (issue #600): a too-low gate starves the battery for good (issue #624), a
     too-high one only delays detecting a full or empty one.
     """
-    nominal = min_actionable_output(report.get("device_type", ""))
+    nominal = min_actionable_output(report.device_type)
     if nominal > 0.0:
         observed = state.pace_responded_at
         if observed > 0.0:
@@ -1076,19 +1116,17 @@ class LoadBalancer:
         )
         self._invalidate_efficiency_cache()
 
-    def _commit_probe(self, reports: dict, now: float, actual: float) -> None:
+    def _commit_probe(self, reports: Reports, now: float, actual: float) -> None:
         probe = self._probe_state
         if probe is None:
             return
         participants = [
             cid for cid in (*probe.active_ids, *probe.backup_ids) if cid in reports
         ]
-        total_actual = sum(
-            abs(parse_int(reports.get(cid, {}).get("power", 0))) for cid in participants
-        )
+        total_actual = sum(abs(_report_of(reports, cid).power) for cid in participants)
         if total_actual > 0:
             for cid in participants:
-                actual_share = abs(parse_int(reports.get(cid, {}).get("power", 0)))
+                actual_share = abs(_report_of(reports, cid).power)
                 self._get_consumer(cid).fade_weight = actual_share / total_actual
         else:
             active_count = max(1, len(probe.active_ids))
@@ -1149,7 +1187,7 @@ class LoadBalancer:
             self._reset_fn()
 
     def _resolve_probe_state(
-        self, reports: dict, now: float, grid_total: float
+        self, reports: Reports, now: float, grid_total: float
     ) -> bool:
         probe = self._probe_state
         if probe is None:
@@ -1161,11 +1199,8 @@ class LoadBalancer:
                 f"participants disappeared: {[cid[:16] for cid in missing]}"
             )
             return True
-        actual = parse_int(reports.get(probe.candidate_id, {}).get("power", 0))
-        desired_total = (
-            sum(parse_int(report.get("power", 0)) for report in reports.values())
-            + grid_total
-        )
+        actual = _report_of(reports, probe.candidate_id).power
+        desired_total = sum(report.power for report in reports.values()) + grid_total
         probe_success_threshold = self._probe_success_threshold
         demand_sign = 1 if desired_total > 0 else -1 if desired_total < 0 else 0
         actual_sign = 1 if actual > 0 else -1 if actual < 0 else 0
@@ -1188,7 +1223,7 @@ class LoadBalancer:
     def _compute_desired_contribution(
         self,
         consumer_id: str,
-        reports: dict,
+        reports: Reports,
         weights: dict[str, float],
         desired_total: float,
     ) -> float:
@@ -1211,7 +1246,7 @@ class LoadBalancer:
     def _compute_probe_target(
         self,
         consumer_id: str | None,
-        reports: dict,
+        reports: Reports,
         grid_total: float,
         eff_part: dict[str, float],
     ) -> list[float] | None:
@@ -1232,11 +1267,8 @@ class LoadBalancer:
         if consumer_id != candidate_id and consumer_id not in support_reports:
             return None
 
-        desired_total = (
-            sum(parse_int(report.get("power", 0)) for report in reports.values())
-            + grid_total
-        )
-        probe_actual = parse_int(reports.get(candidate_id, {}).get("power", 0))
+        desired_total = sum(report.power for report in reports.values()) + grid_total
+        probe_actual = _report_of(reports, candidate_id).power
         probe_ceiling = max(abs(desired_total), self._cfg.probe_min_power)
 
         if consumer_id == candidate_id:
@@ -1269,8 +1301,7 @@ class LoadBalancer:
             )
 
         backup_weights = {
-            cid: max(0.01, eff_part.get(cid, 1.0))
-            * _report_weight(reports.get(cid, {}))
+            cid: max(0.01, eff_part.get(cid, 1.0)) * _report_of(reports, cid).weight
             for cid in support_reports
         }
         qualified_probe_actual = probe_actual if probe.proof_samples > 0 else 0
@@ -1280,7 +1311,7 @@ class LoadBalancer:
             backup_weights,
             desired_total - qualified_probe_actual,
         )
-        reported = parse_int(support_reports.get(consumer_id, {}).get("power", 0))
+        reported = _report_of(support_reports, consumer_id).power
         return self._emit(
             consumer_id, NetOutputW(desired), reported, support_reports, backup_weights
         )
@@ -1298,7 +1329,7 @@ class LoadBalancer:
         self,
         consumer_id: str | None,
         mode: ConsumerMode,
-        reports: dict,
+        reports: Reports,
         grid_total: float,
         result: list[float],
     ) -> None:
@@ -1325,11 +1356,11 @@ class LoadBalancer:
             consumer_id,
             f"manual={mode.manual_value:g}" if mode.mode == "manual" else mode.mode,
             rotation,
-            _report_weight(reports.get(consumer_id, {})),
+            _report_of(reports, consumer_id).weight,
             self._diag_num(grid_total),
             self._diag_num(self._diag_control_grid),
             self._diag_num(self._diag_fair_share),
-            self._diag_num(parse_int(reports.get(consumer_id, {}).get("power", 0))),
+            self._diag_num(_report_of(reports, consumer_id).power),
             self._diag_num(state.last_intent if state else None),
             self._diag_num(sum(result)),
             self._diag_num(state.last_intent_reading if state else None),
@@ -1341,7 +1372,7 @@ class LoadBalancer:
         self,
         consumer_id: str | None,
         consumer_mode: ConsumerMode,
-        all_reports: dict,
+        all_reports: Reports,
         grid_total: float,
         inactive: frozenset[str],
         manual: frozenset[str],
@@ -1349,7 +1380,7 @@ class LoadBalancer:
     ) -> list[float]:
         """Return ``[phase_A, phase_B, phase_C]`` target for *consumer_id*.
 
-        *all_reports* contains every known consumer's report dict.
+        *all_reports* holds every known consumer's :class:`ConsumerReport`.
         *inactive* / *manual* are the sets of paused and manual-override
         consumer IDs; this method filters internally.
         *sample_id* identifies the current meter reading for cache keying.
@@ -1386,8 +1417,8 @@ class LoadBalancer:
             and consumer_id not in self._probe_participants()
             and consumer_id not in self._deprioritized
         ):
-            report = active_reports.get(consumer_id, {})
-            actual = parse_int(report.get("power", 0))
+            report = _report_of(active_reports, consumer_id)
+            actual = report.power
             # The floor is compared against the unpaced intent too: a battery
             # the clamp holds below its floor must still register as pushed
             # (issue #522); the stall escape bounds how long that lasts.
@@ -1403,7 +1434,7 @@ class LoadBalancer:
             )
 
         if consumer_mode.mode == "manual" and state is not None:
-            reported = parse_int(active_reports.get(consumer_id, {}).get("power", 0))
+            reported = _report_of(active_reports, consumer_id).power
             result = self._emit(
                 consumer_id,
                 NetOutputW(consumer_mode.manual_value),
@@ -1581,7 +1612,7 @@ class LoadBalancer:
         """
         return self._control_quality.snapshot()
 
-    def _pool_out_of_headroom(self, reports: dict, grid_total: float) -> bool:
+    def _pool_out_of_headroom(self, reports: Reports, grid_total: float) -> bool:
         """Whether the pool physically cannot close the remaining error.
 
         Either every battery is saturated, or there is a surplus nothing
@@ -1600,7 +1631,7 @@ class LoadBalancer:
             for cid in reports
         )
 
-    def _cannot_absorb(self, reports: dict) -> bool:
+    def _cannot_absorb(self, reports: Reports) -> bool:
         """Whether a surplus is genuinely beyond what the pool can take.
 
         Not simply "no AC-chargeable battery reporting": a DC-only battery
@@ -1610,12 +1641,12 @@ class LoadBalancer:
         symmetrically about zero on an all-DC pool as a full pack.
         """
         for cid, report in reports.items():
-            if _is_ac_chargeable(report.get("device_type", "")):
+            if _is_ac_chargeable(report.device_type):
                 return False
             # Output it could still give back.  The floor is where the battery
             # stops being able to reduce, so anything above it is headroom.
             floor = self._effective_min_dc_output(cid, reports)
-            if parse_int(report.get("power", 0)) > floor + self._cfg.balance_deadband:
+            if report.power > floor + self._cfg.balance_deadband:
                 return False
         return True
 
@@ -1640,23 +1671,24 @@ class LoadBalancer:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _effective_min_dc_output(self, consumer_id: str | None, reports: dict) -> float:
+    def _effective_min_dc_output(
+        self, consumer_id: str | None, reports: Reports
+    ) -> float:
         """Per-consumer MIN_DC_OUTPUT floor (W); 0 means no floor.
 
         An explicit per-device override (``min_dc_output`` in the report) wins
         for any battery; otherwise the global floor applies only to batteries
         that depend on a sleep-prone external inverter (``_needs_dc_output_floor``).
         """
-        report = reports.get(consumer_id, {}) if consumer_id else {}
-        override = report.get("min_dc_output")
-        if override is not None:
-            return max(0.0, float(override))
-        if _needs_dc_output_floor(report.get("device_type", "")):
+        report = _report_of(reports, consumer_id)
+        if report.min_dc_output is not None:
+            return report.min_dc_output
+        if _needs_dc_output_floor(report.device_type):
             return self._cfg.min_dc_output
         return 0.0
 
     def _apply_min_dc_output(
-        self, consumer_id: str | None, reports: dict, result: list[float]
+        self, consumer_id: str | None, reports: Reports, result: list[float]
     ) -> list[float]:
         """Hold an external-inverter DC battery at ``MIN_DC_OUTPUT`` discharge.
 
@@ -1675,9 +1707,9 @@ class LoadBalancer:
         report = reports[consumer_id]
         # Respect an explicit park: distribution_weight=0 means "take no share",
         # i.e. sit at 0 — don't silently wake it (mirrors manual/inactive).
-        if _report_weight(report) == 0:
+        if report.weight == 0:
             return result
-        reported = parse_int(report.get("power", 0))
+        reported = report.power
         # Use the consumer's FULL intended reading: ``_split_by_phase`` spreads
         # the scalar across phases but preserves the total, so sum(result)
         # recovers it regardless of phase distribution. ``result[idx]`` alone is
@@ -1695,11 +1727,11 @@ class LoadBalancer:
             NetOutputW(eff_min),
             reported,
             reports,
-            single_phase=report.get("phase") or "A",
+            single_phase=report.phase,
         )
 
     def _steer_to_zero(
-        self, consumer_id: str | None, reports: dict, *, paced: bool = False
+        self, consumer_id: str | None, reports: Reports, *, paced: bool = False
     ) -> list[float]:
         """Drive a consumer's output to zero (``NetOutputW(0)``).
 
@@ -1710,15 +1742,15 @@ class LoadBalancer:
         (issue #469).  Inactive consumers keep the one-shot behaviour — a
         user-initiated mode change, not a closed-loop handoff.
         """
-        report = reports.get(consumer_id, {}) if consumer_id else {}
-        reported = parse_int(report.get("power", 0))
+        report = _report_of(reports, consumer_id)
+        reported = report.power
         return self._emit(
             consumer_id,
             NetOutputW(0),
             reported,
             reports,
             pace=paced,
-            single_phase=report.get("phase") or "A",
+            single_phase=report.phase,
             # An unpaced wind-down is a one-shot command, recorded as 0 rather
             # than as the reading that carries it.
             last_target=None if paced else 0.0,
@@ -1730,7 +1762,7 @@ class LoadBalancer:
         consumer_id: str | None,
         desired: NetOutputW,
         reported: float,
-        reports: dict,
+        reports: Reports,
         weights: dict[str, float] | None = None,
         *,
         pace: bool = False,
@@ -1772,13 +1804,13 @@ class LoadBalancer:
     @staticmethod
     def _split_by_phase(
         target: float,
-        reports: dict,
+        reports: Reports,
         weights: dict[str, float] | None = None,
     ) -> list[float]:
         """Distribute *target* across phases proportional to weights."""
         phase_effective: dict[str, float] = {"A": 0.0, "B": 0.0, "C": 0.0}
         for cid, report in reports.items():
-            phase = (report.get("phase") or "A").upper()
+            phase = report.phase
             if phase not in phase_effective:
                 phase = "A"
             w = (weights or {}).get(cid, 1.0)
@@ -1800,7 +1832,7 @@ class LoadBalancer:
     def _compute_auto_target(
         self,
         consumer_id: str | None,
-        reports: dict,
+        reports: Reports,
         grid_total: float,
         sample_id: tuple = (),
     ) -> list[float]:
@@ -1914,11 +1946,7 @@ class LoadBalancer:
         if consumer_id:
             residual = self._damp_oscillation(consumer_id, residual)
 
-        reported = (
-            parse_int(reports.get(consumer_id, {}).get("power", 0))
-            if consumer_id
-            else 0
-        )
+        reported = _report_of(reports, consumer_id).power if consumer_id else 0
         return self._emit(
             consumer_id,
             NetOutputW(reported + residual),
@@ -1929,7 +1957,7 @@ class LoadBalancer:
         )
 
     @staticmethod
-    def _charge_blind(reports: dict, grid_total: float) -> tuple[set[str], bool]:
+    def _charge_blind(reports: Reports, grid_total: float) -> tuple[set[str], bool]:
         """Batteries that can't absorb the current surplus, and whether any can.
 
         Excludes batteries that can't charge from AC (B2500 family, Jupiter;
@@ -1946,29 +1974,23 @@ class LoadBalancer:
         (issue #359).
         """
         ac_charging = any(
-            _is_ac_chargeable(r.get("device_type", ""))
-            and parse_int(r.get("power", 0)) < 0
-            for r in reports.values()
+            _is_ac_chargeable(r.device_type) and r.power < 0 for r in reports.values()
         )
         any_ac_chargeable = any(
-            _is_ac_chargeable(r.get("device_type", "")) for r in reports.values()
+            _is_ac_chargeable(r.device_type) for r in reports.values()
         )
         in_charge_territory = any_ac_chargeable and (
             grid_total < 0 or (grid_total == 0 and ac_charging)
         )
         charge_blind = (
-            {
-                cid
-                for cid, r in reports.items()
-                if not _is_ac_chargeable(r.get("device_type", ""))
-            }
+            {cid for cid, r in reports.items() if not _is_ac_chargeable(r.device_type)}
             if in_charge_territory
             else set()
         )
         return charge_blind, any_ac_chargeable
 
     def _note_all_dc_surplus(
-        self, reports: dict, grid_total: float, any_ac_chargeable: bool
+        self, reports: Reports, grid_total: float, any_ac_chargeable: bool
     ) -> None:
         """Log once while every reporter is DC-only under surplus.
 
@@ -1987,7 +2009,7 @@ class LoadBalancer:
                 "reporting — nothing here can absorb it. Reporting "
                 "device_types: %s",
                 -grid_total,
-                sorted({reports[cid].get("device_type", "") or "?" for cid in reports}),
+                sorted({r.device_type or "?" for r in reports.values()}),
             )
             self._all_dc_surplus_warned = True
         elif not all_dc_under_surplus:
@@ -1996,7 +2018,7 @@ class LoadBalancer:
     def _fading_target(
         self,
         consumer_id: str,
-        reports: dict,
+        reports: Reports,
         grid_total: float,
         eff_part: dict[str, float],
     ) -> list[float]:
@@ -2004,10 +2026,8 @@ class LoadBalancer:
         fade_w = self._get_consumer(consumer_id).fade_weight
         if fade_w == 0.0:
             return self._steer_to_zero(consumer_id, reports, paced=True)
-        reported = parse_int(reports.get(consumer_id, {}).get("power", 0))
-        total_battery = sum(
-            parse_int(reports.get(cid, {}).get("power", 0)) for cid in reports
-        )
+        reported = _report_of(reports, consumer_id).power
+        total_battery = sum(report.power for report in reports.values())
         demand = total_battery + grid_total
         total_fade = sum(self._get_consumer(cid).fade_weight for cid in reports)
         desired = demand * fade_w / total_fade if total_fade > 0 else 0.0
@@ -2018,7 +2038,7 @@ class LoadBalancer:
     @staticmethod
     def _fair_share(
         consumer_id: str | None,
-        reports: dict,
+        reports: Reports,
         control_grid: float,
         eff_part: dict[str, float],
     ) -> float:
@@ -2031,8 +2051,7 @@ class LoadBalancer:
         fall back to an even split.
         """
         share_part = {
-            cid: eff_part[cid] * _report_weight(reports.get(cid, {}))
-            for cid in eff_part
+            cid: eff_part[cid] * _report_of(reports, cid).weight for cid in eff_part
         }
         total_effective = sum(share_part.values())
         if consumer_id and consumer_id in reports and total_effective > 0:
@@ -2042,7 +2061,7 @@ class LoadBalancer:
     def _concentrated_share(
         self,
         consumer_id: str | None,
-        reports: dict,
+        reports: Reports,
         control_grid: float,
         eff_part: dict[str, float],
         charge_blind: set[str],
@@ -2063,7 +2082,7 @@ class LoadBalancer:
             for cid in reports
             if cid not in charge_blind
             and eff_part.get(cid, 0.0) > 0.1
-            and _report_weight(reports[cid]) > 0.0
+            and reports[cid].weight > 0.0
         ]
         if not (
             cfg.fair_distribution
@@ -2071,18 +2090,18 @@ class LoadBalancer:
             and len(conc_ids) > 1
             and consumer_id in conc_ids
             and 0 < abs(control_grid) < cfg.concentrate_deadband
-            and len({(reports[c].get("phase") or "A").upper() for c in conc_ids}) == 1
+            and len({reports[c].phase for c in conc_ids}) == 1
             and self._concentration_pool_balanced(reports, conc_ids)
         ):
             return None
         designated = max(
             conc_ids,
-            key=lambda c: (abs(parse_int(reports[c].get("power", 0))), c),
+            key=lambda c: (abs(reports[c].power), c),
         )
         return control_grid if consumer_id == designated else 0.0
 
     def _predict_control_grid(
-        self, reports: dict, grid_total: float, sample_id: tuple
+        self, reports: Reports, grid_total: float, sample_id: tuple
     ) -> float:
         """Return the grid power the control path should act on.
 
@@ -2098,7 +2117,7 @@ class LoadBalancer:
         """
         if self._cfg.grid_predict_trust <= 0.0:
             return grid_total
-        pool_output = sum(parse_int(r.get("power", 0)) for r in reports.values())
+        pool_output = sum(r.power for r in reports.values())
         if self._pred_grid is None:
             self._pred_grid = grid_total
             self._pred_pool_output = pool_output
@@ -2186,7 +2205,7 @@ class LoadBalancer:
         return residual * (1.0 - cfg.osc_damp_max * state.osc_score)
 
     def _pace_reading(
-        self, consumer_id: str, reading: float, reported: float, reports: dict
+        self, consumer_id: str, reading: float, reported: float, reports: Reports
     ) -> float:
         """Clamp the auto-path *reading* to the consumer's ramp-pacing cap.
 
@@ -2228,9 +2247,7 @@ class LoadBalancer:
         # with a minimum actionable command (the DC-output family); any other
         # battery can execute an arbitrarily small command and can never be
         # deadlocked by the clamp, so it stays on the unmodified path.
-        can_stall = _needs_dc_output_floor(
-            (reports.get(consumer_id) or {}).get("device_type", "")
-        )
+        can_stall = _needs_dc_output_floor(_report_of(reports, consumer_id).device_type)
         stalled = False
         if sign == 0 or sign != state.pace_sign:
             cap = base
@@ -2302,7 +2319,9 @@ class LoadBalancer:
         state.pace_last_sent = abs(out)
         return out
 
-    def _concentration_pool_balanced(self, reports: dict, conc_ids: list[str]) -> bool:
+    def _concentration_pool_balanced(
+        self, reports: Reports, conc_ids: list[str]
+    ) -> bool:
         """True iff every battery in *conc_ids* already sits at its fair share.
 
         Deadband concentration bypasses balance correction for the tick, so it
@@ -2316,13 +2335,11 @@ class LoadBalancer:
             # No deadband means balance correction always runs at full authority;
             # never let concentration suppress it.
             return False
-        actual_total = sum(
-            parse_int(reports.get(cid, {}).get("power", 0)) for cid in conc_ids
-        )
-        weights = {cid: _report_weight(reports.get(cid, {})) for cid in conc_ids}
+        actual_total = sum(_report_of(reports, cid).power for cid in conc_ids)
+        weights = {cid: _report_of(reports, cid).weight for cid in conc_ids}
         total_weight = sum(weights.values())
         for cid in conc_ids:
-            actual_self = parse_int(reports.get(cid, {}).get("power", 0))
+            actual_self = _report_of(reports, cid).power
             if total_weight > 0:
                 target_share = actual_total * weights[cid] / total_weight
             else:
@@ -2334,26 +2351,24 @@ class LoadBalancer:
     def _balance_correction(
         self,
         consumer_id: str,
-        reports: dict,
+        reports: Reports,
         eff_part: dict[str, float],
         fair_share: float,
     ) -> float:
         """Apply fair-share balance correction for *consumer_id*."""
         cfg = self._cfg
-        actual_self = parse_int(reports.get(consumer_id, {}).get("power", 0))
+        actual_self = _report_of(reports, consumer_id).power
         participating = [cid for cid in reports if eff_part.get(cid, 1.0) > 0.1]
         if not participating:
             return fair_share
 
-        actual_total = sum(
-            parse_int(reports.get(cid, {}).get("power", 0)) for cid in participating
-        )
+        actual_total = sum(_report_of(reports, cid).power for cid in participating)
         # Pull each battery toward its weight-proportional share of the pool's
         # total output, so the configured ratio is the steady state; with
         # neutral weights this is the plain average.  Participation is still
         # decided by ``eff_part`` above, so a small weight never drops a
         # healthy battery from the pool.
-        weights = {cid: _report_weight(reports.get(cid, {})) for cid in participating}
+        weights = {cid: _report_of(reports, cid).weight for cid in participating}
         total_weight = sum(weights.values())
         if total_weight > 0:
             target_share = actual_total * weights.get(consumer_id, 0.0) / total_weight
@@ -2385,7 +2400,7 @@ class LoadBalancer:
     # Efficiency deprioritization
     # ------------------------------------------------------------------
 
-    def _sync_pool(self, reports: dict, grace: float) -> None:
+    def _sync_pool(self, reports: Reports, grace: float) -> None:
         """Reconcile the rotation order with the reporting pool.
 
         Drops departed consumers, appends new arrivals (in id order, each with a
@@ -2401,11 +2416,11 @@ class LoadBalancer:
                 self._priority.append(cid)
                 self._set_consumer_grace(cid, grace)
         self._priority.sort(
-            key=lambda cid: _efficiency_window_weight(reports.get(cid, {})),
+            key=lambda cid: _report_of(reports, cid).efficiency_window_weight,
             reverse=True,
         )
 
-    def _demand_estimate(self, reports: dict, grid_total: float) -> float:
+    def _demand_estimate(self, reports: Reports, grid_total: float) -> float:
         """Low-pass-filtered household demand driving the active-set decision.
 
         ``|total_battery_power + grid_total|`` is the true house load; filtering
@@ -2414,7 +2429,7 @@ class LoadBalancer:
         loop still acts on the unsmoothed grid, so tracking is unaffected.
         """
         total_battery_power = sum(
-            parse_int(reports.get(cid, {}).get("power", 0)) for cid in self._priority
+            _report_of(reports, cid).power for cid in self._priority
         )
         raw_abs_target = abs(total_battery_power + grid_total)
         alpha = self._cfg.efficiency_demand_alpha
@@ -2451,7 +2466,7 @@ class LoadBalancer:
         return slots
 
     def _compute_efficiency_deprioritized(
-        self, reports: dict, sample_id: tuple, grid_total: float
+        self, reports: Reports, sample_id: tuple, grid_total: float
     ) -> dict[str, float]:
         """Decide which consumers to deprioritize for efficiency."""
         cfg = self._cfg
@@ -2479,7 +2494,9 @@ class LoadBalancer:
         # so a lower-weight battery rotates out sooner (weight 0 → threshold 0 →
         # it rotates out on the next tick).
         if not probe_active and not probe_resolved and self._priority:
-            head_weight = _efficiency_window_weight(reports.get(self._priority[0], {}))
+            head_weight = _report_of(
+                reports, self._priority[0]
+            ).efficiency_window_weight
             if (
                 now - self._last_rotation
                 >= cfg.efficiency_rotation_interval * head_weight

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -12,6 +12,7 @@ from typing import Any, Literal, cast
 from astrameter.config.logger import debug_traceback, logger
 from astrameter.power_units import three_phases
 from astrameter.request_dedupe import RequestDeduplicator
+from astrameter.udp_server import UdpServer
 
 from .balancer import (
     SATURATION_GRACE_SECONDS,
@@ -377,22 +378,6 @@ class CT002Snapshot:
     balancer: BalancerSnapshot
 
 
-class _CT002Protocol(asyncio.DatagramProtocol):
-    def __init__(self, ct002: CT002):
-        self.ct002 = ct002
-        self._tasks: set[asyncio.Task] = set()
-
-    def connection_made(self, transport):
-        self.transport = transport
-
-    def datagram_received(self, data, addr):
-        task = asyncio.create_task(
-            self.ct002._safe_handle_request(data, addr, self.transport)
-        )
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
-
-
 class CT002:
     def __init__(
         self,
@@ -453,8 +438,7 @@ class CT002:
         self._dedup: RequestDeduplicator[str] = RequestDeduplicator(
             dedupe_time_window, clock=clock or time.time
         )
-        self._transport = None
-        self._protocol: _CT002Protocol | None = None
+        self._server: UdpServer | None = None
         self._cleanup_task = None
         self._stopped = asyncio.Event()
         # Clock used for rate-limiting ``before_send`` warning logs.
@@ -1507,13 +1491,7 @@ class CT002:
             pass
 
     async def start(self):
-        loop = asyncio.get_running_loop()
-        transport, protocol = await loop.create_datagram_endpoint(
-            lambda: _CT002Protocol(self),
-            local_addr=("0.0.0.0", self.udp_port),
-        )
-        self._transport = transport
-        self._protocol = protocol
+        self._server = await UdpServer.serve(self.udp_port, self._safe_handle_request)
         self._stopped.clear()
         self._cleanup_task = asyncio.create_task(self._cleanup_loop())
         self._started_at = self._clock()
@@ -1530,14 +1508,9 @@ class CT002:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._cleanup_task
             self._cleanup_task = None
-        if self._transport:
-            self._transport.close()
-            self._transport = None
-        if self._protocol:
-            for task in list(self._protocol._tasks):
-                task.cancel()
-            await asyncio.gather(*self._protocol._tasks, return_exceptions=True)
-        self._protocol = None
+        if self._server:
+            await self._server.close()
+            self._server = None
         self._running = False
         self._rev += 1
         self._stopped.set()

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -5,11 +5,12 @@ import contextlib
 import dataclasses
 import math
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from datetime import datetime, timezone
 from typing import Any, Literal, cast
 
 from astrameter.config.logger import debug_traceback, logger
+from astrameter.power_units import three_phases
 from astrameter.request_dedupe import RequestDeduplicator
 
 from .balancer import (
@@ -150,6 +151,68 @@ def _values_finite(values) -> bool:
     except (TypeError, ValueError, OverflowError):
         # OverflowError: float(10**400) — an int too large for a float.
         return False
+
+
+# ---------------------------------------------------------------------------
+# The incoming poll
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class CT002Request:
+    """One battery's poll, decoded (see docs/ct002-ct003-protocol.md).
+
+    Fields 1-6 appear in all observed traffic.  Field 7 ("participate") is a
+    newer addition older senders omit; absent or empty means the reporter
+    takes part in aggregation, an explicit 0 opts out.
+    """
+
+    meter_dev_type: str
+    meter_mac: str
+    ct_type: str
+    ct_mac: str
+    phase: str
+    power: int
+    participates: bool
+    addr: tuple
+
+    @classmethod
+    def from_fields(cls, fields: Sequence[str], addr: tuple = ("", 0)) -> CT002Request:
+        """Decode a parsed field list.  Requires at least the four id fields."""
+
+        def field(index: int) -> str:
+            return fields[index] if len(fields) > index else ""
+
+        participate = field(6).strip()
+        return cls(
+            meter_dev_type=field(0),
+            meter_mac=field(1),
+            ct_type=field(2),
+            ct_mac=field(3),
+            phase=field(4).strip().upper(),
+            power=parse_int(field(5), 0),
+            participates=participate == "" or parse_int(participate, 1) != 0,
+            addr=addr,
+        )
+
+    @property
+    def consumer_id(self) -> str:
+        """Stable id for the reporting battery: its MAC, else its socket."""
+        if self.meter_mac:
+            return self.meter_mac.lower()
+        return f"{self.addr[0]}:{self.addr[1]}"
+
+    @property
+    def in_inspection_mode(self) -> bool:
+        """Whether this is an unassigned / diagnostic reporter.
+
+        "A"/"B"/"C" are the physical phases and "D" is combined / whole-home
+        mode (newer Marstek firmware) — all four are valid, actively-steered
+        operating phases.  Anything else ("0", empty, a marker we have yet to
+        meet) counts as inspection, so a future value cannot be mistaken for a
+        real phase.
+        """
+        return self.phase not in STEERED_PHASES
 
 
 # ---------------------------------------------------------------------------
@@ -364,7 +427,7 @@ class CT002:
         self.debug_status = debug_status
         self.active_control = active_control
         self.before_send: (
-            Callable[[tuple, list, str], Awaitable[list[float] | None]] | None
+            Callable[[tuple, CT002Request, str], Awaitable[list[float] | None]] | None
         ) = None
         self.event_listener: Callable[[str, str, dict[str, Any]], None] | None = None
         self._device_id = device_id
@@ -429,12 +492,6 @@ class CT002:
             clock=clock,
             reset_fn=reset_fn,
         )
-
-    def _consumer_key(self, addr, fields):
-        battery_mac = fields[1] if len(fields) > 1 else ""
-        if battery_mac:
-            return battery_mac.lower()
-        return f"{addr[0]}:{addr[1]}"
 
     def _get_consumer(self, consumer_id: str) -> Consumer:
         consumer = self._consumers.get(consumer_id)
@@ -992,24 +1049,16 @@ class CT002:
         )
         return " | ".join(parts)
 
-    def _build_response_fields(self, request_fields, values):
+    def _build_response_fields(self, request: CT002Request, values):
         if not values or len(values) != 3:
             values = [0, 0, 0]
         phase_a, phase_b, phase_c = values
         measured_total_power = phase_a + phase_b + phase_c
-        meter_dev_type = request_fields[0] if len(request_fields) > 0 else "HMG-50"
-        meter_mac = request_fields[1] if len(request_fields) > 1 else ""
-        ct_type = self.ct_type
-        ct_mac = (
-            self.ct_mac
-            if self.ct_mac
-            else (request_fields[3] if len(request_fields) > 3 else "")
-        )
         response_fields = [
-            ct_type,
-            ct_mac,
-            meter_dev_type,
-            meter_mac,
+            self.ct_type,
+            self.ct_mac or request.ct_mac,
+            request.meter_dev_type,
+            request.meter_mac,
             str(round(phase_a)),
             str(round(phase_b)),
             str(round(phase_c)),
@@ -1073,12 +1122,9 @@ class CT002:
         # scoped to a phase-"D" requester: a per-phase target also sums into
         # that field, so an unscoped check would spuriously set the ABC count on
         # phase-A/B/C responses (where the battery ignores it anyway).
-        reported_phase = (
-            (request_fields[4] if len(request_fields) > 4 else "").strip().upper()
-        )
         abc = phase_values["ABC"]
         if self.active_control:
-            if abc["active"] or (reported_phase == "D" and measured_total_power != 0):
+            if abc["active"] or (request.phase == "D" and measured_total_power != 0):
                 response_fields[11] = "1"
         else:
             response_fields[11] = str(abc["count"])
@@ -1089,7 +1135,7 @@ class CT002:
         self._info_idx_counter = (self._info_idx_counter + 1) % 256
         return response_fields
 
-    async def _call_before_send(self, addr, fields, consumer_id):
+    async def _call_before_send(self, request: CT002Request):
         """Invoke the ``before_send`` powermeter hook.
 
         Returns ``(result, failed)``.  ``failed`` is ``True`` only when the
@@ -1101,7 +1147,7 @@ class CT002:
         if not self.before_send:
             return None, False
         try:
-            result = await self.before_send(addr, fields, consumer_id)
+            result = await self.before_send(request.addr, request, request.consumer_id)
         except Exception as exc:
             # Rate-limit: log loudly on the first failure after a
             # healthy spell, then at most once every 30 s while the
@@ -1123,7 +1169,7 @@ class CT002:
                     "batteries hold their current output until the "
                     "powermeter recovers.",
                     self._before_send_failure_count,
-                    addr,
+                    request.addr,
                     exc,
                     exc_info=debug_traceback(),
                 )
@@ -1139,15 +1185,11 @@ class CT002:
             self._before_send_last_warn = 0.0
         return result, False
 
-    def _validate_ct_mac(self, request_fields):
+    def _ct_mac_matches(self, request: CT002Request) -> bool:
+        """Whether *request* names the CT MAC we are configured to answer for."""
         if not self.ct_mac:
             return True
-        if len(request_fields) < 4:
-            return False
-        req_ct_mac = request_fields[3]
-        if not req_ct_mac:
-            return False
-        return req_ct_mac.lower() == self.ct_mac.lower()
+        return bool(request.ct_mac) and request.ct_mac.lower() == self.ct_mac.lower()
 
     async def _safe_handle_request(self, data, addr, transport):
         try:
@@ -1156,59 +1198,11 @@ class CT002:
             logger.exception("Error handling CT002 request from %s", addr)
 
     async def _handle_request(self, data, addr, transport):
-        logger.debug("CT002 request from %s: %s", addr, data.hex())
-        fields, error = parse_request(data)
-        if error:
-            logger.debug("Invalid CT002 request from %s: %s", addr, error)
+        request = self._decode_request(data, addr)
+        if request is None:
             return
-        if len(fields) < 4:
-            logger.debug("CT002 request from %s missing required fields", addr)
-            return
-        if not self._validate_ct_mac(fields):
-            logger.debug(
-                "Ignoring CT002 request from %s due to CT MAC mismatch (req=%s, cfg=%s)",
-                addr,
-                fields[3] if len(fields) > 3 else None,
-                self.ct_mac,
-            )
-            return
-        consumer_id = self._consumer_key(addr, fields)
-        reported_phase = (fields[4] if len(fields) > 4 else "").strip().upper()
-        reported_power = parse_int(fields[5] if len(fields) > 5 else 0)
-        # Optional 7th field: "participate" flag (newer senders, e.g. B2500).
-        # Absent/empty defaults to participating; an explicit 0 opts out of
-        # aggregation.
-        participate_raw = fields[6].strip() if len(fields) > 6 else ""
-        participates = participate_raw == "" or parse_int(participate_raw, 1) != 0
+        consumer_id = request.consumer_id
 
-        # Only an unassigned / diagnostic reporter is in inspection mode: "0",
-        # empty, or any other unexpected marker.  "A"/"B"/"C" are the physical
-        # phases and "D" is combined / whole-home mode (newer Marstek firmware)
-        # — all four are valid, actively-steered operating phases, so they are
-        # NOT inspection.  Accept any other value as inspection so a future
-        # marker doesn't get mistaken for a real phase.
-        in_inspection_mode = reported_phase not in STEERED_PHASES
-        if in_inspection_mode:
-            logger.debug(
-                "CT002 request from %s in inspection mode (phase=%r)",
-                addr,
-                reported_phase,
-            )
-
-        logger.debug(
-            "CT002 parsed fields from %s: meter_dev_type=%s meter_mac=%s ct_type=%s ct_mac=%s phase=%r power=%s consumer_id=%s%s",
-            addr,
-            fields[0] if len(fields) > 0 else None,
-            fields[1] if len(fields) > 1 else None,
-            fields[2] if len(fields) > 2 else None,
-            fields[3] if len(fields) > 3 else None,
-            reported_phase,
-            reported_power,
-            consumer_id,
-            " in inspection mode" if in_inspection_mode else "",
-        )
-
-        meter_dev_type = fields[0] if len(fields) > 0 else ""
         # Record the report for *every* poll, before the dedupe decision: the
         # window suppresses our reply, it does not mean the battery went quiet.
         # Booking it here keeps `poll_interval` measuring the battery's real
@@ -1222,27 +1216,81 @@ class CT002:
         # inspection and combined reporters into phase A (issue #460).
         self._update_consumer_report(
             consumer_id,
-            phase=reported_phase,
-            power=reported_power,
-            device_type=meter_dev_type,
+            phase=request.phase,
+            power=request.power,
+            device_type=request.meter_dev_type,
             source_ip=str(addr[0]),
-            participates=participates,
+            participates=request.participates,
         )
 
+        if not self._should_serve(request):
+            return
+
+        self._inflight_consumers.add(consumer_id)
+        try:
+            await self._serve(request, transport)
+        finally:
+            self._inflight_consumers.discard(consumer_id)
+
+    def _decode_request(self, data, addr) -> CT002Request | None:
+        """Decode one datagram, or ``None`` when it is not ours to answer."""
+        logger.debug("CT002 request from %s: %s", addr, data.hex())
+        fields, error = parse_request(data)
+        if error:
+            logger.debug("Invalid CT002 request from %s: %s", addr, error)
+            return None
+        if len(fields) < 4:
+            logger.debug("CT002 request from %s missing required fields", addr)
+            return None
+
+        request = CT002Request.from_fields(fields, addr)
+        if not self._ct_mac_matches(request):
+            logger.debug(
+                "Ignoring CT002 request from %s due to CT MAC mismatch (req=%s, cfg=%s)",
+                addr,
+                request.ct_mac,
+                self.ct_mac,
+            )
+            return None
+
+        if request.in_inspection_mode:
+            logger.debug(
+                "CT002 request from %s in inspection mode (phase=%r)",
+                addr,
+                request.phase,
+            )
+        logger.debug(
+            "CT002 parsed fields from %s: meter_dev_type=%s meter_mac=%s ct_type=%s "
+            "ct_mac=%s phase=%r power=%s consumer_id=%s%s",
+            addr,
+            request.meter_dev_type,
+            request.meter_mac,
+            request.ct_type,
+            request.ct_mac,
+            request.phase,
+            request.power,
+            request.consumer_id,
+            " in inspection mode" if request.in_inspection_mode else "",
+        )
+        return request
+
+    def _should_serve(self, request: CT002Request) -> bool:
+        """Whether this poll earns a reply, or is a duplicate we drop."""
+        consumer_id = request.consumer_id
         # Deduplication check (keyed by consumer id so repeats from the
         # same battery are suppressed regardless of source UDP port).
         if not self._dedup.should_process(consumer_id):
             logger.debug(
                 "Ignoring request from %s (consumer=%s) due to dedupe window",
-                addr,
+                request.addr,
                 consumer_id,
             )
-            # The report above moved liveness and poll_interval on, and this
+            # The report already moved liveness and poll_interval on, and this
             # path never reaches the increment at the end of a served poll.
             # Without this a status client that skips unchanged revisions
             # would show a deduped battery frozen at its last answered poll.
             self._rev += 1
-            return
+            return False
 
         # Coalesce concurrent polls from the same battery.  If a handler for
         # this consumer is already parked awaiting the next meter reading, the
@@ -1251,203 +1299,204 @@ class CT002:
         # multiple deltas on the wire milliseconds apart the moment the meter
         # updates and wakes every parked handler, winding the battery up by N
         # times the intended correction and stepping the stateful balancer N
-        # times per real sample.  Drop it; the report update above already
-        # refreshed the per-consumer state, and the in-flight handler emits the
-        # one response.
+        # times per real sample.  Drop it; the report update already refreshed
+        # the per-consumer state, and the in-flight handler emits the one
+        # response.
         if consumer_id in self._inflight_consumers:
             logger.debug(
                 "Coalescing CT002 poll from %s (consumer=%s): a handler is "
                 "already awaiting the next meter reading; dropping this "
                 "duplicate to avoid a burst of deltas",
-                addr,
+                request.addr,
                 consumer_id,
             )
-            return
-        self._inflight_consumers.add(consumer_id)
+            return False
+        return True
+
+    async def _serve(self, request: CT002Request, transport) -> None:
+        """Read the meter, answer the poll, and publish what we served."""
+        consumer_id = request.consumer_id
+        updated, meter_failed = await self._call_before_send(request)
+        if updated is not None:
+            self.set_consumer_value(consumer_id, updated)
+
+        raw_values, values, meter_failed = self._resolve_target(request, meter_failed)
+        if not request.in_inspection_mode:
+            self._record_instructed_power(request, values)
+
         try:
-            updated, meter_failed = await self._call_before_send(
-                addr, fields, consumer_id
+            response_fields = self._build_response_fields(request, values)
+            response = build_payload(response_fields)
+        except Exception as exc:
+            logger.warning(
+                "Failed to build CT002 response for %s (%s): %s",
+                request.addr,
+                request,
+                exc,
+                exc_info=True,
             )
-            if updated is not None:
-                self.set_consumer_value(consumer_id, updated)
-
-            if meter_failed:
-                # Powermeter unavailable: do NOT re-drive control from the stale
-                # cached reading.  The CT002 instruction is a delta
-                # (``new_target = current_power + grid_field``), so re-issuing a
-                # delta derived from a frozen reading winds the battery up in
-                # active control, and feeds frozen per-phase values into a phase
-                # self-diagnosis in inspection mode (issue #403).  Send a zero
-                # adjustment instead so each battery holds its current output —
-                # matching the ESPHome component, which uses ``[0, 0, 0]`` when
-                # its sensor ages out (see esphome/components/ct002/ct002.cpp).
-                values = [0, 0, 0]
-            else:
-                values = self._get_consumer_value(consumer_id)
-                if values is None:
-                    values = [0, 0, 0]
-                elif not _values_finite(values):
-                    # A non-finite reading (NaN/Inf from a flaky source or a
-                    # filter chain fed one) is a meter failure, not a sample.
-                    # One NaN fed into the stateful controller poisons the
-                    # grid-state predictor permanently: every later innovation
-                    # is NaN, so no fresh meter sample can ever correct the
-                    # estimate, and each battery ends up pinned at the
-                    # ramp-pacing base step until restart (issue #548). Take
-                    # the same hold path as an unavailable meter.
-                    meter_failed = True
-                    values = [0, 0, 0]
-            raw_values = ([*list(values), 0, 0, 0])[:3]
-            meter_value = sum(parse_int(v, 0) for v in raw_values)
-            is_active = self.is_consumer_active(consumer_id)
-            # On a meter failure the ``[0, 0, 0]`` above is a *sentinel*, not a
-            # real reading: run active control only when the meter is healthy.
-            # Feeding the sentinel through the balancer would let the stateful
-            # controller (the grid-state predictor, saturation EMA, ...) treat a
-            # fabricated zero grid as a fresh sample and emit a non-zero delta
-            # from its internal state — exactly the wind-up issue #403 guards
-            # against — so the battery must instead hold on the literal zero
-            # adjustment.
-            if self.active_control and not in_inspection_mode and not meter_failed:
-                values = self._compute_smooth_target(values, consumer_id)
-            values = ([*list(values), 0, 0, 0])[:3]
-
-            # Record the *net* power we expect this battery to be at after
-            # applying the instruction (its reported output plus the delta we
-            # deliver — the battery's firmware computes
-            # ``new_target = current_power + grid_reading_field``).  In active
-            # control the cross-talk *_chrg_power / *_dchrg_power fields convey
-            # this net power per phase so other batteries can see who is actively
-            # charging/discharging cells; storing only the delta would lose
-            # the steady-state signal and flip signs on small corrections
-            # (issue #376).  In relay mode the buckets forward the *reported*
-            # power instead, like the real CT (issue #457) — this value is then
-            # only a diagnostic.  Skip during inspection mode: there is no
-            # instruction to record (we send raw meter readings as information,
-            # not a target; the battery is running its phase-discovery routine,
-            # not our integral controller); its reported power is aggregated
-            # into the x bucket from ``consumer.power`` instead.
-            if not in_inspection_mode:
-                consumer = self._get_consumer(consumer_id)
-                if consumer.phase.upper() == "D":
-                    # Combined / whole-home mode: the battery reads the summed
-                    # grid field (field 7 == sum of the per-phase values), so its
-                    # net is the reported power plus the whole target, not a
-                    # single phase.
-                    delta = sum(values)
-                else:
-                    delta = values[phase_index(consumer.phase)]
-                consumer.last_instructed_power = float(reported_power + delta)
-
-            try:
-                response_fields = self._build_response_fields(fields, values)
-                response = build_payload(response_fields)
-            except Exception as exc:
-                logger.warning(
-                    "Failed to build CT002 response for %s (%s): %s",
-                    addr,
-                    fields,
-                    exc,
-                    exc_info=True,
-                )
-                return
-            logger.debug(
-                "CT002 response to %s: %s (fields=%s)",
-                addr,
-                response.hex(),
-                response_fields,
-            )
-            if self.debug_status:
-                phase_values = self._collect_reports_by_phase()
-                logger.info(
-                    "CT002 status: %s",
-                    self._format_status(values, phase_values, consumer_id, meter_value),
-                )
-            transport.sendto(response, addr)
-            self._track_answer(consumer_id)
-
-            # Record what we just served for the read-only status surface.
-            # This is the one point where the raw meter reading, the emitted
-            # target and the meter-health verdict are all in scope, so the
-            # dashboard cannot observe a half-updated combination.
-            self._last_grid_values = [float(v) for v in raw_values]
-            self._last_grid_at = self._clock()
-            self._last_meter_failed = meter_failed
-            self._last_target_by_consumer[consumer_id] = [float(v) for v in values]
-            self._rev += 1
-
-            # Fire event listener after response is sent
-            if not in_inspection_mode:
-                consumer = self._consumers.get(consumer_id)
-                quality = self._balancer.control_quality()
-                self._call_event_listener(
+            return
+        logger.debug(
+            "CT002 response to %s: %s (fields=%s)",
+            request.addr,
+            response.hex(),
+            response_fields,
+        )
+        if self.debug_status:
+            logger.info(
+                "CT002 status: %s",
+                self._format_status(
+                    values,
+                    self._collect_reports_by_phase(),
                     consumer_id,
-                    {
-                        "grid_power": {
-                            "l1": float(raw_values[0]),
-                            "l2": float(raw_values[1]),
-                            "l3": float(raw_values[2]),
-                            "total": sum(float(v) for v in raw_values),
-                        },
-                        "target": {
-                            "l1": float(values[0]),
-                            "l2": float(values[1]),
-                            "l3": float(values[2]),
-                        },
-                        "phase": consumer.phase if consumer else reported_phase,
-                        "reported_power": reported_power,
-                        "device_type": consumer.device_type if consumer else "",
-                        "battery_ip": addr[0],
-                        "ct_type": fields[2] if len(fields) > 2 else "",
-                        "ct_mac": fields[3] if len(fields) > 3 else "",
-                        "saturation": self._balancer.get_saturation(consumer_id),
-                        "last_target": self._balancer.get_last_target(consumer_id),
-                        "active": is_active,
-                        "poll_interval": consumer.poll_interval if consumer else None,
-                        "answer_interval": (
-                            consumer.answer_interval if consumer else None
-                        ),
-                        "last_seen": datetime.now(timezone.utc).isoformat(),
-                        "smooth_target": self._last_smooth_target,
-                        "manual_target": consumer.manual_target if consumer else None,
-                        "auto_target": (
-                            not consumer.manual_enabled if consumer else True
-                        ),
-                        "distribution_weight": (
-                            consumer.distribution_weight if consumer else 1.0
-                        ),
-                        "efficiency_window_weight": (
-                            consumer.efficiency_window_weight if consumer else 1.0
-                        ),
-                        "min_dc_output": consumer.min_dc_output if consumer else None,
-                        "active_control": self.active_control,
-                        "efficiency_rotation": (
-                            self._balancer.efficiency_rotation_enabled
-                        ),
-                        "consumer_count": sum(
-                            1 for c in self._consumers.values() if c.timestamp > 0
-                        ),
-                        "control_quality": quality.verdict,
-                        # None until the window says something; published as
-                        # JSON null so the HA sensor reads "unknown" rather
-                        # than a flawless 100 it has no evidence for.
-                        "control_quality_score": (
-                            round(quality.score, 1)
-                            if quality.score is not None
-                            else None
-                        ),
-                        # The evidence behind the verdict.  It deliberately
-                        # names no cause, so whatever reads the verdict needs
-                        # these to act on it — MQTT clients included, not just
-                        # the dashboard.  Null until at least one sample has
-                        # been folded in: the EMAs read as a perfectly held
-                        # grid before that, and a 0 W mean error next to an
-                        # "idle" verdict is a lie a graph would record.
-                        **_control_quality_evidence(quality),
-                    },
-                )
-        finally:
-            self._inflight_consumers.discard(consumer_id)
+                    sum(parse_int(v, 0) for v in raw_values),
+                ),
+            )
+        transport.sendto(response, request.addr)
+        self._track_answer(consumer_id)
+
+        # Record what we just served for the read-only status surface.  This is
+        # the one point where the raw meter reading, the emitted target and the
+        # meter-health verdict are all in scope, so the dashboard cannot observe
+        # a half-updated combination.
+        self._last_grid_values = [float(v) for v in raw_values]
+        self._last_grid_at = self._clock()
+        self._last_meter_failed = meter_failed
+        self._last_target_by_consumer[consumer_id] = [float(v) for v in values]
+        self._rev += 1
+
+        if not request.in_inspection_mode:
+            self._call_event_listener(
+                consumer_id, self._consumer_event(request, raw_values, values)
+            )
+
+    def _resolve_target(
+        self, request: CT002Request, meter_failed: bool
+    ) -> tuple[list, list, bool]:
+        """The raw meter reading, the per-phase target, and the meter verdict.
+
+        On a meter failure the target is a literal ``[0, 0, 0]`` *hold*, not a
+        reading: the CT002 instruction is a delta
+        (``new_target = current_power + grid_field``), so re-issuing one derived
+        from a frozen reading winds the battery up in active control, and feeds
+        frozen per-phase values into a phase self-diagnosis in inspection mode
+        (issue #403).  The ESPHome component does the same when its sensor ages
+        out (see esphome/components/ct002/ct002.cpp).
+        """
+        if meter_failed:
+            values: list = [0, 0, 0]
+        else:
+            values = self._get_consumer_value(request.consumer_id)
+            if values is None:
+                values = [0, 0, 0]
+            elif not _values_finite(values):
+                # A non-finite reading (NaN/Inf from a flaky source or a filter
+                # chain fed one) is a meter failure, not a sample.  One NaN fed
+                # into the stateful controller poisons the grid-state predictor
+                # permanently: every later innovation is NaN, so no fresh meter
+                # sample can ever correct the estimate, and each battery ends up
+                # pinned at the ramp-pacing base step until restart (issue #548).
+                # Take the same hold path as an unavailable meter.
+                meter_failed = True
+                values = [0, 0, 0]
+
+        raw_values = three_phases(values)
+        # The hold above is a *sentinel*, not a real reading, so active control
+        # runs only when the meter is healthy.  Feeding the sentinel through the
+        # balancer would let the stateful controller (the grid-state predictor,
+        # saturation EMA, ...) treat a fabricated zero grid as a fresh sample
+        # and emit a non-zero delta from its internal state — exactly the
+        # wind-up issue #403 guards against — so the battery must instead hold
+        # on the literal zero adjustment.
+        if self.active_control and not request.in_inspection_mode and not meter_failed:
+            values = self._compute_smooth_target(values, request.consumer_id)
+        return raw_values, three_phases(values), meter_failed
+
+    def _record_instructed_power(self, request: CT002Request, values: list) -> None:
+        """Book the net power we expect this battery to reach.
+
+        Its reported output plus the delta we deliver — the firmware computes
+        ``new_target = current_power + grid_reading_field``.  In active control
+        the cross-talk ``*_chrg_power`` / ``*_dchrg_power`` fields convey this
+        net power per phase so other batteries can see who is actively
+        charging/discharging cells; storing only the delta would lose the
+        steady-state signal and flip signs on small corrections (issue #376).
+        In relay mode the buckets forward the *reported* power instead, like the
+        real CT (issue #457), and this value is then only a diagnostic.
+
+        Inspection mode has nothing to record — we send raw meter readings as
+        information, not a target, and the battery's reported power reaches the
+        x bucket from ``consumer.power`` instead — so callers skip it there.
+        """
+        consumer = self._get_consumer(request.consumer_id)
+        if consumer.phase.upper() == "D":
+            # Combined / whole-home mode: the battery reads the summed grid
+            # field (field 7 == sum of the per-phase values), so its net is the
+            # reported power plus the whole target, not a single phase.
+            delta = sum(values)
+        else:
+            delta = values[phase_index(consumer.phase)]
+        consumer.last_instructed_power = float(request.power + delta)
+
+    def _consumer_event(
+        self, request: CT002Request, raw_values: list, values: list
+    ) -> dict[str, Any]:
+        """The per-consumer payload MQTT and the dashboard subscribe to."""
+        consumer_id = request.consumer_id
+        consumer = self._consumers.get(consumer_id)
+        quality = self._balancer.control_quality()
+        return {
+            "grid_power": {
+                "l1": float(raw_values[0]),
+                "l2": float(raw_values[1]),
+                "l3": float(raw_values[2]),
+                "total": sum(float(v) for v in raw_values),
+            },
+            "target": {
+                "l1": float(values[0]),
+                "l2": float(values[1]),
+                "l3": float(values[2]),
+            },
+            "phase": consumer.phase if consumer else request.phase,
+            "reported_power": request.power,
+            "device_type": consumer.device_type if consumer else "",
+            "battery_ip": request.addr[0],
+            "ct_type": request.ct_type,
+            "ct_mac": request.ct_mac,
+            "saturation": self._balancer.get_saturation(consumer_id),
+            "last_target": self._balancer.get_last_target(consumer_id),
+            "active": self.is_consumer_active(consumer_id),
+            "poll_interval": consumer.poll_interval if consumer else None,
+            "answer_interval": consumer.answer_interval if consumer else None,
+            "last_seen": datetime.now(timezone.utc).isoformat(),
+            "smooth_target": self._last_smooth_target,
+            "manual_target": consumer.manual_target if consumer else None,
+            "auto_target": not consumer.manual_enabled if consumer else True,
+            "distribution_weight": consumer.distribution_weight if consumer else 1.0,
+            "efficiency_window_weight": (
+                consumer.efficiency_window_weight if consumer else 1.0
+            ),
+            "min_dc_output": consumer.min_dc_output if consumer else None,
+            "active_control": self.active_control,
+            "efficiency_rotation": self._balancer.efficiency_rotation_enabled,
+            "consumer_count": sum(
+                1 for c in self._consumers.values() if c.timestamp > 0
+            ),
+            "control_quality": quality.verdict,
+            # None until the window says something; published as JSON null so
+            # the HA sensor reads "unknown" rather than a flawless 100 it has
+            # no evidence for.
+            "control_quality_score": (
+                round(quality.score, 1) if quality.score is not None else None
+            ),
+            # The evidence behind the verdict.  It deliberately names no cause,
+            # so whatever reads the verdict needs these to act on it — MQTT
+            # clients included, not just the dashboard.  Null until at least one
+            # sample has been folded in: the EMAs read as a perfectly held grid
+            # before that, and a 0 W mean error next to an "idle" verdict is a
+            # lie a graph would record.
+            **_control_quality_evidence(quality),
+        }
 
     async def _cleanup_loop(self):
         try:

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -1518,6 +1518,9 @@ class CT002:
 
     async def start(self):
         self._server = await UdpServer.serve(self.udp_port, self._safe_handle_request)
+        # Read the bound port back: a configured 0 asks the OS to pick one, and
+        # the log line and status document below would otherwise both say "0".
+        self.udp_port = self._server.port or self.udp_port
         self._stopped.clear()
         self._cleanup_task = asyncio.create_task(self._cleanup_loop())
         self._started_at = self._clock()

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -19,6 +19,7 @@ from .balancer import (
     BalancerConsumerSnapshot,
     BalancerSnapshot,
     ConsumerMode,
+    ConsumerReport,
     LoadBalancer,
     _needs_dc_output_floor,
     device_capabilities,
@@ -722,14 +723,14 @@ class CT002:
         mode = self._consumer_mode(consumer_id)
 
         reports = {
-            cid: {
-                "phase": c.phase,
-                "power": c.power,
-                "device_type": c.device_type,
-                "weight": c.distribution_weight,
-                "efficiency_window_weight": c.efficiency_window_weight,
-                "min_dc_output": c.min_dc_output,
-            }
+            cid: ConsumerReport(
+                phase=c.phase,
+                power=c.power,
+                device_type=c.device_type,
+                weight=c.distribution_weight,
+                efficiency_window_weight=c.efficiency_window_weight,
+                min_dc_output=c.min_dc_output,
+            )
             for cid, c in self._consumers.items()
             if c.timestamp > 0
         }

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -49,6 +49,7 @@ __all__ = [
     "SOH",
     "STX",
     "UDP_PORT",
+    "PhaseBucket",
     "ReportingConsumerRow",
     "ReportingPhase",
     "build_payload",
@@ -301,6 +302,34 @@ class ConsumerOverride:
 ReportingPhase = Literal["a", "b", "c", "d", "0"]
 
 
+@dataclasses.dataclass
+class PhaseBucket:
+    """What one cross-talk bucket aggregates over the batteries reporting into it.
+
+    ``chrg_power`` is never positive and ``dchrg_power`` never negative — the
+    same sign split the UDP response carries.  ``count`` includes every battery
+    in the bucket, idle ones too, because relay mode forwards it as the divisor
+    each battery takes its 1/N share by; ``active`` says whether any of them is
+    actually moving power.
+    """
+
+    chrg_power: int = 0
+    dchrg_power: int = 0
+    count: int = 0
+    active: bool = False
+
+    def add(self, power: int) -> None:
+        """Fold one battery's net power into the bucket."""
+        self.count += 1
+        if power == 0:
+            return
+        self.active = True
+        if power < 0:
+            self.chrg_power += power
+        else:
+            self.dchrg_power += power
+
+
 @dataclasses.dataclass(frozen=True, slots=True)
 class ReportingConsumerRow:
     """One UDP-reporting consumer, for integrations that need a stable device list."""
@@ -372,7 +401,7 @@ class CT002Snapshot:
     grid_sample_at: float | None
     meter_failed: bool
     consecutive_meter_failures: int
-    buckets: dict[str, dict[str, int | bool]]
+    buckets: dict[str, PhaseBucket]
     consumers: tuple[ConsumerSnapshot, ...]
     orphan_overrides: tuple[tuple[str, ConsumerOverride], ...]
     balancer: BalancerSnapshot
@@ -797,11 +826,8 @@ class CT002:
             sample_id,
         )
 
-    def _collect_reports_by_phase(self):
-        by_phase = {
-            bucket: {"chrg_power": 0, "dchrg_power": 0, "active": False, "count": 0}
-            for bucket in PHASE_BUCKETS
-        }
+    def _collect_reports_by_phase(self) -> dict[str, PhaseBucket]:
+        by_phase = {bucket: PhaseBucket() for bucket in PHASE_BUCKETS}
 
         now = self._clock()
         for consumer in self._consumers.values():
@@ -819,11 +845,6 @@ class CT002:
             if self._consumer_expired(consumer, now):
                 continue
             bucket = _bucket_for_phase(consumer.phase)
-            # Count every battery reporting into the bucket (regardless of its
-            # current power) so relay mode can forward the real per-phase
-            # battery count — each battery divides the forwarded aggregate by it
-            # to take its 1/N share.
-            by_phase[bucket]["count"] += 1
             if self.active_control and bucket in ("A", "B", "C", "ABC"):
                 # Active control: use the net AC power we *instructed* this
                 # consumer to be at (its reported output plus the delta in the
@@ -850,13 +871,7 @@ class CT002:
                 # never actively instructed, so their reported power is the only
                 # truthful signal in either mode.
                 power = consumer.power
-            if power == 0:
-                continue
-            by_phase[bucket]["active"] = True
-            if power < 0:
-                by_phase[bucket]["chrg_power"] += power
-            else:
-                by_phase[bucket]["dchrg_power"] += power
+            by_phase[bucket].add(power)
         return by_phase
 
     # ------------------------------------------------------------------
@@ -962,13 +977,11 @@ class CT002:
         """Number of consumers that have reported at least once over UDP."""
         return sum(1 for c in self._consumers.values() if c.timestamp > 0)
 
-    def reporting_phase_buckets(self) -> dict[str, dict[str, int | bool]]:
+    def reporting_phase_buckets(self) -> dict[str, PhaseBucket]:
         """Per-bucket charge/discharge power (W) and counts for integrations.
 
-        Keys are :data:`PHASE_BUCKETS` (``x``/``A``/``B``/``C``/``ABC``); each
-        value has ``chrg_power`` (≤0), ``dchrg_power`` (≥0), ``count`` and
-        ``active`` — the same sign-split the UDP response carries. Used by the
-        opt-in HTTP cloud reporter for its ``cz…cd`` / ``dz…dd`` fields.
+        Keyed by :data:`PHASE_BUCKETS` (``x``/``A``/``B``/``C``/``ABC``).  Used
+        by the opt-in HTTP cloud reporter for its ``cz…cd`` / ``dz…dd`` fields.
         """
         return self._collect_reports_by_phase()
 
@@ -1011,8 +1024,8 @@ class CT002:
         if meter_value is not None:
             parts.append(f"meter {meter_value}W")
         phases = " ".join(f"{p}:{int(v)}W" for p, v in zip("ABC", values, strict=False))
-        chrg = " ".join(f"{p}:{phase_values[p]['chrg_power']}" for p in PHASE_BUCKETS)
-        dchrg = " ".join(f"{p}:{phase_values[p]['dchrg_power']}" for p in PHASE_BUCKETS)
+        chrg = " ".join(f"{p}:{phase_values[p].chrg_power}" for p in PHASE_BUCKETS)
+        dchrg = " ".join(f"{p}:{phase_values[p].dchrg_power}" for p in PHASE_BUCKETS)
         consumers_with_reports = sorted(
             ((c.consumer_id, c) for c in self._consumers.values() if c.timestamp > 0),
             key=lambda x: x[0],
@@ -1082,19 +1095,19 @@ class CT002:
                 # a real count N would make every battery under-respond by a
                 # factor of N.  The issue #455 relay-count fix applies to the
                 # relay branch below only; don't generalize it here.
-                if pv["active"] or phase_power[idx] != 0:
+                if pv.active or phase_power[idx] != 0:
                     response_fields[8 + idx] = "1"
             else:
                 # Relay mode forwards the per-phase aggregate; report the real
                 # battery count so each battery takes its 1/N share.
-                response_fields[8 + idx] = str(pv["count"])
-            response_fields[15 + idx] = str(pv["chrg_power"])
-            response_fields[20 + idx] = str(pv["dchrg_power"])
+                response_fields[8 + idx] = str(pv.count)
+            response_fields[15 + idx] = str(pv.chrg_power)
+            response_fields[20 + idx] = str(pv.dchrg_power)
 
         # x (unassigned/inspection) bucket — chrg/dchrg only; the response
         # carries no x count field.
-        response_fields[14] = str(phase_values["x"]["chrg_power"])
-        response_fields[19] = str(phase_values["x"]["dchrg_power"])
+        response_fields[14] = str(phase_values["x"].chrg_power)
+        response_fields[19] = str(phase_values["x"].dchrg_power)
         # ABC (combined, phase "D") bucket.  A combined-mode battery reads the
         # summed grid field (field 7, ``measured_total_power``) and divides it
         # by this count.  Under active control we deliver a per-consumer target
@@ -1108,12 +1121,12 @@ class CT002:
         # phase-A/B/C responses (where the battery ignores it anyway).
         abc = phase_values["ABC"]
         if self.active_control:
-            if abc["active"] or (request.phase == "D" and measured_total_power != 0):
+            if abc.active or (request.phase == "D" and measured_total_power != 0):
                 response_fields[11] = "1"
         else:
-            response_fields[11] = str(abc["count"])
-        response_fields[18] = str(abc["chrg_power"])
-        response_fields[23] = str(abc["dchrg_power"])
+            response_fields[11] = str(abc.count)
+        response_fields[18] = str(abc.chrg_power)
+        response_fields[23] = str(abc.dchrg_power)
 
         response_fields += ["0"] * (len(RESPONSE_LABELS) - len(response_fields))
         self._info_idx_counter = (self._info_idx_counter + 1) % 256

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -7,7 +7,7 @@ import math
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from datetime import datetime, timezone
-from typing import Any, Literal, cast
+from typing import Any, Literal, NamedTuple, cast
 
 from astrameter.config.logger import debug_traceback, logger
 from astrameter.power_units import three_phases
@@ -300,6 +300,19 @@ class ConsumerOverride:
 # Lowercase phase label carried on reporting rows: the three physical phases,
 # ``d`` (combined / whole-home) and ``0`` (unassigned / inspection).
 ReportingPhase = Literal["a", "b", "c", "d", "0"]
+
+
+class _ServedTarget(NamedTuple):
+    """What one poll resolved to, before it goes on the wire."""
+
+    raw_values: list
+    """The meter reading as read, padded to [L1, L2, L3]."""
+
+    values: list
+    """The per-phase instruction to send — a hold of zeros on a meter failure."""
+
+    meter_failed: bool
+    """True when the reading is a hold sentinel rather than a sample."""
 
 
 @dataclasses.dataclass
@@ -1369,7 +1382,7 @@ class CT002:
 
     def _resolve_target(
         self, request: CT002Request, meter_failed: bool
-    ) -> tuple[list, list, bool]:
+    ) -> _ServedTarget:
         """The raw meter reading, the per-phase target, and the meter verdict.
 
         On a meter failure the target is a literal ``[0, 0, 0]`` *hold*, not a
@@ -1407,7 +1420,7 @@ class CT002:
         # on the literal zero adjustment.
         if self.active_control and not request.in_inspection_mode and not meter_failed:
             values = self._compute_smooth_target(values, request.consumer_id)
-        return raw_values, three_phases(values), meter_failed
+        return _ServedTarget(raw_values, three_phases(values), meter_failed)
 
     def _record_instructed_power(self, request: CT002Request, values: list) -> None:
         """Book the net power we expect this battery to reach.

--- a/src/astrameter/ct002/ct002_test.py
+++ b/src/astrameter/ct002/ct002_test.py
@@ -372,3 +372,19 @@ def test_values_finite_helper() -> None:
     assert _values_finite(["abc"]) is False
     assert _values_finite([None]) is False
     assert _values_finite([10**400]) is False  # float() raises OverflowError
+
+
+async def test_start_reports_the_port_the_os_assigned() -> None:
+    """``udp_port=0`` asks the OS for a free port; the CT must report the real one.
+
+    The log line and the status document both read ``self.udp_port``, so leaving
+    it at the configured 0 would tell an operator the emulator is listening on
+    port 0.
+    """
+    ct = CT002(udp_port=0)
+    await ct.start()
+    try:
+        assert ct.udp_port != 0
+        assert ct.status_snapshot().udp_port == ct.udp_port
+    finally:
+        await ct.stop()

--- a/src/astrameter/ct002/ct002_test.py
+++ b/src/astrameter/ct002/ct002_test.py
@@ -230,7 +230,7 @@ async def _gated_before_send(ct: CT002, gate: asyncio.Event) -> list[int]:
     returns a fixed grid reading.  Returns a one-element call counter list."""
     calls = [0]
 
-    async def before_send(_addr, _fields=None, _consumer_id=None):
+    async def before_send(_addr, _request=None, _consumer_id=None):
         calls[0] += 1
         await gate.wait()
         return [150.0, 0.0, 0.0]
@@ -334,7 +334,7 @@ async def test_non_finite_reading_holds_and_control_recovers(bad: float) -> None
     ct = CT002(ct_mac="", active_control=True, clock=clock)
     grid = [300.0]
 
-    async def before_send(_addr, _fields=None, _consumer_id=None):
+    async def before_send(_addr, _request=None, _consumer_id=None):
         return [grid[0], 0.0, 0.0]
 
     ct.before_send = before_send

--- a/src/astrameter/main.py
+++ b/src/astrameter/main.py
@@ -321,10 +321,10 @@ def _ct_measurement(
     buckets = device.reporting_phase_buckets()
 
     def charge(bucket: str) -> int:
-        return int(buckets.get(bucket, {}).get("chrg_power", 0))
+        return buckets[bucket].chrg_power
 
     def discharge(bucket: str) -> int:
-        return int(buckets.get(bucket, {}).get("dchrg_power", 0))
+        return buckets[bucket].dchrg_power
 
     return CtMeasurement(
         ap=ap,

--- a/src/astrameter/main.py
+++ b/src/astrameter/main.py
@@ -40,6 +40,7 @@ from astrameter.mqtt_insights import (
     normalize_mac,
     ver_v_from_marstek_api_version,
 )
+from astrameter.power_units import three_phases
 from astrameter.powermeter import Powermeter
 from astrameter.powermeter.wrappers.health import HealthTrackingPowermeter
 from astrameter.shelly import Shelly
@@ -59,12 +60,6 @@ def _powermeter_log_name(powermeter: Powermeter) -> str:
         else powermeter
     )
     return type(inner).__name__
-
-
-def _three_phases(values) -> list:
-    """Pad or trim a reading to the three phase values the CT protocol carries."""
-    phases = list(values)[:3]
-    return phases + [0.0] * (3 - len(phases))
 
 
 async def read_ct_powermeter(
@@ -97,7 +92,7 @@ async def read_ct_powermeter(
                 "serving last known value",
                 _powermeter_log_name(powermeter),
             )
-    return _three_phases(await powermeter.get_powermeter_watts())
+    return three_phases(await powermeter.get_powermeter_watts())
 
 
 async def _read_grid_phases(powermeters: list[ConfiguredPowermeter]) -> list[float]:
@@ -115,7 +110,7 @@ async def _read_grid_phases(powermeters: list[ConfiguredPowermeter]) -> list[flo
         await asyncio.wait_for(
             chosen.wait_for_next_message(), timeout=FRESH_READING_TIMEOUT_S
         )
-    return [float(v) for v in _three_phases(await chosen.get_powermeter_watts_raw())]
+    return [float(v) for v in three_phases(await chosen.get_powermeter_watts_raw())]
 
 
 async def check_powermeter(powermeter: Powermeter, client_filter: ClientFilter):
@@ -253,7 +248,7 @@ def _build_device(
             lambda: _reset_all_powermeters(powermeters),
         )
 
-        async def update_readings(addr, _fields=None, _consumer_id=None):
+        async def update_readings(addr, _request=None, _consumer_id=None):
             return await read_ct_powermeter(addr, powermeters)
 
         device.before_send = update_readings

--- a/src/astrameter/mqtt_insights/service.py
+++ b/src/astrameter/mqtt_insights/service.py
@@ -405,6 +405,73 @@ class MqttInsightsService:
             with contextlib.suppress(asyncio.QueueFull):
                 self._queue.put_nowait(evt)
 
+    def _client_args(self, tls_context: ssl.SSLContext | None) -> dict[str, Any]:
+        """Connection arguments shared by the service loop and the parting
+        "offline" publish, which reconnects after the loop has been cancelled."""
+        cfg = self._config
+        return {
+            "hostname": cfg.broker,
+            "port": cfg.port,
+            "username": cfg.username,
+            "password": cfg.password,
+            "tls_context": tls_context,
+        }
+
+    async def _announce(self, client: aiomqtt.Client) -> None:
+        """Publish presence and discovery, then subscribe, on every connect."""
+        cfg = self._config
+        # Clear discovery on (re)connect so we re-publish.
+        self._discovered.clear()
+        await client.publish(
+            system_status_topic(cfg.base_topic), payload=b"online", qos=1, retain=True
+        )
+
+        # Top-level "AstraMeter" hub device that the per-meter devices link up
+        # to via via_device. Uses ADDON_SLUG as the identifier on the HA add-on,
+        # falling back to a stable base-topic-derived id so the grouping also
+        # works in standalone/Docker. Republished on every reconnect.
+        if cfg.ha_discovery:
+            topic, payload = build_addon_device_discovery(
+                cfg.base_topic, self._hub_identifier(), cfg.ha_discovery_prefix
+            )
+            await _publish_json(client, topic, payload)
+            await self._publish_bridge(client, cfg)
+
+        await client.subscribe(consumer_command_filter(cfg.base_topic))
+        await client.subscribe(device_command_filter(cfg.base_topic))
+
+        # Store the client so register_marstek() called while already connected
+        # can live-subscribe, and so the dashboard write path has a connection
+        # to publish on — both need it whether or not Marstek MQTT is enabled.
+        # Then subscribe every registered binding's App topics.
+        async with self._marstek_lock:
+            self._client = client
+            if cfg.marstek_mqtt_enabled:
+                for binding in self._marstek_bindings.values():
+                    for topic in app_topics_for(binding):
+                        await client.subscribe(topic)
+
+    def _session_loops(self, client: aiomqtt.Client) -> list[Any]:
+        """The concurrent loops one connection runs until it drops."""
+        cfg = self._config
+        loops: list[Any] = [self._publish_loop(client), self._listen_commands(client)]
+        if cfg.marstek_mqtt_enabled and cfg.marstek_mqtt_interval > 0:
+            loops.append(self._marstek_broadcast_loop(client))
+        if self._powermeters and cfg.powermeter_health_interval > 0:
+            loops.append(self._powermeter_health_loop(client))
+        return loops
+
+    async def _serve_connection(self, client: aiomqtt.Client) -> None:
+        """Announce ourselves, then run the session loops until one ends."""
+        await self._announce(client)
+        self._connected.set()
+        try:
+            await asyncio.gather(*self._session_loops(client))
+        finally:
+            async with self._marstek_lock:
+                self._client = None
+            await self._cancel_marstek_tasks()
+
     async def _run(self) -> None:
         cfg = self._config
         tls_context = ssl.create_default_context() if cfg.tls else None
@@ -412,11 +479,7 @@ class MqttInsightsService:
         while True:
             try:
                 async with aiomqtt.Client(
-                    hostname=cfg.broker,
-                    port=cfg.port,
-                    username=cfg.username,
-                    password=cfg.password,
-                    tls_context=tls_context,
+                    **self._client_args(tls_context),
                     keepalive=60,
                     will=aiomqtt.Will(
                         topic=system_status_topic(cfg.base_topic),
@@ -428,68 +491,14 @@ class MqttInsightsService:
                     logger.info(
                         "MQTT Insights connected to %s:%s", cfg.broker, cfg.port
                     )
-                    # Clear discovery on (re)connect so we re-publish
-                    self._discovered.clear()
-
-                    await client.publish(
-                        system_status_topic(cfg.base_topic),
-                        payload=b"online",
-                        qos=1,
-                        retain=True,
-                    )
-
-                    # Top-level "AstraMeter" hub device that the per-meter
-                    # devices link up to via via_device. Uses ADDON_SLUG as the
-                    # identifier on the HA add-on, falling back to a stable
-                    # base-topic-derived id so the grouping also works in
-                    # standalone/Docker. Republished on every reconnect.
-                    if cfg.ha_discovery:
-                        topic, payload = build_addon_device_discovery(
-                            cfg.base_topic,
-                            self._hub_identifier(),
-                            cfg.ha_discovery_prefix,
-                        )
-                        await _publish_json(client, topic, payload)
-                        await self._publish_bridge(client, cfg)
-
-                    await client.subscribe(consumer_command_filter(cfg.base_topic))
-                    await client.subscribe(device_command_filter(cfg.base_topic))
-
-                    # Store the client so register_marstek() called while
-                    # already connected can live-subscribe, and so the
-                    # dashboard write path has a connection to publish on —
-                    # both need it whether or not Marstek MQTT is enabled.
-                    # Then subscribe every registered binding's App topics.
-                    async with self._marstek_lock:
-                        self._client = client
-                        if cfg.marstek_mqtt_enabled:
-                            for binding in self._marstek_bindings.values():
-                                for topic in app_topics_for(binding):
-                                    await client.subscribe(topic)
-
-                    self._connected.set()
-
-                    try:
-                        coros: list[Any] = [
-                            self._publish_loop(client),
-                            self._listen_commands(client),
-                        ]
-                        if cfg.marstek_mqtt_enabled and cfg.marstek_mqtt_interval > 0:
-                            coros.append(self._marstek_broadcast_loop(client))
-                        if self._powermeters and cfg.powermeter_health_interval > 0:
-                            coros.append(self._powermeter_health_loop(client))
-                        await asyncio.gather(*coros)
-                    finally:
-                        async with self._marstek_lock:
-                            self._client = None
-                        await self._cancel_marstek_tasks()
+                    await self._serve_connection(client)
 
             except asyncio.CancelledError:
                 self._connected.clear()
                 # Graceful shutdown: publish offline in a shielded scope
                 # so the pending cancellation doesn't abort the publish.
                 with contextlib.suppress(Exception):
-                    await asyncio.shield(self._publish_offline(cfg, tls_context))
+                    await asyncio.shield(self._publish_offline(tls_context))
                 raise
             except (aiomqtt.MqttError, OSError) as exc:
                 self._connected.clear()
@@ -545,18 +554,11 @@ class MqttInsightsService:
         }
         await _publish_json(client, bridge_topic(cfg.base_topic), payload)
 
-    async def _publish_offline(
-        self, cfg: MqttInsightsConfig, tls_context: ssl.SSLContext | None
-    ) -> None:
-        async with aiomqtt.Client(
-            hostname=cfg.broker,
-            port=cfg.port,
-            username=cfg.username,
-            password=cfg.password,
-            tls_context=tls_context,
-        ) as client:
+    async def _publish_offline(self, tls_context: ssl.SSLContext | None) -> None:
+        """Reconnect just long enough to retract the retained "online" status."""
+        async with aiomqtt.Client(**self._client_args(tls_context)) as client:
             await client.publish(
-                system_status_topic(cfg.base_topic),
+                system_status_topic(self._config.base_topic),
                 payload=b"offline",
                 qos=1,
                 retain=True,

--- a/src/astrameter/power_units.py
+++ b/src/astrameter/power_units.py
@@ -28,6 +28,12 @@ POWER_UNIT_SCALE = {
 POWER_UNITS = tuple(POWER_UNIT_SCALE)
 
 
+def three_phases(values) -> list:
+    """Pad or trim a reading to the three phase values the CT protocol carries."""
+    phases = list(values)[:3]
+    return phases + [0.0] * (3 - len(phases))
+
+
 def is_power_unit(unit: str | None) -> bool:
     """Whether a ``unit_of_measurement`` is one AstraMeter reads as power.
 

--- a/src/astrameter/shelly/shelly.py
+++ b/src/astrameter/shelly/shelly.py
@@ -13,6 +13,7 @@ from astrameter.config import ClientFilter
 from astrameter.config.logger import debug_traceback, logger
 from astrameter.powermeter import Powermeter
 from astrameter.request_dedupe import RequestDeduplicator
+from astrameter.udp_server import UdpServer
 
 BATTERY_INACTIVE_TIMEOUT_SECONDS = 120
 POLL_INTERVAL_EMA_ALPHA = 0.3
@@ -48,22 +49,6 @@ class ShellySnapshot:
     batteries: tuple[ShellyBatterySnapshot, ...]
 
 
-class _ShellyProtocol(asyncio.DatagramProtocol):
-    def __init__(self, shelly: Shelly):
-        self.shelly = shelly
-        self._tasks: set[asyncio.Task] = set()
-
-    def connection_made(self, transport):
-        self.transport = transport
-
-    def datagram_received(self, data, addr):
-        task = asyncio.create_task(
-            self.shelly._safe_handle_request(self.transport, data, addr)
-        )
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
-
-
 class Shelly:
     def __init__(
         self,
@@ -77,8 +62,7 @@ class Shelly:
         self._device_id = device_id
         self._device_type = device_type
         self._powermeters = powermeters
-        self._transport = None
-        self._protocol: _ShellyProtocol | None = None
+        self._server: UdpServer | None = None
         self._battery_last_seen: dict[str, float] = {}
         self._battery_poll_interval: dict[str, float] = {}
         self._inactive_batteries: set[str] = set()
@@ -232,7 +216,7 @@ class Shelly:
                 "event_listener failed for %s: %s", battery_ip, exc, exc_info=True
             )
 
-    async def _safe_handle_request(self, transport, data, addr):
+    async def _safe_handle_request(self, data, addr, transport):
         try:
             await self._handle_request(transport, data, addr)
         except Exception:
@@ -373,18 +357,10 @@ class Shelly:
             pass
 
     async def start(self):
-        loop = asyncio.get_running_loop()
-        transport, protocol = await loop.create_datagram_endpoint(
-            lambda: _ShellyProtocol(self),
-            local_addr=("0.0.0.0", self._udp_port),
-        )
-        self._transport = transport
-        self._protocol = protocol
+        self._server = await UdpServer.serve(self._udp_port, self._safe_handle_request)
         self._stopped.clear()
         self._inactive_check_task = asyncio.create_task(self._inactive_check_loop())
-        bound = self._transport.get_extra_info("sockname")
-        if bound:
-            self._udp_port = bound[1]
+        self._udp_port = self._server.port or self._udp_port
         self._started_at = time.time()
         self._running = True
         logger.info(f"Shelly emulator listening on UDP port {self._udp_port}...")
@@ -432,15 +408,8 @@ class Shelly:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._inactive_check_task
             self._inactive_check_task = None
-        # Close transport first to stop new datagrams from spawning tasks,
-        # then cancel and await any in-flight handler tasks.
-        if self._transport:
-            self._transport.close()
-            self._transport = None
-        if self._protocol:
-            for task in list(self._protocol._tasks):
-                task.cancel()
-            await asyncio.gather(*self._protocol._tasks, return_exceptions=True)
-        self._protocol = None
+        if self._server:
+            await self._server.close()
+            self._server = None
         self._running = False
         self._stopped.set()

--- a/src/astrameter/simulator/eval_harness.py
+++ b/src/astrameter/simulator/eval_harness.py
@@ -150,7 +150,7 @@ async def run_scenario(
     meter_read_at = [-math.inf]
     grid_history: list[tuple[float, dict[str, float]]] = []
 
-    async def before_send(_addr, _fields=None, _consumer_id=None):
+    async def before_send(_addr, _request=None, _consumer_id=None):
         now = clock() - _EPOCH
         # Draw the house load once; derive both the true grid and the raw
         # consumption from that same sample (get_grid_contribution re-draws

--- a/src/astrameter/simulator/eval_metrics.py
+++ b/src/astrameter/simulator/eval_metrics.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import itertools
 import math
 from collections.abc import Callable, Iterator, Sequence
+from typing import NamedTuple
 
 from .eval_spec import Scenario, _Sample
 
@@ -132,20 +133,28 @@ def _oracle_cost_ct(scenario: Scenario, samples: list[_Sample]) -> float:
     return _grid_cost_ct(import_wh, export_wh)
 
 
-def _compute_metrics(
-    scenario: Scenario,
-    seed: int,
-    samples: list[_Sample],
-    marks: list[tuple[float, str]],
-) -> dict:
-    duration_h = scenario.duration_s / 3600.0
-    specs = scenario.batteries
+class _EventResponse(NamedTuple):
+    """How the loop answered the labeled disturbances in a run."""
 
-    # Per-event settling & overshoot.
+    settle_times: list[float]
+    overshoots: list[float]
+    unsettled: int
+    measured: int
+
+
+def _event_response(
+    scenario: Scenario, samples: list[_Sample], marks: list[tuple[float, str]]
+) -> _EventResponse:
+    """Settling time and overshoot per labeled event.
+
+    Each event owns the window up to ``EVENT_WINDOW_S`` later, truncated by the
+    next event.  An event whose initial error is already inside the settling
+    band is skipped: there is no disturbance to measure a response against.
+    """
     settle_times: list[float] = []
     overshoots: list[float] = []
     unsettled = 0
-    events_measured = 0
+    measured = 0
     for idx, (t0, _label) in enumerate(marks):
         t_end = min(
             scenario.duration_s,
@@ -157,8 +166,8 @@ def _compute_metrics(
             continue
         e0 = window[0].grid
         if abs(e0) < SETTLE_BAND_W:
-            continue  # disturbance too small to measure against the band
-        events_measured += 1
+            continue
+        measured += 1
         sign = 1.0 if e0 > 0 else -1.0
         settle = _settle_time(samples, t0, t_end)
         if settle is None:
@@ -167,8 +176,15 @@ def _compute_metrics(
         else:
             settle_times.append(settle)
         overshoots.append(max(0.0, max(-sign * s.grid for s in window)))
+    return _EventResponse(settle_times, overshoots, unsettled, measured)
 
-    # Oscillation: hysteresis band crossings.
+
+def _band_crossings(samples: list[_Sample]) -> int:
+    """Times the grid swung clean through the deadband from one side to the other.
+
+    The band is the hysteresis: brushing it does not count, only reaching the
+    far side after having reached the near one.
+    """
     crossings = 0
     state = 0
     for s in samples:
@@ -180,35 +196,51 @@ def _compute_metrics(
             if state == 1:
                 crossings += 1
             state = -1
+    return crossings
 
-    # Steady-state RMS, outside post-event transients.
-    def in_transient(t: float) -> bool:
-        return any(t0 <= t < t0 + STEADY_EXCLUDE_S for t0, _ in marks)
 
-    steady = [s.grid for s in samples if not in_transient(s.t)]
-    steady_rms = math.sqrt(sum(g * g for g in steady) / len(steady)) if steady else 0.0
+def _steady_rms(samples: list[_Sample], marks: list[tuple[float, str]]) -> float:
+    """RMS grid error outside the post-event transients — hunting, not reaction."""
+    steady = [
+        s.grid
+        for s in samples
+        if not any(t0 <= s.t < t0 + STEADY_EXCLUDE_S for t0, _ in marks)
+    ]
+    return math.sqrt(sum(g * g for g in steady) / len(steady)) if steady else 0.0
 
-    # Sustained oscillation amplitude: the robust peak-to-peak swing (p95 - p5)
-    # over the whole run. Non-zero for any continuous hunting, which the
-    # step-response metrics (only fired by labeled steps) read as 0; percentiles
-    # keep a single brief transient from dominating.
-    all_grid = [s.grid for s in samples]
-    grid_p2p = _percentile(all_grid, 0.95) - _percentile(all_grid, 0.05)
 
-    # Time-weighted integrals (true time averages, not sample averages skewed by
-    # staggered polls): grid_rms is the whole-run L2 tracking error, transients
-    # included, whose effort partner is battery_travel; share_imbalance is the
-    # watts misallocated within each phase group of >=2 batteries (sum of
-    # |power_i - fair share|), 0 by construction with one battery per phase.
+class _Integrals(NamedTuple):
+    """True time averages, not sample averages skewed by staggered polls."""
+
+    grid_rms: float
+    mean_abs_grid: float
+    share_imbalance: float
+    battery_travel_w: float
+    import_wh: float
+    export_wh: float
+    avoidable_import_wh: float
+    avoidable_export_wh: float
+
+
+def _time_weighted(scenario: Scenario, samples: list[_Sample]) -> _Integrals:
+    """Integrate tracking error, share imbalance, effort and grid energy over time.
+
+    ``grid_rms`` is the whole-run L2 tracking error, transients included, whose
+    effort partner is ``battery_travel_w``.  ``share_imbalance`` is the watts
+    misallocated within each phase group of >=2 batteries (the sum of
+    ``|power_i - fair share|``), 0 by construction with one battery per phase.
+    Grid energy is split into what was exchanged and the part of it the pack
+    still had the headroom and the charge (or the room) to have covered.
+    """
+    specs = scenario.batteries
     phase_groups: dict[str, list[int]] = {}
-    for i, sp in enumerate(specs):
-        phase_groups.setdefault((sp.phase or "A").upper(), []).append(i)
+    for i, spec in enumerate(specs):
+        phase_groups.setdefault((spec.phase or "A").upper(), []).append(i)
     balance_groups = [grp for grp in phase_groups.values() if len(grp) >= 2]
 
     import_wh = export_wh = avoid_import_wh = avoid_export_wh = 0.0
     travel_w = 0.0
-    grid_sq_dt = abs_grid_dt = total_dt = 0.0
-    imbalance_dt = 0.0
+    grid_sq_dt = abs_grid_dt = total_dt = imbalance_dt = 0.0
     for prev, cur, dt in _intervals(samples):
         grid_sq_dt += prev.grid * prev.grid * dt
         abs_grid_dt += abs(prev.grid) * dt
@@ -240,54 +272,82 @@ def _compute_metrics(
                 avoid_export_wh += -wh
         travel_w += sum(abs(cur.powers[i] - prev.powers[i]) for i in range(len(specs)))
 
-    grid_rms = math.sqrt(grid_sq_dt / total_dt) if total_dt > 0 else 0.0
-    mean_abs = abs_grid_dt / total_dt if total_dt > 0 else 0.0
-    share_imbalance = imbalance_dt / total_dt if total_dt > 0 else 0.0
+    def per_second(total: float) -> float:
+        return total / total_dt if total_dt > 0 else 0.0
+
+    return _Integrals(
+        grid_rms=math.sqrt(per_second(grid_sq_dt)),
+        mean_abs_grid=per_second(abs_grid_dt),
+        share_imbalance=per_second(imbalance_dt),
+        battery_travel_w=travel_w,
+        import_wh=import_wh,
+        export_wh=export_wh,
+        avoidable_import_wh=avoid_import_wh,
+        avoidable_export_wh=avoid_export_wh,
+    )
+
+
+def _mean(values: Sequence[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _compute_metrics(
+    scenario: Scenario,
+    seed: int,
+    samples: list[_Sample],
+    marks: list[tuple[float, str]],
+) -> dict:
+    duration_h = scenario.duration_s / 3600.0
+    events = _event_response(scenario, samples, marks)
+    integrals = _time_weighted(scenario, samples)
+
+    # Sustained oscillation amplitude: the robust peak-to-peak swing (p95 - p5)
+    # over the whole run. Non-zero for any continuous hunting, which the
+    # step-response metrics (only fired by labeled steps) read as 0; percentiles
+    # keep a single brief transient from dominating.
+    all_grid = [s.grid for s in samples]
+    grid_p2p = _percentile(all_grid, 0.95) - _percentile(all_grid, 0.05)
 
     # Money: the bill for the residual grid minus the perfect-foresight bill.
     # The oracle is a true lower bound, so the clamp only absorbs the
     # per-phase-routing slack of the three-phase scenario.
-    grid_cost = _grid_cost_ct(import_wh, export_wh)
+    grid_cost = _grid_cost_ct(integrals.import_wh, integrals.export_wh)
     oracle_cost = _oracle_cost_ct(scenario, samples)
     cost_regret = max(0.0, grid_cost - oracle_cost)
 
     # SoC extremes let a scenario verify it drove the pack into saturation
     # (not in the metric tables; for tests and context).
     all_socs = [soc for s in samples for soc in s.socs]
-    soc_min = round(min(all_socs), 3) if all_socs else 0.0
-    soc_max = round(max(all_socs), 3) if all_socs else 0.0
 
     return {
         "scenario": scenario.name,
         "seed": seed,
         "duration_h": round(duration_h, 3),
         "samples": len(samples),
-        "soc_min": soc_min,
-        "soc_max": soc_max,
-        "events_measured": events_measured,
-        "unsettled_events": unsettled,
-        "settle_mean_s": round(sum(settle_times) / len(settle_times), 1)
-        if settle_times
+        "soc_min": round(min(all_socs), 3) if all_socs else 0.0,
+        "soc_max": round(max(all_socs), 3) if all_socs else 0.0,
+        "events_measured": events.measured,
+        "unsettled_events": events.unsettled,
+        "settle_mean_s": round(_mean(events.settle_times), 1),
+        "settle_p95_s": round(_percentile(events.settle_times, 0.95), 1),
+        "overshoot_mean_w": round(_mean(events.overshoots), 1),
+        "overshoot_max_w": round(max(events.overshoots), 1)
+        if events.overshoots
         else 0.0,
-        "settle_p95_s": round(_percentile(settle_times, 0.95), 1),
-        "overshoot_mean_w": round(sum(overshoots) / len(overshoots), 1)
-        if overshoots
-        else 0.0,
-        "overshoot_max_w": round(max(overshoots), 1) if overshoots else 0.0,
-        "band_crossings_per_h": round(crossings / duration_h, 2),
+        "band_crossings_per_h": round(_band_crossings(samples) / duration_h, 2),
         "grid_p2p_w": round(grid_p2p, 1),
-        "grid_rms_w": round(grid_rms, 1),
-        "steady_rms_w": round(steady_rms, 1),
-        "mean_abs_grid_w": round(mean_abs, 1),
-        "share_imbalance_w": round(share_imbalance, 1),
-        "import_wh": round(import_wh, 1),
-        "export_wh": round(export_wh, 1),
-        "avoidable_import_wh": round(avoid_import_wh, 1),
-        "avoidable_export_wh": round(avoid_export_wh, 1),
+        "grid_rms_w": round(integrals.grid_rms, 1),
+        "steady_rms_w": round(_steady_rms(samples, marks), 1),
+        "mean_abs_grid_w": round(integrals.mean_abs_grid, 1),
+        "share_imbalance_w": round(integrals.share_imbalance, 1),
+        "import_wh": round(integrals.import_wh, 1),
+        "export_wh": round(integrals.export_wh, 1),
+        "avoidable_import_wh": round(integrals.avoidable_import_wh, 1),
+        "avoidable_export_wh": round(integrals.avoidable_export_wh, 1),
         "grid_cost_ct": round(grid_cost, 2),
         "oracle_cost_ct": round(oracle_cost, 2),
         "cost_regret_ct": round(cost_regret, 2),
-        "battery_travel_w_per_h": round(travel_w / duration_h, 0),
+        "battery_travel_w_per_h": round(integrals.battery_travel_w / duration_h, 0),
     }
 
 

--- a/src/astrameter/status/serialize.py
+++ b/src/astrameter/status/serialize.py
@@ -314,10 +314,10 @@ def ct002_to_wire(device) -> dict[str, Any]:
             "buckets": {
                 name: compact(
                     {
-                        "chrg_w": bucket.get("chrg_power"),
-                        "dchrg_w": bucket.get("dchrg_power"),
-                        "count": bucket.get("count"),
-                        "active": bucket.get("active"),
+                        "chrg_w": bucket.chrg_power,
+                        "dchrg_w": bucket.dchrg_power,
+                        "count": bucket.count,
+                        "active": bucket.active,
                     }
                 )
                 for name, bucket in device.buckets.items()

--- a/src/astrameter/udp_server.py
+++ b/src/astrameter/udp_server.py
@@ -1,0 +1,76 @@
+"""A bound UDP socket that answers each datagram in its own task.
+
+Both emulators — the CT002 responder and the Shelly one — serve a request by
+awaiting a meter read, so a handler cannot run inline on the event loop's
+datagram callback without stalling every other battery behind the slowest one.
+Each datagram therefore gets a task, and shutdown has to cancel whatever is
+still parked mid-poll.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+Handler = Callable[[bytes, tuple, asyncio.DatagramTransport], Coroutine[Any, Any, None]]
+
+
+class _HandlerProtocol(asyncio.DatagramProtocol):
+    def __init__(self, handler: Handler) -> None:
+        self._handler = handler
+        self._transport: asyncio.DatagramTransport | None = None
+        # asyncio keeps only a weak reference to a running task, so a handler
+        # nobody holds can be collected mid-poll; the set is that reference.
+        self._tasks: set[asyncio.Task] = set()
+
+    def connection_made(self, transport) -> None:
+        self._transport = transport
+
+    def datagram_received(self, data: bytes, addr: tuple) -> None:
+        assert self._transport is not None
+        task: asyncio.Task = asyncio.create_task(
+            self._handler(data, addr, self._transport)
+        )
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def drain(self) -> None:
+        for task in list(self._tasks):
+            task.cancel()
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+
+
+class UdpServer:
+    """A listening UDP socket, bound by :meth:`serve` and closed by :meth:`close`."""
+
+    def __init__(
+        self, transport: asyncio.DatagramTransport, protocol: _HandlerProtocol
+    ) -> None:
+        self._transport = transport
+        self._protocol = protocol
+
+    @classmethod
+    async def serve(cls, port: int, handler: Handler) -> UdpServer:
+        """Bind *port* on every interface and route datagrams to *handler*."""
+        loop = asyncio.get_running_loop()
+        transport, protocol = await loop.create_datagram_endpoint(
+            lambda: _HandlerProtocol(handler),
+            local_addr=("0.0.0.0", port),
+        )
+        return cls(transport, protocol)
+
+    @property
+    def port(self) -> int:
+        """The port actually bound — the real one when 0 asked for any free port."""
+        sockname = self._transport.get_extra_info("sockname")
+        return int(sockname[1]) if sockname else 0
+
+    async def close(self) -> None:
+        """Stop listening, then cancel and await every in-flight handler.
+
+        Closing the transport first stops new datagrams from spawning tasks, so
+        the drain below cannot race a fresh arrival.
+        """
+        self._transport.close()
+        await self._protocol.drain()

--- a/tests/components/ct002/test_balancer_parity.py
+++ b/tests/components/ct002/test_balancer_parity.py
@@ -22,7 +22,12 @@ from pathlib import Path
 
 import pytest
 
-from astrameter.ct002.balancer import BalancerConfig, ConsumerMode, LoadBalancer
+from astrameter.ct002.balancer import (
+    BalancerConfig,
+    ConsumerMode,
+    ConsumerReport,
+    LoadBalancer,
+)
 
 HERE = Path(__file__).parent
 REPO_ROOT = HERE.parent.parent.parent
@@ -165,13 +170,13 @@ class PyDriver:
             i = 6
             for _ in range(n):
                 rc, dev, phase, power, md, eww = parts[i : i + 6]
-                reports[rc] = {
-                    "device_type": dev,
-                    "phase": phase,
-                    "power": int(power),
-                    "min_dc_output": None if float(md) < 0 else float(md),
-                    "efficiency_window_weight": float(eww),
-                }
+                reports[rc] = ConsumerReport(
+                    device_type=dev,
+                    phase=phase,
+                    power=int(power),
+                    min_dc_output=None if float(md) < 0 else float(md),
+                    efficiency_window_weight=float(eww),
+                )
                 i += 6
             res = self.balancer.compute_target(
                 cid,

--- a/tests/components/ct002/test_shared_e2e.py
+++ b/tests/components/ct002/test_shared_e2e.py
@@ -113,7 +113,7 @@ class PythonBackend:
             consumer_ttl=100000,  # fixed, matching test.e2e.host.yaml
         )
 
-        async def _before_send(_addr, _fields=None, _consumer_id=None):
+        async def _before_send(_addr, _request=None, _consumer_id=None):
             if self._meter_unavailable:
                 # Mirror a powermeter that detects its own staleness and
                 # raises (HomeAssistant / HomeWizard). This is the #403 trigger.

--- a/tests/issue_repros/repro_issue522.py
+++ b/tests/issue_repros/repro_issue522.py
@@ -34,6 +34,7 @@ from astrameter.ct002.balancer import (
     BalancerConfig,
     BalancerConsumerState,
     ConsumerMode,
+    ConsumerReport,
     LoadBalancer,
     SaturationTracker,
 )
@@ -157,7 +158,9 @@ def part_b_case(pace_base, pace_max):
         **SAT_KW,
     )
     for tick in range(900):
-        reports = {b.mac: {"phase": b.phase, "power": round(b.power)} for b in bats}
+        reports = {
+            b.mac: ConsumerReport(phase=b.phase, power=round(b.power)) for b in bats
+        }
         grid = dict(base)
         for b in bats:
             grid[b.phase] -= b.power
@@ -175,7 +178,7 @@ def part_b_case(pace_base, pace_max):
             for b in bats
         }
         for b in bats:
-            b.step(tg[b.mac][PHASE_IDX[b.phase]], reports[b.mac]["power"])
+            b.step(tg[b.mac][PHASE_IDX[b.phase]], reports[b.mac].power)
         clock.advance(0.5)
     grid = dict(base)
     for b in bats:

--- a/tests/issue_repros/repro_issue600.py
+++ b/tests/issue_repros/repro_issue600.py
@@ -40,7 +40,12 @@ from __future__ import annotations
 
 import time
 
-from astrameter.ct002.balancer import BalancerConfig, ConsumerMode, LoadBalancer
+from astrameter.ct002.balancer import (
+    BalancerConfig,
+    ConsumerMode,
+    ConsumerReport,
+    LoadBalancer,
+)
 from astrameter.simulator.b2500_steering import (
     MIN_OUTPUT_W,
     B2500SteeringController,
@@ -163,11 +168,9 @@ def _run(
         if t >= stuck_s:
             stuck.healthy = True  # the mode is fixed / the battery is charged
         reports = {
-            b.mac: {
-                "phase": b.phase,
-                "power": round(b.power),
-                "device_type": b.device_type,
-            }
+            b.mac: ConsumerReport(
+                phase=b.phase, power=round(b.power), device_type=b.device_type
+            )
             for b in bats
         }
         grid = house - sum(b.power for b in bats)

--- a/tests/smoke_efficiency_saturation.py
+++ b/tests/smoke_efficiency_saturation.py
@@ -121,7 +121,7 @@ class SmokeHarness:
             **ct_kwargs,
         )
 
-        async def update_readings(_addr, _fields=None, _consumer_id=None):
+        async def update_readings(_addr, _request=None, _consumer_id=None):
             grid = self.powermeter.compute_grid()
             return [grid["phase_a"], grid["phase_b"], grid["phase_c"]]
 

--- a/tests/test_b2500_e2e.py
+++ b/tests/test_b2500_e2e.py
@@ -62,7 +62,7 @@ class _B2500Harness:
             consumer_ttl=100000,
         )
 
-        async def update_readings(_addr, _fields=None, _consumer_id=None):
+        async def update_readings(_addr, _request=None, _consumer_id=None):
             grid = self.powermeter.compute_grid()
             return [grid["phase_a"], grid["phase_b"], grid["phase_c"]]
 
@@ -170,7 +170,7 @@ class _MixedHarness:
             consumer_ttl=100000,
         )
 
-        async def update_readings(_addr, _fields=None, _consumer_id=None):
+        async def update_readings(_addr, _request=None, _consumer_id=None):
             grid = self.powermeter.compute_grid()
             return [grid["phase_a"], grid["phase_b"], grid["phase_c"]]
 

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -12,6 +12,7 @@ from astrameter.ct002.balancer import (
     BalancerConfig,
     BalancerConsumerState,
     ConsumerMode,
+    ConsumerReport,
     LoadBalancer,
     NetOutputW,
     SaturationTracker,
@@ -534,7 +535,7 @@ class TestPaceReading:
 
     def _auto(self, lb, reported, grid, dt=1.0):
         self.clock.advance(dt)
-        reports = {"a": {"device_type": "HMG-50", "phase": "A", "power": reported}}
+        reports = {"a": ConsumerReport(device_type="HMG-50", phase="A", power=reported)}
         return lb.compute_target(
             "a", ConsumerMode("auto"), reports, grid, frozenset(), frozenset(), ()
         )[0]
@@ -611,8 +612,8 @@ class TestPaceReading:
             pace_base_step=50, pace_max_step=200, min_efficient_power=400
         )
         reports = {
-            "a": {"device_type": "HMG-50", "phase": "A", "power": 300},
-            "b": {"device_type": "HMG-50", "phase": "A", "power": 300},
+            "a": ConsumerReport(device_type="HMG-50", phase="A", power=300),
+            "b": ConsumerReport(device_type="HMG-50", phase="A", power=300),
         }
 
         def target_for(cid):
@@ -650,7 +651,7 @@ class TestPaceReading:
 
     def test_manual_and_inactive_paths_are_not_paced(self):
         lb = self._make_balancer(pace_base_step=50, pace_max_step=200)
-        reports = {"a": {"device_type": "HMG-50", "phase": "A", "power": 600}}
+        reports = {"a": ConsumerReport(device_type="HMG-50", phase="A", power=600)}
         manual = lb.compute_target(
             "a", ConsumerMode("manual", 0.0), reports, 0, frozenset(), frozenset(), ()
         )
@@ -692,7 +693,7 @@ class TestGridPredictor:
     def _grid(self, lb, reported, grid):
         # sample_id = (grid,) mirrors production (the meter reading), so a
         # changed grid is a fresh sample.
-        reports = {"a": {"device_type": "HMG-50", "phase": "A", "power": reported}}
+        reports = {"a": ConsumerReport(device_type="HMG-50", phase="A", power=reported)}
         return lb.compute_target(
             "a", ConsumerMode("auto"), reports, grid, frozenset(), frozenset(), (grid,)
         )[0]
@@ -761,8 +762,8 @@ class TestConcentrateDeadband:
 
     def _reports(self):
         return {
-            "a": {"device_type": "HMG-50", "phase": "A", "power": 200},
-            "b": {"device_type": "HMG-50", "phase": "A", "power": 100},
+            "a": ConsumerReport(device_type="HMG-50", phase="A", power=200),
+            "b": ConsumerReport(device_type="HMG-50", phase="A", power=100),
         }
 
     def _target(self, lb, cid, reports, grid):
@@ -782,8 +783,8 @@ class TestConcentrateDeadband:
         # batteries are on different phases (it would over-correct one phase).
         lb = self._lb(concentrate_deadband=60)
         reports = {
-            "a": {"device_type": "HMG-50", "phase": "A", "power": 200},
-            "b": {"device_type": "HMG-50", "phase": "B", "power": 100},
+            "a": ConsumerReport(device_type="HMG-50", phase="A", power=200),
+            "b": ConsumerReport(device_type="HMG-50", phase="B", power=100),
         }
 
         def total(cid):
@@ -804,8 +805,8 @@ class TestConcentrateDeadband:
         # threshold, so the most-active battery (a, 160 W) takes the whole
         # correction and the other is left untouched.
         reports = {
-            "a": {"device_type": "HMG-50", "phase": "A", "power": 160},
-            "b": {"device_type": "HMG-50", "phase": "A", "power": 140},
+            "a": ConsumerReport(device_type="HMG-50", phase="A", power=160),
+            "b": ConsumerReport(device_type="HMG-50", phase="A", power=140),
         }
         a = self._target(lb, "a", reports, 30)
         b = self._target(lb, "b", reports, 30)
@@ -822,8 +823,8 @@ class TestConcentrateDeadband:
         # fair share instead of being left at 0.
         lb = self._lb(concentrate_deadband=60)
         reports = {
-            "a": {"device_type": "VNSE3", "phase": "A", "power": -890},
-            "b": {"device_type": "VNSE3", "phase": "A", "power": -88},
+            "a": ConsumerReport(device_type="VNSE3", phase="A", power=-890),
+            "b": ConsumerReport(device_type="VNSE3", phase="A", power=-88),
         }
         # Small surplus (charge territory): the lagging battery (b) must keep
         # charging more rather than being parked at 0 by concentration.
@@ -841,8 +842,8 @@ class TestConcentrateDeadband:
         # lets the grid-neutral swap through.
         lb = self._lb(concentrate_deadband=60)
         reports = {
-            "a": {"device_type": "VNSE3", "phase": "A", "power": -890},
-            "b": {"device_type": "VNSE3", "phase": "A", "power": -88},
+            "a": ConsumerReport(device_type="VNSE3", phase="A", power=-890),
+            "b": ConsumerReport(device_type="VNSE3", phase="A", power=-88),
         }
         a = self._target(lb, "a", reports, -30)
         b = self._target(lb, "b", reports, -30)
@@ -859,7 +860,7 @@ class TestConcentrateDeadband:
 
     def test_single_battery_unaffected(self):
         lb = self._lb(concentrate_deadband=60)
-        reports = {"a": {"device_type": "HMG-50", "phase": "A", "power": 200}}
+        reports = {"a": ConsumerReport(device_type="HMG-50", phase="A", power=200)}
         assert self._target(lb, "a", reports, 30) == pytest.approx(30.0, abs=1.0)
 
     def test_zero_weight_battery_not_designated(self):
@@ -875,9 +876,9 @@ class TestConcentrateDeadband:
         # grid-neutral redistribution the active pool absorbs), not frozen at
         # 200 — so it reduces output rather than being designated.
         reports = {
-            "a": {"device_type": "HMG-50", "phase": "A", "power": 200, "weight": 0.0},
-            "b": {"device_type": "HMG-50", "phase": "A", "power": 80},
-            "c": {"device_type": "HMG-50", "phase": "A", "power": 70},
+            "a": ConsumerReport(device_type="HMG-50", phase="A", power=200, weight=0.0),
+            "b": ConsumerReport(device_type="HMG-50", phase="A", power=80),
+            "c": ConsumerReport(device_type="HMG-50", phase="A", power=70),
         }
         a = self._target(lb, "a", reports, 30)
         assert self._target(lb, "b", reports, 30) == pytest.approx(30.0, abs=1.0)
@@ -915,7 +916,7 @@ class TestImportTrim:
         # Each call is a fresh meter sample by default (a distinct sample_id),
         # which the trim requires; pass an explicit ``sample`` to repeat a reading
         # (a stale / frozen meter).
-        reports = {"a": {"device_type": "HMG-50", "phase": "A", "power": 200}}
+        reports = {"a": ConsumerReport(device_type="HMG-50", phase="A", power=200)}
         if sample is None:
             self._tick = getattr(self, "_tick", 0) + 1
             sample = (float(self._tick), grid)
@@ -994,8 +995,8 @@ class TestEfficiencyDemandSmoothing:
         # Two batteries on one phase, 200 W each: demand = |400 + grid|. A fresh
         # sample_id per poll so the efficiency demand EMA advances each call.
         reports = {
-            "a": {"device_type": "HMG-50", "phase": "A", "power": 200},
-            "b": {"device_type": "HMG-50", "phase": "A", "power": 200},
+            "a": ConsumerReport(device_type="HMG-50", phase="A", power=200),
+            "b": ConsumerReport(device_type="HMG-50", phase="A", power=200),
         }
         lb.compute_target(
             "a", ConsumerMode("auto"), reports, grid, frozenset(), frozenset(), (tick,)

--- a/tests/test_balancer_dc_start_floor.py
+++ b/tests/test_balancer_dc_start_floor.py
@@ -25,13 +25,14 @@ from astrameter.ct002.balancer import (
     BalancerConfig,
     BalancerConsumerState,
     ConsumerMode,
+    ConsumerReport,
     LoadBalancer,
     SaturationTracker,
     min_actionable_output,
     saturation_floor,
 )
 
-B2500 = {"device_type": "HMJ-2", "phase": "A", "power": 0}
+B2500 = ConsumerReport(device_type="HMJ-2", phase="A", power=0)
 
 
 class _FakeClock:
@@ -115,9 +116,11 @@ def test_the_floor_prefers_evidence_over_the_nominal_figure() -> None:
     # family with no nominal floor: that unit is being held above its deadband,
     # and the gate has to follow, or it is judged against a command it is never
     # sent (flagged by CodeRabbit on #629).
-    assert saturation_floor(state, {"device_type": "VNSE3-0"}, 150.0) == 150.0
+    assert (
+        saturation_floor(state, ConsumerReport(device_type="VNSE3-0"), 150.0) == 150.0
+    )
     # With no override, a battery with a built-in inverter keeps no floor.
-    assert saturation_floor(state, {"device_type": "VNSE3-0"}, 0.0) == 0.0
+    assert saturation_floor(state, ConsumerReport(device_type="VNSE3-0"), 0.0) == 0.0
 
 
 def test_compute_target_supplies_each_consumer_its_floor() -> None:
@@ -140,8 +143,8 @@ def test_compute_target_supplies_each_consumer_its_floor() -> None:
     )
     b2500, venus = "aaaaaaaaaaaa", "bbbbbbbbbbbb"
     reports = {
-        b2500: {"device_type": "HMJ-2", "phase": "A", "power": 1},
-        venus: {"device_type": "VNSE3-0", "phase": "A", "power": 1},
+        b2500: ConsumerReport(device_type="HMJ-2", phase="A", power=1),
+        venus: ConsumerReport(device_type="VNSE3-0", phase="A", power=1),
     }
     seen: dict[str, float] = {}
     real_update = lb._saturation.update
@@ -202,7 +205,7 @@ def test_a_configured_floor_below_the_start_floor_does_not_lock_a_unit_out() -> 
     power = {"aaaaaaaaaaaa": 230.0, "bbbbbbbbbbbb": 4.0}
     for step in range(400):
         reports = {
-            cid: {"device_type": "HMJ-2", "phase": "A", "power": round(w)}
+            cid: ConsumerReport(device_type="HMJ-2", phase="A", power=round(w))
             for cid, w in power.items()
         }
         grid = house - sum(power.values())

--- a/tests/test_balancer_distribution_weight.py
+++ b/tests/test_balancer_distribution_weight.py
@@ -34,7 +34,7 @@ def _make_balancer(*, fair_distribution: bool = True) -> LoadBalancer:
     )
 
 
-def _report(power: float, weight: float = 1.0, phase: str = "A") -> dict:
+def _report(power: float, weight: float = 1.0, phase: str = "A") -> ConsumerReport:
     return ConsumerReport(phase=phase, power=power, device_type="HMA-2", weight=weight)
 
 

--- a/tests/test_balancer_distribution_weight.py
+++ b/tests/test_balancer_distribution_weight.py
@@ -9,6 +9,7 @@ the unweighted behaviour.
 from astrameter.ct002.balancer import (
     BalancerConfig,
     ConsumerMode,
+    ConsumerReport,
     LoadBalancer,
 )
 
@@ -34,7 +35,7 @@ def _make_balancer(*, fair_distribution: bool = True) -> LoadBalancer:
 
 
 def _report(power: float, weight: float = 1.0, phase: str = "A") -> dict:
-    return {"phase": phase, "power": power, "device_type": "HMA-2", "weight": weight}
+    return ConsumerReport(phase=phase, power=power, device_type="HMA-2", weight=weight)
 
 
 def test_fair_share_honours_weight():
@@ -71,8 +72,8 @@ def test_neutral_weight_matches_equal_split():
     weighted = {"a": _report(0.0), "b": _report(0.0)}
     # An absent "weight" key must behave exactly like the neutral default.
     bare = {
-        "a": {"phase": "A", "power": 0, "device_type": "HMA-2"},
-        "b": {"phase": "A", "power": 0, "device_type": "HMA-2"},
+        "a": ConsumerReport(phase="A", power=0, device_type="HMA-2"),
+        "b": ConsumerReport(phase="A", power=0, device_type="HMA-2"),
     }
     for reports in (weighted, bare):
         lb = _make_balancer(fair_distribution=False)

--- a/tests/test_balancer_efficiency_window_weight.py
+++ b/tests/test_balancer_efficiency_window_weight.py
@@ -52,7 +52,7 @@ def _make_balancer(clock, *, rotation_interval: float = 900.0) -> LoadBalancer:
     )
 
 
-def _report(power: float, eff_weight: float = 1.0) -> dict:
+def _report(power: float, eff_weight: float = 1.0) -> ConsumerReport:
     return ConsumerReport(
         phase="A",
         power=power,

--- a/tests/test_balancer_efficiency_window_weight.py
+++ b/tests/test_balancer_efficiency_window_weight.py
@@ -16,6 +16,7 @@ import time
 
 from astrameter.ct002.balancer import (
     BalancerConfig,
+    ConsumerReport,
     LoadBalancer,
 )
 
@@ -52,12 +53,12 @@ def _make_balancer(clock, *, rotation_interval: float = 900.0) -> LoadBalancer:
 
 
 def _report(power: float, eff_weight: float = 1.0) -> dict:
-    return {
-        "phase": "A",
-        "power": power,
-        "device_type": "HMG-50",
-        "efficiency_window_weight": eff_weight,
-    }
+    return ConsumerReport(
+        phase="A",
+        power=power,
+        device_type="HMG-50",
+        efficiency_window_weight=eff_weight,
+    )
 
 
 def test_zero_weight_battery_stays_deprioritized_while_limiting():

--- a/tests/test_balancer_empty_battery_lockup.py
+++ b/tests/test_balancer_empty_battery_lockup.py
@@ -29,6 +29,7 @@ import time
 from astrameter.ct002.balancer import (
     BalancerConfig,
     ConsumerMode,
+    ConsumerReport,
     LoadBalancer,
 )
 
@@ -110,7 +111,9 @@ def test_full_batteries_eventually_get_active_slot() -> None:
     active_membership: list[set[str]] = []
 
     for tick in range(1800):
-        reports = {b.mac: {"phase": "A", "power": round(b.power)} for b in batteries}
+        reports = {
+            b.mac: ConsumerReport(phase="A", power=round(b.power)) for b in batteries
+        }
         grid_total = phase_a_load - sum(b.power for b in batteries)
 
         deltas: dict[str, float] = {}
@@ -127,7 +130,7 @@ def test_full_batteries_eventually_get_active_slot() -> None:
             deltas[b.mac] = phase_targets[0]
 
         for b in batteries:
-            b.step(deltas[b.mac], reports[b.mac]["power"])
+            b.step(deltas[b.mac], reports[b.mac].power)
 
         slots = max(1, len(lb._priority) - len(lb._deprioritized))
         active_membership.append(set(lb._priority[:slots]))

--- a/tests/test_balancer_mixed_battery_charging.py
+++ b/tests/test_balancer_mixed_battery_charging.py
@@ -47,6 +47,7 @@ import pytest
 from astrameter.ct002.balancer import (
     BalancerConfig,
     ConsumerMode,
+    ConsumerReport,
     LoadBalancer,
     _is_ac_chargeable,
     _needs_dc_output_floor,
@@ -223,11 +224,9 @@ def _run_scenario(batteries, surplus_watts: float, ticks: int):
 
     for tick in range(ticks):
         reports = {
-            b.mac: {
-                "phase": "A",
-                "power": round(b.power),
-                "device_type": b.device_type,
-            }
+            b.mac: ConsumerReport(
+                phase="A", power=round(b.power), device_type=b.device_type
+            )
             for b in batteries
         }
         # Grid = (load - solar) - battery_sum.  Here we model a clean
@@ -250,7 +249,7 @@ def _run_scenario(batteries, surplus_watts: float, ticks: int):
             deltas[b.mac] = phase_targets[0]
 
         for b in batteries:
-            b.step(deltas[b.mac], reports[b.mac]["power"])
+            b.step(deltas[b.mac], reports[b.mac].power)
             power_trace[b.mac].append(b.power)
 
         clock.advance(1.0)
@@ -552,11 +551,9 @@ def test_transient_surplus_does_not_collapse_dc_only_pool() -> None:
     power_trace: dict[str, list[float]] = {"dc_a": [], "dc_b": []}
     for tick in range(45):
         reports = {
-            bat.mac: {
-                "phase": "A",
-                "power": round(bat.power),
-                "device_type": bat.device_type,
-            }
+            bat.mac: ConsumerReport(
+                phase="A", power=round(bat.power), device_type=bat.device_type
+            )
             for bat in (a, b)
         }
         grid_total = house_load(tick) - sum(bat.power for bat in (a, b))
@@ -570,7 +567,7 @@ def test_transient_surplus_does_not_collapse_dc_only_pool() -> None:
                 manual=frozenset(),
                 sample_id=(tick,),
             )[0]
-            bat.step(delta, reports[bat.mac]["power"])
+            bat.step(delta, reports[bat.mac].power)
             power_trace[bat.mac].append(bat.power)
         clock.advance(1.0)
 
@@ -607,7 +604,9 @@ def test_sustained_surplus_dc_only_balancer_never_asks_to_discharge() -> None:
     max_target_seen: dict[str, float] = {m: float("-inf") for m in macs}
     for tick in range(200):
         # Batteries pinned at 0 W (real B2500 cannot accept AC charge).
-        reports = {m: {"phase": "A", "power": 0, "device_type": "HMJ-1"} for m in macs}
+        reports = {
+            m: ConsumerReport(phase="A", power=0, device_type="HMJ-1") for m in macs
+        }
         grid_total = -surplus  # nothing absorbs, so grid stays at -600 W
         for m in macs:
             delta = lb.compute_target(
@@ -674,13 +673,13 @@ def _run_floor_scenario(
 
     for tick in range(ticks):
         reports = {
-            b.mac: {
-                "phase": "A",
-                "power": round(b.power),
-                "device_type": b.device_type,
-                "weight": weights.get(b.mac, 1.0),
-                "min_dc_output": overrides.get(b.mac),
-            }
+            b.mac: ConsumerReport(
+                phase="A",
+                power=round(b.power),
+                device_type=b.device_type,
+                weight=weights.get(b.mac, 1.0),
+                min_dc_output=overrides.get(b.mac),
+            )
             for b in batteries
         }
         grid_total = -surplus_watts - sum(b.power for b in batteries)
@@ -705,7 +704,7 @@ def _run_floor_scenario(
             deltas[b.mac] = phase_targets[0]
 
         for b in batteries:
-            b.step(deltas[b.mac], reports[b.mac]["power"])
+            b.step(deltas[b.mac], reports[b.mac].power)
             power_trace[b.mac].append(b.power)
         clock.advance(1.0)
 

--- a/tests/test_balancer_pace_saturation.py
+++ b/tests/test_balancer_pace_saturation.py
@@ -22,7 +22,12 @@ from __future__ import annotations
 
 import time
 
-from astrameter.ct002.balancer import BalancerConfig, ConsumerMode, LoadBalancer
+from astrameter.ct002.balancer import (
+    BalancerConfig,
+    ConsumerMode,
+    ConsumerReport,
+    LoadBalancer,
+)
 
 PHASE_IDX = {"A": 0, "B": 1, "C": 2}
 
@@ -79,7 +84,8 @@ def _run(pace_base_step: float, pace_max_step: float) -> dict[str, float]:
 
     for tick in range(600):
         reports = {
-            b.mac: {"phase": b.phase, "power": round(b.power)} for b in batteries
+            b.mac: ConsumerReport(phase=b.phase, power=round(b.power))
+            for b in batteries
         }
         grid = dict(base)
         for b in batteries:
@@ -98,7 +104,7 @@ def _run(pace_base_step: float, pace_max_step: float) -> dict[str, float]:
             for b in batteries
         }
         for b in batteries:
-            b.step(targets[b.mac][PHASE_IDX[b.phase]], reports[b.mac]["power"])
+            b.step(targets[b.mac][PHASE_IDX[b.phase]], reports[b.mac].power)
         clock.advance(0.5)
 
     grid = dict(base)

--- a/tests/test_balancer_probe_lockup.py
+++ b/tests/test_balancer_probe_lockup.py
@@ -24,6 +24,7 @@ from collections.abc import Callable
 from astrameter.ct002.balancer import (
     BalancerConfig,
     ConsumerMode,
+    ConsumerReport,
     LoadBalancer,
     ProbeState,
 )
@@ -81,8 +82,8 @@ def _reports(active_power: int, backup_power: int) -> dict:
     """Build the ``reports`` dict the balancer expects: both batteries
     are self-reporting on phase B (matching log2)."""
     return {
-        "24215edb1936": {"phase": "B", "power": active_power},
-        "acd929a74b20": {"phase": "B", "power": backup_power},
+        "24215edb1936": ConsumerReport(phase="B", power=active_power),
+        "acd929a74b20": ConsumerReport(phase="B", power=backup_power),
     }
 
 
@@ -150,8 +151,8 @@ class TestProbeReseedsSmoother:
         )
         lb._commit_probe(  # type: ignore[attr-defined]
             reports={
-                "24215edb1936": {"phase": "B", "power": 22},
-                "acd929a74b20": {"phase": "B", "power": 94},
+                "24215edb1936": ConsumerReport(phase="B", power=22),
+                "acd929a74b20": ConsumerReport(phase="B", power=94),
             },
             now=clock(),
             actual=22.0,

--- a/tests/test_balancer_slot_hysteresis.py
+++ b/tests/test_balancer_slot_hysteresis.py
@@ -27,6 +27,7 @@ import time
 from astrameter.ct002.balancer import (
     BalancerConfig,
     ConsumerMode,
+    ConsumerReport,
     LoadBalancer,
 )
 
@@ -73,9 +74,9 @@ def _make_balancer(clock: _FakeClock) -> LoadBalancer:
 def _tick(lb: LoadBalancer, demand: float, carried: float, tick: int) -> None:
     """One balancer pass: the first battery carries *carried* W of *demand*."""
     reports = {
-        MACS[0]: {"phase": "A", "power": round(carried)},
-        MACS[1]: {"phase": "A", "power": 0},
-        MACS[2]: {"phase": "A", "power": 0},
+        MACS[0]: ConsumerReport(phase="A", power=round(carried)),
+        MACS[1]: ConsumerReport(phase="A", power=0),
+        MACS[2]: ConsumerReport(phase="A", power=0),
     }
     grid_total = demand - carried
     for mac in MACS:

--- a/tests/test_balancer_steer_logging.py
+++ b/tests/test_balancer_steer_logging.py
@@ -19,6 +19,7 @@ from astrameter.config.logger import logger
 from astrameter.ct002.balancer import (
     BalancerConfig,
     ConsumerMode,
+    ConsumerReport,
     LoadBalancer,
 )
 
@@ -27,9 +28,9 @@ MANUAL, AUTO, IDLE = "aaaaaaaaaaaa", "bbbbbbbbbbbb", "cccccccccccc"
 
 def _reports() -> dict:
     return {
-        MANUAL: {"device_type": "HMJ-2", "phase": "A", "power": 400},
-        AUTO: {"device_type": "HMJ-2", "phase": "A", "power": 350},
-        IDLE: {"device_type": "HMJ-2", "phase": "A", "power": 0},
+        MANUAL: ConsumerReport(device_type="HMJ-2", phase="A", power=400),
+        AUTO: ConsumerReport(device_type="HMJ-2", phase="A", power=350),
+        IDLE: ConsumerReport(device_type="HMJ-2", phase="A", power=0),
     }
 
 
@@ -189,7 +190,7 @@ def test_a_consumer_the_efficiency_layer_idled_says_so(
         clock=lambda: clock[0],
     )
     reports = {
-        cid: {"device_type": "HMJ-2", "phase": "A", "power": 50}
+        cid: ConsumerReport(device_type="HMJ-2", phase="A", power=50)
         for cid in ("dddddddddddd", "eeeeeeeeeeee", "ffffffffffff")
     }
     # Demand well under one battery's efficient slice, so the layer idles two.

--- a/tests/test_control_quality.py
+++ b/tests/test_control_quality.py
@@ -17,6 +17,7 @@ from astrameter.ct002.balancer import (
     CONTROL_QUALITY_WARMUP_SECONDS,
     BalancerConfig,
     ConsumerMode,
+    ConsumerReport,
     ControlQualityTracker,
     LoadBalancer,
 )
@@ -310,7 +311,9 @@ class TestControlQualityInBalancer:
 
     def _poll(self, balancer, clock, grid, *, reported=0.0, device_type="HMG-50"):
         clock.advance(1.0)
-        reports = {"a": {"device_type": device_type, "phase": "A", "power": reported}}
+        reports = {
+            "a": ConsumerReport(device_type=device_type, phase="A", power=reported)
+        }
         balancer.compute_target(
             "a",
             ConsumerMode("auto"),
@@ -338,7 +341,9 @@ class TestControlQualityInBalancer:
         balancer, clock = self._make()
         for _ in range(120):
             clock.advance(1.0)
-            reports = {"a": {"device_type": "HMG-50", "phase": "A", "power": 300.0}}
+            reports = {
+                "a": ConsumerReport(device_type="HMG-50", phase="A", power=300.0)
+            }
             balancer.compute_target(
                 "a", ConsumerMode("auto"), reports, 0.0, frozenset(), frozenset(), ()
             )
@@ -358,7 +363,7 @@ class TestControlQualityInBalancer:
         for i in range(400):
             clock.advance(1.0)
             grid = 400.0 if i % 2 == 0 else -400.0
-            reports = {"a": {"device_type": "HMA-1", "phase": "A", "power": 300.0}}
+            reports = {"a": ConsumerReport(device_type="HMA-1", phase="A", power=300.0)}
             balancer.compute_target(
                 "a",
                 ConsumerMode("auto"),
@@ -404,8 +409,8 @@ class TestControlQualityInBalancer:
         def poll_pair():
             clock.advance(1.0)
             reports = {
-                "a": {"device_type": "HMG-50", "phase": "A", "power": 0.0},
-                "b": {"device_type": "HMG-50", "phase": "A", "power": 0.0},
+                "a": ConsumerReport(device_type="HMG-50", phase="A", power=0.0),
+                "b": ConsumerReport(device_type="HMG-50", phase="A", power=0.0),
             }
             balancer.compute_target(
                 "a",

--- a/tests/test_ct002_active_control.py
+++ b/tests/test_ct002_active_control.py
@@ -3,7 +3,7 @@
 import dataclasses
 import time
 
-from astrameter.ct002.balancer import ProbeState, split_balancer_knobs
+from astrameter.ct002.balancer import ConsumerReport, ProbeState, split_balancer_knobs
 from astrameter.ct002.ct002 import CT002
 
 
@@ -1276,8 +1276,8 @@ class TestEfficiencySaturationSwap:
             proof_samples=1,
         )
         reports = {
-            "a": {"phase": "A", "power": 200},
-            "b": {"phase": "A", "power": 80},
+            "a": ConsumerReport(phase="A", power=200),
+            "b": ConsumerReport(phase="A", power=80),
         }
         out_a = device._balancer._compute_probe_target("a", reports, -80, {})
 

--- a/tests/test_ct002_protocol.py
+++ b/tests/test_ct002_protocol.py
@@ -1,7 +1,7 @@
 import logging
 from unittest.mock import MagicMock
 
-from astrameter.ct002 import CT002, ReportingConsumerRow
+from astrameter.ct002 import CT002, CT002Request, ReportingConsumerRow
 from astrameter.ct002.balancer import BalancerConfig
 from astrameter.ct002.protocol import (
     ETX,
@@ -66,10 +66,12 @@ def test_checksum_matches_helper():
 
 def test_ct002_response_field_count_stable():
     device = CT002()
-    request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "0", "0"]
+    request = CT002Request.from_fields(
+        ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "0", "0"]
+    )
 
     response_fields = device._build_response_fields(
-        request_fields=request_fields,
+        request=request,
         values=[500, 0, 0],
     )
 
@@ -128,14 +130,16 @@ def _set_instruction(
 
 def test_ct002_relays_sum_of_charge_instructions_by_phase():
     device = CT002()
-    request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "B", "-100"]
+    request = CT002Request.from_fields(
+        ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "B", "-100"]
+    )
 
     # We *instructed* consumer-a to charge on A and consumer-b to charge on B.
     _set_instruction(device, "consumer-a", phase="A", instructed=-180)
     _set_instruction(device, "consumer-b", phase="B", instructed=-240)
 
     response_for_a = device._build_response_fields(
-        request_fields=request_fields,
+        request=request,
         values=[10, 20, 30],
     )
 
@@ -147,7 +151,7 @@ def test_ct002_relays_sum_of_charge_instructions_by_phase():
     assert response_for_a[9] == "1"  # B_chrg_nb
 
     response_for_b = device._build_response_fields(
-        request_fields=request_fields,
+        request=request,
         values=[10, 20, 30],
     )
 
@@ -163,7 +167,9 @@ def test_ct002_relay_reports_battery_count_per_phase():
     phase, not a flat 1.
     """
     device = CT002(active_control=False)
-    request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "A", "-100"]
+    request = CT002Request.from_fields(
+        ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "A", "-100"]
+    )
 
     # Two batteries on phase A, one on B, none on C.
     _set_instruction(device, "consumer-a1", phase="A", instructed=-180)
@@ -171,7 +177,7 @@ def test_ct002_relay_reports_battery_count_per_phase():
     _set_instruction(device, "consumer-b", phase="B", instructed=-240)
 
     response = device._build_response_fields(
-        request_fields=request_fields,
+        request=request,
         values=[10, 20, 30],
     )
 
@@ -183,14 +189,16 @@ def test_ct002_relay_reports_battery_count_per_phase():
 def test_ct002_active_control_reports_count_one_per_phase():
     """Active control distributes a per-consumer target, so *_chrg_nb stays 1."""
     device = CT002(active_control=True)
-    request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "A", "-100"]
+    request = CT002Request.from_fields(
+        ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "A", "-100"]
+    )
 
     _set_instruction(device, "consumer-a1", phase="A", instructed=-180)
     _set_instruction(device, "consumer-a2", phase="A", instructed=-120)
 
     # Only phase A carries power, so B/C stay inactive.
     response = device._build_response_fields(
-        request_fields=request_fields,
+        request=request,
         values=[10, 0, 0],
     )
 
@@ -201,7 +209,9 @@ def test_ct002_active_control_reports_count_one_per_phase():
 def test_ct002_excludes_non_participating_from_aggregation():
     """A consumer that sent participate=0 is left out of the relay aggregates."""
     device = CT002(active_control=False)
-    request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "A", "-100"]
+    request = CT002Request.from_fields(
+        ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "A", "-100"]
+    )
 
     # Relay buckets aggregate the *reported* power (issue #457).
     device._update_consumer_report("consumer-a1", phase="A", power=-180)
@@ -210,7 +220,7 @@ def test_ct002_excludes_non_participating_from_aggregation():
     device._consumers["consumer-a2"].participates = False
 
     response = device._build_response_fields(
-        request_fields=request_fields,
+        request=request,
         values=[10, 0, 0],
     )
 
@@ -223,7 +233,7 @@ async def test_ct002_handle_request_respects_participate_field():
     """The optional 7th request field marks a consumer non-participating."""
     transport = MagicMock()
 
-    async def before_send(_addr, _fields, _consumer_id):
+    async def before_send(_addr, _request, _consumer_id):
         return [0, 0, 0]
 
     # 7th field == "0" → opted out → treated as inactive by active control.
@@ -249,13 +259,15 @@ async def test_ct002_handle_request_respects_participate_field():
 
 def test_ct002_splits_positive_instructions_into_dchrg_fields():
     device = CT002()
-    request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "B", "100"]
+    request = CT002Request.from_fields(
+        ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "B", "100"]
+    )
 
     _set_instruction(device, "consumer-a", phase="A", instructed=500)
     _set_instruction(device, "consumer-b", phase="B", instructed=800)
 
     response = device._build_response_fields(
-        request_fields=request_fields,
+        request=request,
         values=[10, 20, 30],
     )
 
@@ -270,14 +282,16 @@ def test_ct002_splits_positive_instructions_into_dchrg_fields():
 
 def test_ct002_splits_mixed_sign_instructions_per_storage_before_aggregation():
     device = CT002()
-    request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "A", "0"]
+    request = CT002Request.from_fields(
+        ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "A", "0"]
+    )
 
     # Same phase, opposite instructions to different storages.
     _set_instruction(device, "consumer-a", phase="A", instructed=-300)
     _set_instruction(device, "consumer-b", phase="A", instructed=120)
 
     response = device._build_response_fields(
-        request_fields=request_fields,
+        request=request,
         values=[10, 20, 30],
     )
 
@@ -291,7 +305,9 @@ def test_ct002_pv_passthrough_does_not_appear_as_dchrg():
     """Regression for #376: positive *report* but negative *net instruction*
     must not populate *_dchrg_power (otherwise other batteries idle)."""
     device = CT002()
-    request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "C", "-100"]
+    request = CT002Request.from_fields(
+        ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "C", "-100"]
+    )
 
     # Venus D reports +500 (PV passthrough) but its net instructed target is
     # -500 (we expect it to charge, even though firmware will keep
@@ -300,7 +316,7 @@ def test_ct002_pv_passthrough_does_not_appear_as_dchrg():
     device._consumers["venus-d"].last_instructed_power = -500.0
 
     response = device._build_response_fields(
-        request_fields=request_fields,
+        request=request,
         values=[0, 0, -500],
     )
 
@@ -313,7 +329,9 @@ def test_ct002_discharging_battery_with_small_correction_keeps_dchrg_signal():
     corrected down by 100 must still register as discharging (+400 W),
     not flip into the charge bucket on the strength of the delta alone."""
     device = CT002()
-    request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "B", "0"]
+    request = CT002Request.from_fields(
+        ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "B", "0"]
+    )
 
     # Venus on phase A is discharging at 500 W; we just sent it a -100 W
     # correction (charge a little) → net target 400 W (still discharging).
@@ -321,7 +339,7 @@ def test_ct002_discharging_battery_with_small_correction_keeps_dchrg_signal():
     device._consumers["venus-a"].last_instructed_power = 400.0
 
     response = device._build_response_fields(
-        request_fields=request_fields,
+        request=request,
         values=[0, 0, 0],
     )
 
@@ -342,7 +360,7 @@ async def _drive_request(
     ``last_instructed_power``."""
     transport = MagicMock()
 
-    async def before_send(_addr, _fields, _consumer_id):
+    async def before_send(_addr, _request, _consumer_id):
         return list(delta_values)
 
     device.before_send = before_send
@@ -446,7 +464,10 @@ async def test_relay_buckets_aggregate_reported_power_not_reported_plus_grid():
     assert by_phase["A"]["chrg_power"] == -100
     assert by_phase["A"]["dchrg_power"] == 0
     response = device._build_response_fields(
-        ["HMG-50", "FFEEDDCCBBAA", "HME-4", "112233445566", "B", "0"], [0, 0, 0]
+        CT002Request.from_fields(
+            ["HMG-50", "FFEEDDCCBBAA", "HME-4", "112233445566", "B", "0"]
+        ),
+        [0, 0, 0],
     )
     assert response[15] == "-100"  # A_chrg_power
 
@@ -506,13 +527,13 @@ async def _drive_and_capture(
 async def _seed_good_reading(device: CT002, battery_mac: str) -> None:
     """Establish a non-zero cached grid reading via a successful poll."""
 
-    async def good(_addr, _fields, _consumer_id):
+    async def good(_addr, _request, _consumer_id):
         return [500, 0, 0]
 
     await _drive_and_capture(device, battery_mac, "A", 0, before_send=good)
 
 
-async def _raise_stale(_addr, _fields, _consumer_id):
+async def _raise_stale(_addr, _request, _consumer_id):
     raise ValueError("powermeter unavailable (test)")
 
 
@@ -561,7 +582,7 @@ async def test_handle_request_uses_cache_when_before_send_returns_none():
     device = CT002(ct_mac="112233445566", active_control=True)
     await _seed_good_reading(device, "AABBCCDDEEFF")
 
-    async def returns_none(_addr, _fields, _consumer_id):
+    async def returns_none(_addr, _request, _consumer_id):
         return None
 
     # Inspection mode skips the balancer, so the served value is the cached
@@ -575,17 +596,19 @@ async def test_handle_request_uses_cache_when_before_send_returns_none():
 
 def test_ct002_info_idx_increments_and_wraps():
     device = CT002()
-    request_fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "A", "0"]
+    request = CT002Request.from_fields(
+        ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "A", "0"]
+    )
 
-    first = device._build_response_fields(request_fields, [1, 2, 3])
-    second = device._build_response_fields(request_fields, [1, 2, 3])
+    first = device._build_response_fields(request, [1, 2, 3])
+    second = device._build_response_fields(request, [1, 2, 3])
 
     assert first[13] == "0"
     assert second[13] == "1"
 
     device._info_idx_counter = 255
-    wrap = device._build_response_fields(request_fields, [1, 2, 3])
-    after_wrap = device._build_response_fields(request_fields, [1, 2, 3])
+    wrap = device._build_response_fields(request, [1, 2, 3])
+    after_wrap = device._build_response_fields(request, [1, 2, 3])
 
     assert wrap[13] == "255"
     assert after_wrap[13] == "0"
@@ -626,7 +649,10 @@ async def test_inspection_reporter_counts_in_x_bucket_not_a():
     assert by_phase["A"]["chrg_power"] == 0
 
     response = device._build_response_fields(
-        ["HMG-50", "FFEEDDCCBBAA", "HME-4", "112233445566", "A", "0"], [0, 0, 0]
+        CT002Request.from_fields(
+            ["HMG-50", "FFEEDDCCBBAA", "HME-4", "112233445566", "A", "0"]
+        ),
+        [0, 0, 0],
     )
     assert response[14] == "-200"  # x_chrg_power
     assert response[19] == "0"  # x_dchrg_power
@@ -651,7 +677,10 @@ async def test_combined_phase_d_reporter_lands_in_abc_bucket():
     assert by_phase["A"]["count"] == 0
 
     response = device._build_response_fields(
-        ["HMG-50", "FFEEDDCCBBAA", "HME-4", "112233445566", "A", "0"], [0, 0, 0]
+        CT002Request.from_fields(
+            ["HMG-50", "FFEEDDCCBBAA", "HME-4", "112233445566", "A", "0"]
+        ),
+        [0, 0, 0],
     )
     assert response[11] == "1"  # ABC_chrg_nb
     assert response[23] == "300"  # ABC_dchrg_power
@@ -690,7 +719,10 @@ def test_active_control_combined_mode_response_reports_count_one():
     device._update_consumer_report("venus-d", phase="D", power=0)
     device._consumers["venus-d"].last_instructed_power = -400.0
     response = device._build_response_fields(
-        ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "D", "0"], [-400, 0, 0]
+        CT002Request.from_fields(
+            ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "D", "0"]
+        ),
+        [-400, 0, 0],
     )
     assert response[11] == "1"  # ABC_chrg_nb = 1 (not the real battery count)
     assert response[18] == "-400"  # ABC_chrg_power = instructed net
@@ -703,7 +735,10 @@ def test_relay_mode_combined_count_is_real_battery_count():
     device._update_consumer_report("venus-d1", phase="D", power=100)
     device._update_consumer_report("venus-d2", phase="D", power=100)
     response = device._build_response_fields(
-        ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "D", "0"], [0, 0, 0]
+        CT002Request.from_fields(
+            ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "D", "0"]
+        ),
+        [0, 0, 0],
     )
     assert response[11] == "2"  # ABC count = real battery count in relay mode
 

--- a/tests/test_ct002_protocol.py
+++ b/tests/test_ct002_protocol.py
@@ -441,8 +441,8 @@ async def test_handle_request_pv_passthrough_net_target_and_relay_buckets():
     consumer = device._consumers["aabbccddeeff"]
     assert consumer.last_instructed_power == 0.0
     by_phase = device._collect_reports_by_phase()
-    assert by_phase["A"]["dchrg_power"] == 500
-    assert by_phase["A"]["chrg_power"] == 0
+    assert by_phase["A"].dchrg_power == 500
+    assert by_phase["A"].chrg_power == 0
 
 
 async def test_relay_buckets_aggregate_reported_power_not_reported_plus_grid():
@@ -461,8 +461,8 @@ async def test_relay_buckets_aggregate_reported_power_not_reported_plus_grid():
     assert device._consumers["aabbccddeeff"].last_instructed_power == -150.0
     # ...but the forwarded bucket carries the reported -100.
     by_phase = device._collect_reports_by_phase()
-    assert by_phase["A"]["chrg_power"] == -100
-    assert by_phase["A"]["dchrg_power"] == 0
+    assert by_phase["A"].chrg_power == -100
+    assert by_phase["A"].dchrg_power == 0
     response = device._build_response_fields(
         CT002Request.from_fields(
             ["HMG-50", "FFEEDDCCBBAA", "HME-4", "112233445566", "B", "0"]
@@ -643,10 +643,10 @@ async def test_inspection_reporter_counts_in_x_bucket_not_a():
         delta_values=[0, 0, 0],
     )
     by_phase = device._collect_reports_by_phase()
-    assert by_phase["x"]["count"] == 1
-    assert by_phase["x"]["chrg_power"] == -200
-    assert by_phase["A"]["count"] == 0
-    assert by_phase["A"]["chrg_power"] == 0
+    assert by_phase["x"].count == 1
+    assert by_phase["x"].chrg_power == -200
+    assert by_phase["A"].count == 0
+    assert by_phase["A"].chrg_power == 0
 
     response = device._build_response_fields(
         CT002Request.from_fields(
@@ -672,9 +672,9 @@ async def test_combined_phase_d_reporter_lands_in_abc_bucket():
         delta_values=[0, 0, 0],
     )
     by_phase = device._collect_reports_by_phase()
-    assert by_phase["ABC"]["count"] == 1
-    assert by_phase["ABC"]["dchrg_power"] == 300
-    assert by_phase["A"]["count"] == 0
+    assert by_phase["ABC"].count == 1
+    assert by_phase["ABC"].dchrg_power == 300
+    assert by_phase["A"].count == 0
 
     response = device._build_response_fields(
         CT002Request.from_fields(
@@ -704,11 +704,11 @@ def test_active_control_abc_bucket_uses_instructed_power():
     device._update_consumer_report("ins-x", phase="0", power=-200)
 
     by_phase = device._collect_reports_by_phase()
-    assert by_phase["A"]["chrg_power"] == -500  # instructed net
-    assert by_phase["A"]["dchrg_power"] == 0
-    assert by_phase["ABC"]["chrg_power"] == -300  # instructed net, not reported
-    assert by_phase["ABC"]["count"] == 1
-    assert by_phase["x"]["chrg_power"] == -200  # reported (never instructed)
+    assert by_phase["A"].chrg_power == -500  # instructed net
+    assert by_phase["A"].dchrg_power == 0
+    assert by_phase["ABC"].chrg_power == -300  # instructed net, not reported
+    assert by_phase["ABC"].count == 1
+    assert by_phase["x"].chrg_power == -200  # reported (never instructed)
 
 
 def test_active_control_combined_mode_response_reports_count_one():
@@ -857,5 +857,5 @@ def test_stale_consumer_drops_out_of_aggregation_before_cleanup_runs():
 
     by_phase = device._collect_reports_by_phase()
     assert "b" in device._consumers  # cleanup hasn't run yet
-    assert by_phase["A"]["count"] == 1
-    assert by_phase["A"]["dchrg_power"] == 100  # b's 50 W is gone
+    assert by_phase["A"].count == 1
+    assert by_phase["A"].dchrg_power == 100  # b's 50 W is gone

--- a/tests/test_e2e_probe_lockup.py
+++ b/tests/test_e2e_probe_lockup.py
@@ -193,7 +193,7 @@ class _Harness:
                 consumer_ttl=100000,  # avoid eviction during long mock-time sims
             )
 
-            async def update_readings(_addr, _fields=None, _consumer_id=None):
+            async def update_readings(_addr, _request=None, _consumer_id=None):
                 if self.powermeter_raises_stale:
                     raise ValueError("HomeWizard measurement is stale (test)")
                 if self.frozen_grid is not None:

--- a/tests/test_efficiency_e2e.py
+++ b/tests/test_efficiency_e2e.py
@@ -166,7 +166,7 @@ class _SimHarness:
                 **other_kwargs,
             )
 
-            async def update_readings(_addr, _fields=None, _consumer_id=None):
+            async def update_readings(_addr, _request=None, _consumer_id=None):
                 grid = self.powermeter.compute_grid()
                 return [grid["phase_a"], grid["phase_b"], grid["phase_c"]]
 

--- a/tests/test_issue376_pv_passthrough.py
+++ b/tests/test_issue376_pv_passthrough.py
@@ -119,7 +119,7 @@ class _Issue376Harness:
                 consumer_ttl=100000,
             )
 
-            async def update_readings(_addr, _fields=None, _consumer_id=None):
+            async def update_readings(_addr, _request=None, _consumer_id=None):
                 grid = self.powermeter.compute_grid()
                 return [grid["phase_a"], grid["phase_b"], grid["phase_c"]]
 

--- a/tests/test_issue376_pv_passthrough.py
+++ b/tests/test_issue376_pv_passthrough.py
@@ -167,7 +167,7 @@ class _Issue376Harness:
     def phase_dchrg(self, phase: str) -> float:
         """Aggregated *_dchrg_power for a phase (positive instructed power)."""
         if self.backend == "python":
-            return self.ct002._collect_reports_by_phase()[phase]["dchrg_power"]
+            return self.ct002._collect_reports_by_phase()[phase].dchrg_power
         total = 0.0
         for c in self._esphome.dump()["consumers"].values():
             if c["phase"] != phase:


### PR DESCRIPTION
## Why

No user-visible problem — this is a readability pass over the recent CT002 and
balancer work, which had accumulated one shape in several places: state
travelling between modules as an untyped `dict`, with every reader re-deriving
its own default from it. That is where a bug hides, because nothing says in one
place what a field means or what "missing" implies.

Nine commits, each removing one instance, plus a tenth for review follow-up.
Behaviour is unchanged throughout — see Verification.

- **A typed consumer report for the balancer.** Every consumer's poll arrived as
  a bare `dict`, so ~50 read sites re-derived the value they wanted: forty
  `parse_int(reports.get(cid, {}).get("power", 0))`, two helper functions that
  existed only to re-default a weight, three spellings of "phase, or A if
  missing". A missing key was indistinguishable from a consumer that genuinely
  dropped out between the snapshot and the allocation. A frozen `ConsumerReport`
  now normalises its six fields once, with a `NO_REPORT` singleton for the
  drop-out case.
- **One decode per poll.** `_handle_request` was 293 lines: it re-read the wire
  fields by index (`fields[4] if len(fields) > 4 else ""`, sixteen times across
  four methods, each with its own default), then parsed, deduped, read the
  meter, ran control, built the response, wrote status and assembled a 70-line
  event payload in one body. `CT002Request` decodes once; the steps are
  `_decode_request`, `_should_serve`, `_serve`, `_resolve_target`,
  `_record_instructed_power` and `_consumer_event`. The bounds defaults on
  fields 0, 1 and 3 went with it — a request that reaches the response builder
  has passed the four-field check, so they never fired.
- **One UDP server.** Both emulators carried their own `DatagramProtocol`
  spawning a task per datagram, and both `stop()` methods then reached into
  `protocol._tasks` from outside. Now `udp_server.UdpServer`.
- **`PhaseBucket`.** The cross-talk buckets travelled as `dict[str, dict[str,
  int | bool]]` from the aggregation loop through the snapshot to the response
  builder, the status wire and the cloud reporter.
- **Naming what the efficiency rotation waits for.** `not probe_active and not
  probe_resolved` was spelled four times, and "clear the score, then set a grace
  window" was open-coded at two of the three role transitions and half-done at
  the third.
- **The MQTT reconnect loop** separated from what a connection does — it nested
  five deep, with the retry policy far below the session body it guards.
- **The evaluation's metrics** split into the four independent passes over the
  samples they always were.

`before_send` now receives the decoded request rather than a bare field list; no
implementation read that argument.

One behaviour change, from review: `start()` published `self.udp_port` as
configured, so a `udp_port=0` — asking the OS for a free port — reported "0" in
the log line and the status document. It now reads the bound port back, as the
Shelly emulator already did.

### Verification

- `ruff format` / `ruff check` / `mypy src/` clean; **1583 passed, 98 skipped**
  locally.
- **Steering evaluation: 0 improved, 0 regressed, 15 unchanged across 15 metrics
  — no do-no-harm guardrail regressions.** `cost_regret_ct` 0.76 → 0.76,
  `grid_rms_w` 238.4 → 238.4. CI's `steering-eval` comparison matches a local
  base-vs-head run over the same 33 scenarios × 5 seeds, digit for digit.
- **`ct002-host-protocol` ✅** — the host gtest suite could not run in the
  authoring sandbox (CMake fetches googletest from GitHub and egress was
  blocked), so CI was its first real run against this branch. It passes, along
  with `ct002-host-e2e` and the ESPHome compile matrix.
- CodeRabbit's two findings and its nitpick are all fixed in `6e0f97d`, with a
  regression test covering the port readback.

### Deliberately left

- **`CT002.__init__`'s seven saturation parameters** are pure pass-through to
  `LoadBalancer` → `SaturationTracker`. Same slop, but
  `esphome/components/ct002/balancer.h` mirrors that signature, so the fix
  belongs on both sides in one change.
- **The C++ mirror is untouched.** No shared behaviour changed, so the parity
  rule does not ask for a port; `ct002.cpp` still does its own index-juggling and
  would benefit from the same treatment separately.
- **The interrupted-shutdown window** the review summary raises — a cancelled
  `stop()` leaves `running` true after the socket has closed — is real, but
  predates this PR and is unchanged by it: `stop()` awaited the in-flight
  handlers between closing the transport and clearing `_running` before the
  refactor too, and `UdpServer.close()` keeps exactly that order. Worth a
  `try/finally`, but it belongs in its own change rather than widening this one.
- **CodeRabbit's docstring-coverage check (54.73% vs its 80% threshold)** counts
  201 functions across the diff, most of them test functions whose names already
  say what they assert. Writing a docstring for each would add the kind of noise
  this PR removes, so it is not addressed here.

## Checklist

- [x] Base branch is `develop`, not `main`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest`
- [x] Python ↔ ESPHome parity held for shared CT002 behaviour, or does not apply ([CONTRIBUTING.md](https://github.com/tomquist/AstraMeter/blob/develop/CONTRIBUTING.md)) — does not apply: no shared behaviour changed, and the parity suites pass unmodified
- [x] `web/` changes: rebuilt the dashboard bundle (`cd web && npm run build:dashboard`) and committed it — no `web/` changes
- [x] User-visible change: one bullet under `## Next` in [CHANGELOG.md](https://github.com/tomquist/AstraMeter/blob/develop/CHANGELOG.md) — refactor only, no entry per AGENTS.md

https://claude.ai/code/session_01FnkqVyKV4HzwBY9oLeYwYt