### PR TITLE
Collapse duplicated plumbing, and put every function under mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,10 +74,7 @@ ignore_missing_imports = true
 explicit_package_bases = true
 namespace_packages = true
 mypy_path = ["src"]
-# Every function in the shipped modules carries annotations, so their bodies
-# are checked. The test modules alongside them are not annotated — turning
-# these on would report a thousand fixture signatures, none of them the
-# thing a test is about.
-check_untyped_defs = false
-disallow_incomplete_defs = false
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
 disable_error_code = ["import-untyped"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,10 @@ ignore_missing_imports = true
 explicit_package_bases = true
 namespace_packages = true
 mypy_path = ["src"]
-# Typed surfaces only; full strictness would require annotating the whole codebase
+# Every function in the shipped modules carries annotations, so their bodies
+# are checked. The test modules alongside them are not annotated — turning
+# these on would report a thousand fixture signatures, none of them the
+# thing a test is about.
 check_untyped_defs = false
 disallow_incomplete_defs = false
 disable_error_code = ["import-untyped"]

--- a/src/astrameter/addon_client_test.py
+++ b/src/astrameter/addon_client_test.py
@@ -140,16 +140,16 @@ async def test_restart_accepts_a_reply_that_does_arrive(stub: _StubSupervisor) -
 class _StatesClient(SupervisorClient):
     """A client whose Core-proxy call returns a canned /states payload."""
 
-    def __init__(self, states):
+    def __init__(self, states: Any) -> None:
         super().__init__(base_url="http://supervisor", token="t")
         self._states = states
 
-    async def _request_raw(self, method, path):
+    async def _request_raw(self, method: str, path: str) -> Any:
         assert path == "/core/api/states"
         return self._states
 
 
-async def test_power_entities_keep_unclassed_watt_sensors():
+async def test_power_entities_keep_unclassed_watt_sensors() -> None:
     """Plenty of real installs expose grid power as a plain sensor in W or kW
     with no device_class; excluding those would make the picker useless for
     exactly the people who need it."""
@@ -222,7 +222,7 @@ async def test_power_entities_keep_unclassed_watt_sensors():
     assert entities[3]["name"] == "sensor.p1"
 
 
-async def test_power_entities_offer_every_unit_the_meter_converts():
+async def test_power_entities_offer_every_unit_the_meter_converts() -> None:
     """The picker's list has to be the powermeter's list.
 
     When MW and mW were added to the converter the picker still said "W or
@@ -251,7 +251,7 @@ async def test_power_entities_offer_every_unit_the_meter_converts():
     assert all(e["readable"] for e in entities)
 
 
-async def test_a_mislabelled_power_sensor_is_offered_but_marked():
+async def test_a_mislabelled_power_sensor_is_offered_but_marked() -> None:
     """`device_class: power` with a unit the meter refuses is a common
     mistake in a template sensor. Hiding it makes the entity the user is
     hunting for vanish; offering it silently makes every read fail."""
@@ -278,7 +278,7 @@ async def test_a_mislabelled_power_sensor_is_offered_but_marked():
     assert by_id["sensor.grid_power"]["readable"] is True
 
 
-async def test_a_unit_free_entity_is_readable_when_it_claims_to_be_power():
+async def test_a_unit_free_entity_is_readable_when_it_claims_to_be_power() -> None:
     """No unit attribute means "assume watts" to the powermeter, so a
     device_class that says power must not be marked unreadable."""
     client = _StatesClient(
@@ -293,11 +293,11 @@ async def test_a_unit_free_entity_is_readable_when_it_claims_to_be_power():
     assert (await client.list_power_entities())[0]["readable"] is True
 
 
-async def test_power_entities_tolerate_a_junk_payload():
+async def test_power_entities_tolerate_a_junk_payload() -> None:
     client = _StatesClient(["not a dict", {"no_entity_id": True}, None])
     assert await client.list_power_entities() == []
 
 
-async def test_power_entities_empty_when_core_returns_an_object():
+async def test_power_entities_empty_when_core_returns_an_object() -> None:
     client = _StatesClient({"message": "unauthorized"})
     assert await client.list_power_entities() == []

--- a/src/astrameter/config/addon_schema_test.py
+++ b/src/astrameter/config/addon_schema_test.py
@@ -67,31 +67,31 @@ def mapped_options() -> set[str]:
     return {option_name(field) for fields in FIELD_LISTS for field in fields}
 
 
-def test_the_schema_block_was_parsed():
+def test_the_schema_block_was_parsed() -> None:
     options = schema_options()
     assert "power_input_alias" in options
     assert "import_trim_w" in options
     assert len(options) > 40
 
 
-def test_every_offered_option_is_consumed():
+def test_every_offered_option_is_consumed() -> None:
     """An option in the add-on UI that nothing reads would silently do nothing."""
     ignored = schema_options() - mapped_options() - HANDLED_IN_CODE
     assert not ignored, f"add-on options nothing reads: {sorted(ignored)}"
 
 
-def test_every_mapped_option_exists_in_the_schema():
+def test_every_mapped_option_exists_in_the_schema() -> None:
     """A mapping naming an option the add-on does not offer can never fire."""
     unknown = mapped_options() - schema_options()
     assert not unknown, f"options mapped but not offered: {sorted(unknown)}"
 
 
-def test_no_stale_entries_in_the_handled_in_code_list():
+def test_no_stale_entries_in_the_handled_in_code_list() -> None:
     stale = HANDLED_IN_CODE - schema_options()
     assert not stale, f"options no longer offered: {sorted(stale)}"
 
 
-def test_an_option_is_read_by_exactly_one_mapping():
+def test_an_option_is_read_by_exactly_one_mapping() -> None:
     seen: dict[str, int] = {}
     for fields in FIELD_LISTS:
         for option in map(option_name, fields):

--- a/src/astrameter/config/addon_test.py
+++ b/src/astrameter/config/addon_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -8,10 +9,11 @@ import pytest
 from astrameter.config import addon
 from astrameter.config.ini_config import IniAppConfig
 from astrameter.config.settings import CtSettings, GeneralSettings
-from astrameter.powermeter import HomeAssistant
+from astrameter.powermeter import HomeAssistant, ThrottledPowermeter
+from astrameter.powermeter.wrappers.base import PowermeterWrapper
 
 
-class FakeSupervisor:
+class FakeSupervisor(addon.SupervisorClient):
     """Stand-in for :class:`addon.SupervisorClient`."""
 
     base_url = addon.SUPERVISOR_BASE_URL
@@ -53,7 +55,7 @@ def config(options: dict[str, Any], supervisor: Any = None) -> addon.AddonAppCon
     return addon.AddonAppConfig(options, client)
 
 
-def test_get_option_treats_missing_null_and_empty_as_unset():
+def test_get_option_treats_missing_null_and_empty_as_unset() -> None:
     options = {"set": "value", "null": None, "empty": "", "blank": "  ", "zero": 0}
     assert addon.get_option(options, "set") == "value"
     assert addon.get_option(options, "missing") is None
@@ -64,7 +66,7 @@ def test_get_option_treats_missing_null_and_empty_as_unset():
     assert addon.get_option(options, "zero", "fallback") == 0
 
 
-def test_general_settings_come_from_the_options():
+def test_general_settings_come_from_the_options() -> None:
     general = config(
         {**BASE_OPTIONS, "device_types": "ct002,ct003", "throttle_interval": 2}
     ).general()
@@ -79,14 +81,14 @@ def test_general_settings_come_from_the_options():
     assert general.web_config_enabled is None
 
 
-def test_untouched_options_keep_the_settings_defaults():
+def test_untouched_options_keep_the_settings_defaults() -> None:
     general = config(BASE_OPTIONS).general()
     ct = config(BASE_OPTIONS).ct("ct002")
     assert general.dedupe_time_window == GeneralSettings().dedupe_time_window
     assert ct == CtSettings()
 
 
-def test_ct_settings_are_typed_values_not_strings():
+def test_ct_settings_are_typed_values_not_strings() -> None:
     ct = config(
         {
             **BASE_OPTIONS,
@@ -114,20 +116,20 @@ def test_ct_settings_are_typed_values_not_strings():
     assert ct.cloud_reporting_interval == 30.0
 
 
-def test_both_ct_emulators_share_the_add_on_settings():
+def test_both_ct_emulators_share_the_add_on_settings() -> None:
     """The add-on has one set of CT options, whichever emulators run."""
     cfg = config({**BASE_OPTIONS, "device_types": "ct002,ct003", "ct_mac": "AA:BB"})
     assert cfg.ct("ct002") == cfg.ct("ct003")
     assert cfg.ct("ct003").ct_mac == "AA:BB"
 
 
-def test_global_dedupe_window_reaches_the_ct_emulator():
+def test_global_dedupe_window_reaches_the_ct_emulator() -> None:
     cfg = config({**BASE_OPTIONS, "dedupe_time_window": 1.5})
     assert cfg.general().dedupe_time_window == 1.5
     assert cfg.ct("ct002").dedupe_time_window == 1.5
 
 
-def test_marstek_needs_the_opt_in_and_credentials():
+def test_marstek_needs_the_opt_in_and_credentials() -> None:
     assert (
         not config(
             {
@@ -160,9 +162,10 @@ def test_marstek_needs_the_opt_in_and_credentials():
     assert marstek.timezone == "Europe/Berlin"
 
 
-def test_single_power_entity_is_read_directly():
+def test_single_power_entity_is_read_directly() -> None:
     cfg = config(BASE_OPTIONS)
     meter = cfg.powermeters(cfg.general())[0][0]
+    assert isinstance(meter, PowermeterWrapper)
     source = meter.wrapped_powermeter
     assert isinstance(source, HomeAssistant)
     assert source.power_calculate is False
@@ -171,13 +174,22 @@ def test_single_power_entity_is_read_directly():
     assert (source.ip, source.port, source.path_prefix) == ("supervisor", "80", "/core")
 
 
-def test_three_phase_entities_are_split_per_phase():
+def _inner_source(cfg: addon.AddonAppConfig) -> HomeAssistant:
+    """The Home Assistant source under the health wrapper the loader adds."""
+    meter = cfg.powermeters(cfg.general())[0][0]
+    assert isinstance(meter, PowermeterWrapper)
+    source = meter.wrapped_powermeter
+    assert isinstance(source, HomeAssistant)
+    return source
+
+
+def test_three_phase_entities_are_split_per_phase() -> None:
     cfg = config({**BASE_OPTIONS, "power_input_alias": "sensor.a, sensor.b ,sensor.c"})
-    source = cfg.powermeters(cfg.general())[0][0].wrapped_powermeter
+    source = _inner_source(cfg)
     assert source.current_power_entity == ["sensor.a", "sensor.b", "sensor.c"]
 
 
-def test_input_and_output_entities_switch_to_calculated_power():
+def test_input_and_output_entities_switch_to_calculated_power() -> None:
     cfg = config(
         {
             **BASE_OPTIONS,
@@ -185,13 +197,13 @@ def test_input_and_output_entities_switch_to_calculated_power():
             "power_output_alias": "sensor.export",
         }
     )
-    source = cfg.powermeters(cfg.general())[0][0].wrapped_powermeter
+    source = _inner_source(cfg)
     assert source.power_calculate is True
     assert source.power_input_alias == ["sensor.import"]
     assert source.power_output_alias == ["sensor.export"]
 
 
-def test_power_source_is_conditioned_by_the_options():
+def test_power_source_is_conditioned_by_the_options() -> None:
     cfg = config(
         {
             **BASE_OPTIONS,
@@ -212,7 +224,7 @@ def test_power_source_is_conditioned_by_the_options():
     # Unwrap the conditioning stack down to the source.
     stack = []
     current = meter
-    while hasattr(current, "wrapped_powermeter"):
+    while isinstance(current, PowermeterWrapper):
         stack.append(type(current).__name__)
         current = current.wrapped_powermeter
     assert isinstance(current, HomeAssistant)
@@ -227,19 +239,20 @@ def test_power_source_is_conditioned_by_the_options():
     ]
 
 
-def test_command_line_throttle_override_reaches_the_power_source():
+def test_command_line_throttle_override_reaches_the_power_source() -> None:
     from dataclasses import replace
 
     cfg = config({**BASE_OPTIONS, "throttle_interval": 1})
     general = cfg.general()
     general = replace(general, signal=replace(general.signal, throttle_interval=9))
     meter = cfg.powermeters(general)[0][0]
+    assert isinstance(meter, PowermeterWrapper)
     throttled = meter.wrapped_powermeter
-    assert type(throttled).__name__ == "ThrottledPowermeter"
+    assert isinstance(throttled, ThrottledPowermeter)
     assert throttled.throttle_interval == 9
 
 
-def test_mqtt_uses_home_assistant_broker_when_offered():
+def test_mqtt_uses_home_assistant_broker_when_offered() -> None:
     supervisor = FakeSupervisor(
         mqtt={
             "host": "core-mosquitto",
@@ -260,7 +273,7 @@ def test_mqtt_uses_home_assistant_broker_when_offered():
     assert insights.addon_slug == "a0ef98c5_b2500_meter"
 
 
-def test_custom_mqtt_uri_wins_over_the_home_assistant_broker():
+def test_custom_mqtt_uri_wins_over_the_home_assistant_broker() -> None:
     supervisor = FakeSupervisor(mqtt={"host": "core-mosquitto", "port": 1883})
     insights = config(
         {**BASE_OPTIONS, "mqtt_uri": "mqtts://user:pw@broker:8883"}, supervisor
@@ -271,18 +284,18 @@ def test_custom_mqtt_uri_wins_over_the_home_assistant_broker():
     assert insights.password == "pw"
 
 
-def test_no_mqtt_without_a_broker():
+def test_no_mqtt_without_a_broker() -> None:
     assert config(BASE_OPTIONS, FakeSupervisor(mqtt=None)).mqtt_insights() is None
 
 
-def test_missing_addon_slug_is_simply_omitted():
+def test_missing_addon_slug_is_simply_omitted() -> None:
     supervisor = FakeSupervisor(mqtt={"host": "core-mosquitto"}, slug="")
     insights = config(BASE_OPTIONS, supervisor).mqtt_insights()
     assert insights is not None
     assert insights.addon_slug is None
 
 
-def test_options_are_read_on_every_call():
+def test_options_are_read_on_every_call() -> None:
     """No snapshot is taken: the options stay the single source of truth."""
     options = dict(BASE_OPTIONS)
     cfg = config(options)
@@ -292,24 +305,24 @@ def test_options_are_read_on_every_call():
     assert cfg.ct("ct002").active_control is False
 
 
-def test_load_options_reads_the_supervisor_file(tmp_path):
+def test_load_options_reads_the_supervisor_file(tmp_path: Path) -> None:
     path = tmp_path / "options.json"
     path.write_text(json.dumps({"device_types": "ct002"}), encoding="utf-8")
     assert addon.load_options(str(path)) == {"device_types": "ct002"}
 
 
 @pytest.mark.parametrize("content", ["not json", '["a", "b"]'])
-def test_load_options_survives_a_broken_file(tmp_path, content):
+def test_load_options_survives_a_broken_file(tmp_path: Path, content: str) -> None:
     path = tmp_path / "options.json"
     path.write_text(content, encoding="utf-8")
     assert addon.load_options(str(path)) == {}
 
 
-def test_load_options_survives_a_missing_file(tmp_path):
+def test_load_options_survives_a_missing_file(tmp_path: Path) -> None:
     assert addon.load_options(str(tmp_path / "nope.json")) == {}
 
 
-def test_custom_config_file_replaces_the_add_on_options(tmp_path):
+def test_custom_config_file_replaces_the_add_on_options(tmp_path: Path) -> None:
     (tmp_path / "my.ini").write_text(
         "[GENERAL]\nDEVICE_TYPE = ct003\n", encoding="utf-8"
     )
@@ -323,7 +336,9 @@ def test_custom_config_file_replaces_the_add_on_options(tmp_path):
     assert cfg.general().device_types == ["ct003"]
 
 
-def test_unknown_custom_config_falls_back_to_the_options(tmp_path, caplog):
+def test_unknown_custom_config_falls_back_to_the_options(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     with caplog.at_level("WARNING"):
         cfg = addon.load_config(
             {**BASE_OPTIONS, "custom_config": "missing.ini"},
@@ -340,7 +355,9 @@ def test_unknown_custom_config_falls_back_to_the_options(tmp_path, caplog):
     "name",
     ["/etc/passwd", "../outside.ini", "nested/../../outside.ini"],
 )
-def test_custom_config_cannot_escape_the_addon_config_mount(tmp_path, caplog, name):
+def test_custom_config_cannot_escape_the_addon_config_mount(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, name: str
+) -> None:
     """The option names a file in the add-on's config mount, nothing else."""
     (tmp_path.parent / "outside.ini").write_text("[GENERAL]\n", encoding="utf-8")
     config_dir = tmp_path / "config"
@@ -359,7 +376,9 @@ def test_custom_config_cannot_escape_the_addon_config_mount(tmp_path, caplog, na
     assert "outside" in caplog.text or "not found" in caplog.text
 
 
-def test_custom_config_warns_about_ignored_ui_options(tmp_path, caplog):
+def test_custom_config_warns_about_ignored_ui_options(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     (tmp_path / "my.ini").write_text("[GENERAL]\n", encoding="utf-8")
     with caplog.at_level("WARNING"):
         addon.load_config(
@@ -376,7 +395,12 @@ def test_custom_config_warns_about_ignored_ui_options(tmp_path, caplog):
     assert "mqtt_uri is ignored" in caplog.text
 
 
-def _custom(tmp_path, caplog, body, level="WARNING"):
+def _custom(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    body: str,
+    level: str = "WARNING",
+) -> GeneralSettings:
     """Load *body* as the add-on's custom config file and return its general()."""
     (tmp_path / "my.ini").write_text(body, encoding="utf-8")
     with caplog.at_level(level):
@@ -388,7 +412,9 @@ def _custom(tmp_path, caplog, body, level="WARNING"):
         return cfg.general()
 
 
-def test_custom_config_still_serves_the_dashboard(tmp_path, caplog):
+def test_custom_config_still_serves_the_dashboard(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """A file that says nothing about the dashboard still gets the panel.
 
     Under the add-on the sidebar panel and the Supervisor watchdog both depend
@@ -403,7 +429,9 @@ def test_custom_config_still_serves_the_dashboard(tmp_path, caplog):
     assert "Ignoring" not in caplog.text
 
 
-def test_custom_config_cannot_turn_the_dashboard_or_web_server_off(tmp_path, caplog):
+def test_custom_config_cannot_turn_the_dashboard_or_web_server_off(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     general = _custom(
         tmp_path,
         caplog,
@@ -417,7 +445,9 @@ def test_custom_config_cannot_turn_the_dashboard_or_web_server_off(tmp_path, cap
     assert "DASHBOARD_ALLOW_WRITE" in caplog.text
 
 
-def test_custom_config_keeps_the_rest_of_its_dashboard_settings(tmp_path, caplog):
+def test_custom_config_keeps_the_rest_of_its_dashboard_settings(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """Only *whether* it runs is forced — what it may do stays the file's."""
     general = _custom(
         tmp_path,
@@ -429,7 +459,7 @@ def test_custom_config_keeps_the_rest_of_its_dashboard_settings(tmp_path, caplog
     assert general.dashboard_direct_access is True
 
 
-def test_wait_for_home_assistant_returns_once_the_api_answers():
+def test_wait_for_home_assistant_returns_once_the_api_answers() -> None:
     class LateSupervisor(FakeSupervisor):
         def home_assistant_ready(self) -> bool:
             self.ready_calls += 1
@@ -444,7 +474,9 @@ def test_wait_for_home_assistant_returns_once_the_api_answers():
     assert slept == [5.0, 5.0]
 
 
-def test_wait_for_home_assistant_gives_up_but_lets_the_app_start(caplog):
+def test_wait_for_home_assistant_gives_up_but_lets_the_app_start(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     supervisor = FakeSupervisor(ready=False)
     with caplog.at_level("WARNING"):
         assert not addon.wait_for_home_assistant(
@@ -465,10 +497,14 @@ class FakeResponse:
         return self._payload
 
 
-def patch_requests(monkeypatch, responses: dict[str, Any]):
+def patch_requests(
+    monkeypatch: pytest.MonkeyPatch, responses: dict[str, Any]
+) -> list[tuple[str, dict[str, str]]]:
     calls: list[tuple[str, dict[str, str]]] = []
 
-    def fake_get(url, headers=None, timeout=None):
+    def fake_get(
+        url: str, headers: dict[str, str] | None = None, timeout: float | None = None
+    ) -> Any:
         calls.append((url, headers or {}))
         response = responses.get(url)
         if isinstance(response, Exception):
@@ -480,7 +516,9 @@ def patch_requests(monkeypatch, responses: dict[str, Any]):
     return calls
 
 
-def test_supervisor_client_reads_the_mqtt_service(monkeypatch):
+def test_supervisor_client_reads_the_mqtt_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     service = {"host": "core-mosquitto", "port": 1883, "ssl": False}
     calls = patch_requests(
         monkeypatch,
@@ -495,7 +533,9 @@ def test_supervisor_client_reads_the_mqtt_service(monkeypatch):
     assert calls[0][1]["Authorization"] == "Bearer tok"
 
 
-def test_supervisor_client_reports_no_mqtt_service_when_unavailable(monkeypatch):
+def test_supervisor_client_reports_no_mqtt_service_when_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     patch_requests(
         monkeypatch,
         {"http://supervisor/services/mqtt": FakeResponse(400, {"result": "error"})},
@@ -503,7 +543,9 @@ def test_supervisor_client_reports_no_mqtt_service_when_unavailable(monkeypatch)
     assert addon.SupervisorClient(token="tok").mqtt_service() is None
 
 
-def test_supervisor_client_survives_a_network_error(monkeypatch):
+def test_supervisor_client_survives_a_network_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     patch_requests(
         monkeypatch,
         {"http://supervisor/addons/self/info": addon.requests.ConnectionError("boom")},
@@ -511,7 +553,9 @@ def test_supervisor_client_survives_a_network_error(monkeypatch):
     assert addon.SupervisorClient(token="tok").addon_slug() == ""
 
 
-def test_supervisor_client_reads_the_addon_slug(monkeypatch):
+def test_supervisor_client_reads_the_addon_slug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     patch_requests(
         monkeypatch,
         {
@@ -523,7 +567,9 @@ def test_supervisor_client_reads_the_addon_slug(monkeypatch):
     assert addon.SupervisorClient(token="tok").addon_slug() == "a0ef98c5_b2500_meter"
 
 
-def test_home_assistant_ready_checks_the_core_api(monkeypatch):
+def test_home_assistant_ready_checks_the_core_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     patch_requests(
         monkeypatch,
         {"http://supervisor/core/api/": FakeResponse(200, {"message": "ok"})},
@@ -531,6 +577,8 @@ def test_home_assistant_ready_checks_the_core_api(monkeypatch):
     assert addon.SupervisorClient(token="tok").home_assistant_ready() is True
 
 
-def test_supervisor_token_defaults_to_the_environment(monkeypatch):
+def test_supervisor_token_defaults_to_the_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("SUPERVISOR_TOKEN", "from-env")
     assert addon.SupervisorClient().token == "from-env"

--- a/src/astrameter/config/config_loader.py
+++ b/src/astrameter/config/config_loader.py
@@ -225,10 +225,10 @@ def new_config_parser() -> configparser.ConfigParser:
 
 
 class ClientFilter:
-    def __init__(self, netmasks: list[IPv4Network]):
+    def __init__(self, netmasks: list[IPv4Network]) -> None:
         self.netmasks = netmasks
 
-    def matches(self, client_ip) -> bool:
+    def matches(self, client_ip: str) -> bool:
         try:
             client_ip_addr = IPv4Address(client_ip)
             for netmask in self.netmasks:

--- a/src/astrameter/config/config_loader.py
+++ b/src/astrameter/config/config_loader.py
@@ -34,6 +34,7 @@ from astrameter.powermeter import (
     Powermeter,
     Refoss,
     Script,
+    Shelly,
     Shelly1PM,
     Shelly3EMPro,
     ShellyEM,
@@ -487,20 +488,25 @@ def create_shelly_powermeter(
     section: str, config: configparser.ConfigParser
 ) -> Powermeter:
     shelly_type = config.get(section, "TYPE", fallback="")
-    shelly_ip = config.get(section, "IP", fallback="")
-    shelly_user = config.get(section, "USER", fallback="")
-    shelly_pass = config.get(section, "PASS", fallback="")
-    meter_index = config.get(section, "METER_INDEX", fallback="")
-    if shelly_type == "1PM":
-        return Shelly1PM(shelly_ip, shelly_user, shelly_pass, meter_index)
-    elif shelly_type == "PLUS1PM":
-        return ShellyPlus1PM(shelly_ip, shelly_user, shelly_pass, meter_index)
-    elif shelly_type == "EM" or shelly_type == "3EM":
-        return ShellyEM(shelly_ip, shelly_user, shelly_pass, meter_index)
-    elif shelly_type == "3EMPro":
-        return Shelly3EMPro(shelly_ip, shelly_user, shelly_pass, meter_index)
-    else:
-        raise Exception(f"Error: unknown Shelly type '{shelly_type}'")
+    models: dict[str, type[Shelly]] = {
+        "1PM": Shelly1PM,
+        "PLUS1PM": ShellyPlus1PM,
+        "EM": ShellyEM,
+        "3EM": ShellyEM,
+        "3EMPro": Shelly3EMPro,
+    }
+    model = models.get(shelly_type)
+    if model is None:
+        raise ValueError(
+            f"Unknown Shelly TYPE {shelly_type!r} in section [{section}]; "
+            f"expected one of {', '.join(models)}"
+        )
+    return model(
+        config.get(section, "IP", fallback=""),
+        config.get(section, "USER", fallback=""),
+        config.get(section, "PASS", fallback=""),
+        config.get(section, "METER_INDEX", fallback=""),
+    )
 
 
 def create_amisreader_powermeter(
@@ -536,19 +542,16 @@ def create_sml_powermeter(
 def create_mqtt_powermeter(
     section: str, config: configparser.ConfigParser
 ) -> Powermeter:
-    # Multi-topic: TOPICS takes precedence over TOPIC
-    topics_raw = config.get(section, "TOPICS", fallback=None)
-    if topics_raw:
-        topic: str | list[str] = split_csv(topics_raw)
-    else:
-        topic = config.get(section, "TOPIC", fallback="")
-
-    # Multi-path: JSON_PATHS takes precedence over JSON_PATH
-    json_paths_raw = config.get(section, "JSON_PATHS", fallback=None)
-    if json_paths_raw:
-        json_path: str | list[str] | None = split_csv(json_paths_raw)
-    else:
-        json_path = config.get(section, "JSON_PATH", fallback=None)
+    # The plural key wins where both are set: a list of one is still a list,
+    # which is one value per phase rather than the single value TOPIC means.
+    topics = config.get(section, "TOPICS", fallback="")
+    single_topic: str = config.get(section, "TOPIC", fallback="")
+    topic: str | list[str] = split_csv(topics) if topics else single_topic
+    json_paths = config.get(section, "JSON_PATHS", fallback="")
+    single_path: str | None = config.get(section, "JSON_PATH", fallback=None)
+    json_path: str | list[str] | None = (
+        split_csv(json_paths) if json_paths else single_path
+    )
 
     broker = read_mqtt_connection(section, config)
     return MqttPowermeter(
@@ -637,31 +640,13 @@ def create_vzlogger_powermeter(
     return VZLogger(
         config.get(section, "IP", fallback=""),
         config.get(section, "PORT", fallback=""),
-        _split_labels(config.get(section, "UUID", fallback="")),
+        one_or_blank(config.get(section, "UUID", fallback="")),
     )
 
 
 def create_homeassistant_powermeter(
     section: str, config: configparser.ConfigParser
 ) -> Powermeter:
-    # Split entity strings on commas and strip whitespace
-    def parse_entities(value: str) -> str | list[str]:
-        if not value:
-            return ""
-        entities = [entity.strip() for entity in value.split(",")]
-        # Return single string if only one entity, otherwise return list
-        return entities[0] if len(entities) == 1 else entities
-
-    current_power_entity = parse_entities(
-        config.get(section, "CURRENT_POWER_ENTITY", fallback="")
-    )
-    power_input_alias = parse_entities(
-        config.get(section, "POWER_INPUT_ALIAS", fallback="")
-    )
-    power_output_alias = parse_entities(
-        config.get(section, "POWER_OUTPUT_ALIAS", fallback="")
-    )
-
     ip = config.get(section, "IP", fallback="")
     if ip == "supervisor":
 
@@ -679,10 +664,10 @@ def create_homeassistant_powermeter(
         config.get(section, "PORT", fallback=""),
         config.getboolean(section, "HTTPS", fallback=False),
         token_getter,
-        current_power_entity,
+        one_or_blank(config.get(section, "CURRENT_POWER_ENTITY", fallback="")),
         config.getboolean(section, "POWER_CALCULATE", fallback=False),
-        power_input_alias,
-        power_output_alias,
+        one_or_blank(config.get(section, "POWER_INPUT_ALIAS", fallback="")),
+        one_or_blank(config.get(section, "POWER_OUTPUT_ALIAS", fallback="")),
         config.get(section, "API_PATH_PREFIX", fallback=None),
     )
 
@@ -720,8 +705,8 @@ def create_shrdzm_powermeter(
     )
 
 
-def _split_labels(raw: str) -> str | list[str]:
-    """Like :func:`one_or_many`, but no label at all is "" rather than []."""
+def one_or_blank(raw: str) -> str | list[str]:
+    """Like :func:`one_or_many`, but an unset key is "" rather than []."""
     return one_or_many(raw) or ""
 
 
@@ -734,9 +719,9 @@ def create_tasmota_powermeter(
         config.get(section, "PASS", fallback=""),
         config.get(section, "JSON_STATUS", fallback=""),
         config.get(section, "JSON_PAYLOAD_MQTT_PREFIX", fallback=""),
-        _split_labels(config.get(section, "JSON_POWER_MQTT_LABEL", fallback="")),
-        _split_labels(config.get(section, "JSON_POWER_INPUT_MQTT_LABEL", fallback="")),
-        _split_labels(config.get(section, "JSON_POWER_OUTPUT_MQTT_LABEL", fallback="")),
+        one_or_blank(config.get(section, "JSON_POWER_MQTT_LABEL", fallback="")),
+        one_or_blank(config.get(section, "JSON_POWER_INPUT_MQTT_LABEL", fallback="")),
+        one_or_blank(config.get(section, "JSON_POWER_OUTPUT_MQTT_LABEL", fallback="")),
         config.getboolean(section, "JSON_POWER_CALCULATE", fallback=False),
     )
 

--- a/src/astrameter/config/config_loader.py
+++ b/src/astrameter/config/config_loader.py
@@ -387,7 +387,10 @@ def apply_signal_wrappers(
         offsets = signal.offsets if signal.offsets is not None else [0.0]
         multipliers = signal.multipliers if signal.multipliers is not None else [1.0]
         logger.info(
-            f"Applying power transform (multiplier={multipliers}, offset={offsets}) to {name}"
+            "Applying power transform (multiplier=%s, offset=%s) to %s",
+            multipliers,
+            offsets,
+            name,
         )
         powermeter = TransformedPowermeter(powermeter, offsets, multipliers)
 

--- a/src/astrameter/config/config_loader_test.py
+++ b/src/astrameter/config/config_loader_test.py
@@ -5,7 +5,6 @@ import pytest
 
 from astrameter.config.config_loader import (
     ClientFilter,
-    _split_labels,
     create_amisreader_powermeter,
     create_client_filter,
     create_emlog_powermeter,
@@ -29,12 +28,19 @@ from astrameter.config.config_loader import (
     create_tibber_pulse_powermeter,
     create_tq_em_powermeter,
     create_vzlogger_powermeter,
+    one_or_blank,
     parse_float_list,
     parse_mqtt_uri,
     read_all_powermeter_configs,
     read_mqtt_insights_config,
 )
-from astrameter.powermeter import TransformedPowermeter
+from astrameter.powermeter import (
+    Shelly1PM,
+    Shelly3EMPro,
+    ShellyEM,
+    ShellyPlus1PM,
+    TransformedPowermeter,
+)
 
 
 def test_client_filter():
@@ -57,47 +63,46 @@ def test_create_client_filter():
     create_client_filter("TEST2", config)
 
 
-def test_create_shelly_powermeter():
-    """Test Shelly powermeter creation."""
+@pytest.mark.parametrize(
+    ("shelly_type", "expected"),
+    [
+        ("1PM", Shelly1PM),
+        ("PLUS1PM", ShellyPlus1PM),
+        ("EM", ShellyEM),
+        ("3EM", ShellyEM),
+        ("3EMPro", Shelly3EMPro),
+    ],
+)
+def test_create_shelly_powermeter(shelly_type, expected):
+    """Each TYPE picks its own class, and every one gets the same connection."""
     config = configparser.ConfigParser()
+    config["SHELLY"] = {
+        "TYPE": shelly_type,
+        "IP": "127.0.0.1",
+        "USER": "u",
+        "PASS": "p",
+        "METER_INDEX": "1",
+    }
+    meter = create_shelly_powermeter("SHELLY", config)
+    assert type(meter) is expected
+    assert (meter.ip, meter.user, meter.password) == ("127.0.0.1", "u", "p")
 
-    # Note: These won't connect to real devices, but test that
-    # the creation logic works
 
-    # Test all Shelly types with minimal config
-    config["SHELLY1"] = {"TYPE": "1PM", "IP": "127.0.0.1"}
-    config["SHELLY2"] = {"TYPE": "PLUS1PM", "IP": "127.0.0.1"}
-    config["SHELLY3"] = {"TYPE": "EM", "IP": "127.0.0.1"}
-    config["SHELLY4"] = {"TYPE": "3EM", "IP": "127.0.0.1"}
-    config["SHELLY5"] = {"TYPE": "3EMPro", "IP": "127.0.0.1"}
-
-    # Just verify these run without exceptions
-    try:
-        create_shelly_powermeter("SHELLY1", config)
-        create_shelly_powermeter("SHELLY2", config)
-        create_shelly_powermeter("SHELLY3", config)
-        create_shelly_powermeter("SHELLY4", config)
-        create_shelly_powermeter("SHELLY5", config)
-    except Exception as e:
-        if "Connection" not in str(e):  # Ignore expected connection errors
-            raise
-
-    # Test invalid type - should raise an exception
-    config["SHELLY_INVALID"] = {"TYPE": "INVALID", "IP": "127.0.0.1"}
-    with pytest.raises(Exception, match="unknown Shelly"):
-        create_shelly_powermeter("SHELLY_INVALID", config)
+def test_create_shelly_powermeter_rejects_an_unknown_type():
+    """The message has to name the types, or the only clue is a stack trace."""
+    config = configparser.ConfigParser()
+    config["SHELLY"] = {"TYPE": "INVALID", "IP": "127.0.0.1"}
+    with pytest.raises(ValueError, match="Unknown Shelly TYPE 'INVALID'"):
+        create_shelly_powermeter("SHELLY", config)
 
 
 def test_create_tasmota_powermeter():
-    """Test Tasmota powermeter creation."""
+    """A lone label reaches the meter as the one phase it names."""
     config = configparser.ConfigParser()
-    config["TASMOTA"] = {"IP": "127.0.0.1"}
-
-    try:
-        create_tasmota_powermeter("TASMOTA", config)
-    except Exception as e:
-        if "Connection" not in str(e):  # Ignore expected connection errors
-            raise
+    config["TASMOTA"] = {"IP": "127.0.0.1", "JSON_POWER_MQTT_LABEL": "Power"}
+    meter = create_tasmota_powermeter("TASMOTA", config)
+    assert meter.ip == "127.0.0.1"
+    assert meter.json_power_mqtt_labels == ["Power"]
 
 
 def test_create_tasmota_powermeter_three_phase():
@@ -117,21 +122,21 @@ def test_create_tasmota_powermeter_three_phase():
     assert meter.json_power_output_mqtt_labels == ["Out_L1", "Out_L2", "Out_L3"]
 
 
-def test_split_labels():
-    """Test _split_labels helper."""
-    assert _split_labels("") == ""
-    assert _split_labels("Power") == "Power"
-    assert _split_labels("Power_L1,Power_L2,Power_L3") == [
+def test_one_or_blank():
+    """Test the one_or_blank helper."""
+    assert one_or_blank("") == ""
+    assert one_or_blank("Power") == "Power"
+    assert one_or_blank("Power_L1,Power_L2,Power_L3") == [
         "Power_L1",
         "Power_L2",
         "Power_L3",
     ]
-    assert _split_labels("Power_L1 , Power_L2 , Power_L3") == [
+    assert one_or_blank("Power_L1 , Power_L2 , Power_L3") == [
         "Power_L1",
         "Power_L2",
         "Power_L3",
     ]
-    assert _split_labels(" , , ") == ""
+    assert one_or_blank(" , , ") == ""
 
 
 def test_create_shrdzm_powermeter():

--- a/src/astrameter/config/config_loader_test.py
+++ b/src/astrameter/config/config_loader_test.py
@@ -35,15 +35,27 @@ from astrameter.config.config_loader import (
     read_mqtt_insights_config,
 )
 from astrameter.powermeter import (
+    ESPHomeNative,
+    FritzSmartEnergy,
+    Fronius,
+    HomeAssistant,
+    MqttPowermeter,
+    Powermeter,
+    Refoss,
+    Shelly,
     Shelly1PM,
     Shelly3EMPro,
     ShellyEM,
     ShellyPlus1PM,
+    Sml,
+    Tasmota,
+    TibberPulse,
     TransformedPowermeter,
 )
+from astrameter.powermeter.wrappers.base import PowermeterWrapper
 
 
-def test_client_filter():
+def test_client_filter() -> None:
     """Basic test for ClientFilter."""
     filter = ClientFilter([IPv4Network("192.168.1.0/24")])
     # Just verify it runs without raising exceptions
@@ -52,7 +64,7 @@ def test_client_filter():
     filter.matches("invalid_ip")  # Should handle invalid
 
 
-def test_create_client_filter():
+def test_create_client_filter() -> None:
     """Test create_client_filter with various inputs."""
     config = configparser.ConfigParser()
     config["TEST1"] = {"NETMASK": "192.168.1.0/24,10.0.0.0/8"}
@@ -73,7 +85,7 @@ def test_create_client_filter():
         ("3EMPro", Shelly3EMPro),
     ],
 )
-def test_create_shelly_powermeter(shelly_type, expected):
+def test_create_shelly_powermeter(shelly_type: str, expected: type[Powermeter]) -> None:
     """Each TYPE picks its own class, and every one gets the same connection."""
     config = configparser.ConfigParser()
     config["SHELLY"] = {
@@ -85,10 +97,11 @@ def test_create_shelly_powermeter(shelly_type, expected):
     }
     meter = create_shelly_powermeter("SHELLY", config)
     assert type(meter) is expected
+    assert isinstance(meter, Shelly)
     assert (meter.ip, meter.user, meter.password) == ("127.0.0.1", "u", "p")
 
 
-def test_create_shelly_powermeter_rejects_an_unknown_type():
+def test_create_shelly_powermeter_rejects_an_unknown_type() -> None:
     """The message has to name the types, or the only clue is a stack trace."""
     config = configparser.ConfigParser()
     config["SHELLY"] = {"TYPE": "INVALID", "IP": "127.0.0.1"}
@@ -96,16 +109,17 @@ def test_create_shelly_powermeter_rejects_an_unknown_type():
         create_shelly_powermeter("SHELLY", config)
 
 
-def test_create_tasmota_powermeter():
+def test_create_tasmota_powermeter() -> None:
     """A lone label reaches the meter as the one phase it names."""
     config = configparser.ConfigParser()
     config["TASMOTA"] = {"IP": "127.0.0.1", "JSON_POWER_MQTT_LABEL": "Power"}
     meter = create_tasmota_powermeter("TASMOTA", config)
+    assert isinstance(meter, Tasmota)
     assert meter.ip == "127.0.0.1"
     assert meter.json_power_mqtt_labels == ["Power"]
 
 
-def test_create_tasmota_powermeter_three_phase():
+def test_create_tasmota_powermeter_three_phase() -> None:
     """Test Tasmota powermeter creation with comma-separated labels."""
     config = configparser.ConfigParser()
     config["TASMOTA"] = {
@@ -117,12 +131,13 @@ def test_create_tasmota_powermeter_three_phase():
         "JSON_POWER_OUTPUT_MQTT_LABEL": "Out_L1, Out_L2, Out_L3",
     }
     meter = create_tasmota_powermeter("TASMOTA", config)
+    assert isinstance(meter, Tasmota)
     assert meter.json_power_mqtt_labels == ["Power_L1", "Power_L2", "Power_L3"]
     assert meter.json_power_input_mqtt_labels == ["In_L1", "In_L2", "In_L3"]
     assert meter.json_power_output_mqtt_labels == ["Out_L1", "Out_L2", "Out_L3"]
 
 
-def test_one_or_blank():
+def test_one_or_blank() -> None:
     """Test the one_or_blank helper."""
     assert one_or_blank("") == ""
     assert one_or_blank("Power") == "Power"
@@ -139,7 +154,7 @@ def test_one_or_blank():
     assert one_or_blank(" , , ") == ""
 
 
-def test_create_shrdzm_powermeter():
+def test_create_shrdzm_powermeter() -> None:
     """Test Shrdzm powermeter creation."""
     config = configparser.ConfigParser()
     config["SHRDZM"] = {"IP": "127.0.0.1"}
@@ -151,7 +166,7 @@ def test_create_shrdzm_powermeter():
             raise
 
 
-def test_create_emlog_powermeter():
+def test_create_emlog_powermeter() -> None:
     """Test Emlog powermeter creation."""
     config = configparser.ConfigParser()
     config["EMLOG"] = {"IP": "127.0.0.1"}
@@ -163,7 +178,7 @@ def test_create_emlog_powermeter():
             raise
 
 
-def test_create_iobroker_powermeter():
+def test_create_iobroker_powermeter() -> None:
     """Test IoBroker powermeter creation."""
     config = configparser.ConfigParser()
     config["IOBROKER"] = {"IP": "127.0.0.1"}
@@ -175,7 +190,7 @@ def test_create_iobroker_powermeter():
             raise
 
 
-def test_create_homeassistant_powermeter():
+def test_create_homeassistant_powermeter() -> None:
     """Test HomeAssistant powermeter creation."""
     config = configparser.ConfigParser()
 
@@ -198,7 +213,9 @@ def test_create_homeassistant_powermeter():
             raise
 
 
-def test_create_homeassistant_powermeter_supervisor_token(monkeypatch):
+def test_create_homeassistant_powermeter_supervisor_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """IP=supervisor reads SUPERVISOR_TOKEN from env at call time, not from config."""
     import configparser as _cp
 
@@ -211,13 +228,14 @@ def test_create_homeassistant_powermeter_supervisor_token(monkeypatch):
         "ACCESSTOKEN": "stale-token",
     }
     pm = create_homeassistant_powermeter("HA", config)
+    assert isinstance(pm, HomeAssistant)
     assert pm._token() == "initial-token"
 
     monkeypatch.setenv("SUPERVISOR_TOKEN", "rotated-token")
     assert pm._token() == "rotated-token"
 
 
-def test_create_vzlogger_powermeter():
+def test_create_vzlogger_powermeter() -> None:
     """Test VZLogger powermeter creation."""
     config = configparser.ConfigParser()
     config["VZLOGGER"] = {"IP": "127.0.0.1"}
@@ -229,7 +247,7 @@ def test_create_vzlogger_powermeter():
             raise
 
 
-def test_create_script_powermeter():
+def test_create_script_powermeter() -> None:
     """Test Script powermeter creation."""
     config = configparser.ConfigParser()
     config["SCRIPT"] = {"COMMAND": 'echo "test"'}
@@ -241,7 +259,7 @@ def test_create_script_powermeter():
             raise
 
 
-def test_create_esphome_powermeter():
+def test_create_esphome_powermeter() -> None:
     """Test ESPHome powermeter creation."""
     config = configparser.ConfigParser()
     config["ESPHOME"] = {"IP": "127.0.0.1"}
@@ -253,7 +271,7 @@ def test_create_esphome_powermeter():
             raise
 
 
-async def test_create_esphomenative_powermeter():
+async def test_create_esphomenative_powermeter() -> None:
     """Test ESPHome native API powermeter creation (reads all keys)."""
     config = configparser.ConfigParser()
     config["ESPHOMENATIVE"] = {
@@ -264,12 +282,13 @@ async def test_create_esphomenative_powermeter():
         "CLIENT_INFO": "MyClient",
     }
     pm = create_esphomenative_powermeter("ESPHOMENATIVE", config)
+    assert isinstance(pm, ESPHomeNative)
     assert pm.address == "device.local"
     assert pm.port == 6054
     assert pm.object_id == "grid_power"
 
 
-async def test_create_esphomenative_powermeter_defaults():
+async def test_create_esphomenative_powermeter_defaults() -> None:
     """PORT defaults to 6053 and CLIENT_INFO to AstraMeter."""
     config = configparser.ConfigParser()
     config["ESPHOMENATIVE"] = {
@@ -278,11 +297,12 @@ async def test_create_esphomenative_powermeter_defaults():
         "OBJECT_ID": "grid_power",
     }
     pm = create_esphomenative_powermeter("ESPHOMENATIVE", config)
+    assert isinstance(pm, ESPHomeNative)
     assert pm.port == 6053
     assert pm.object_id == "grid_power"
 
 
-def test_create_amisreader_powermeter():
+def test_create_amisreader_powermeter() -> None:
     """Test AMIS Reader powermeter creation."""
     config = configparser.ConfigParser()
     config["AMIS_READER"] = {"IP": "127.0.0.1"}
@@ -294,7 +314,7 @@ def test_create_amisreader_powermeter():
             raise
 
 
-def test_create_modbus_powermeter():
+def test_create_modbus_powermeter() -> None:
     """Test Modbus powermeter creation."""
     config = configparser.ConfigParser()
     config["MODBUS"] = {"HOST": "127.0.0.1"}
@@ -306,7 +326,7 @@ def test_create_modbus_powermeter():
             raise
 
 
-def test_create_mqtt_powermeter():
+def test_create_mqtt_powermeter() -> None:
     """Test MQTT powermeter creation."""
     config = configparser.ConfigParser()
     config["MQTT"] = {"BROKER": "127.0.0.1"}
@@ -319,7 +339,7 @@ def test_create_mqtt_powermeter():
             raise
 
 
-def test_create_mqtt_powermeter_with_topics():
+def test_create_mqtt_powermeter_with_topics() -> None:
     """Test MQTT powermeter creation with multi-phase TOPICS."""
     config = configparser.ConfigParser()
     config["MQTT"] = {
@@ -327,6 +347,7 @@ def test_create_mqtt_powermeter_with_topics():
         "TOPICS": "home/l1, home/l2, home/l3",
     }
     pm = create_mqtt_powermeter("MQTT", config)
+    assert isinstance(pm, MqttPowermeter)
     assert len(pm._subscriptions) == 3
     assert pm._subscriptions == [
         ("home/l1", None),
@@ -335,7 +356,7 @@ def test_create_mqtt_powermeter_with_topics():
     ]
 
 
-def test_create_mqtt_powermeter_with_json_paths():
+def test_create_mqtt_powermeter_with_json_paths() -> None:
     """Test MQTT powermeter creation with single TOPIC and multiple JSON_PATHS."""
     config = configparser.ConfigParser()
     config["MQTT"] = {
@@ -344,13 +365,14 @@ def test_create_mqtt_powermeter_with_json_paths():
         "JSON_PATHS": "$.l1.power, $.l2.power, $.l3.power",
     }
     pm = create_mqtt_powermeter("MQTT", config)
+    assert isinstance(pm, MqttPowermeter)
     assert len(pm._subscriptions) == 3
     assert pm._subscriptions[0] == ("home/power", "$.l1.power")
     assert pm._subscriptions[1] == ("home/power", "$.l2.power")
     assert pm._subscriptions[2] == ("home/power", "$.l3.power")
 
 
-def test_parse_mqtt_uri_full():
+def test_parse_mqtt_uri_full() -> None:
     parts = parse_mqtt_uri("mqtt://alice:s%40cret@broker.example.com:1884")
     assert parts.host == "broker.example.com"
     assert parts.port == 1884
@@ -359,7 +381,7 @@ def test_parse_mqtt_uri_full():
     assert parts.tls is False
 
 
-def test_parse_mqtt_uri_mqtts_default_port():
+def test_parse_mqtt_uri_mqtts_default_port() -> None:
     parts = parse_mqtt_uri("mqtts://broker.example.com")
     assert parts.host == "broker.example.com"
     assert parts.port == 8883
@@ -368,55 +390,56 @@ def test_parse_mqtt_uri_mqtts_default_port():
     assert parts.tls is True
 
 
-def test_parse_mqtt_uri_mqtt_default_port():
+def test_parse_mqtt_uri_mqtt_default_port() -> None:
     parts = parse_mqtt_uri("mqtt://broker.example.com")
     assert parts.port == 1883
     assert parts.tls is False
 
 
-def test_parse_mqtt_uri_invalid_scheme():
+def test_parse_mqtt_uri_invalid_scheme() -> None:
     with pytest.raises(ValueError):
         parse_mqtt_uri("http://broker.example.com")
 
 
-def test_parse_mqtt_uri_missing_host():
+def test_parse_mqtt_uri_missing_host() -> None:
     with pytest.raises(ValueError):
         parse_mqtt_uri("mqtt://")
 
 
-def test_parse_mqtt_uri_empty():
+def test_parse_mqtt_uri_empty() -> None:
     with pytest.raises(ValueError):
         parse_mqtt_uri("")
 
 
-def test_parse_mqtt_uri_rejects_path():
+def test_parse_mqtt_uri_rejects_path() -> None:
     with pytest.raises(ValueError, match="path"):
         parse_mqtt_uri("mqtt://broker.example.com/some/path")
 
 
-def test_parse_mqtt_uri_allows_trailing_slash():
+def test_parse_mqtt_uri_allows_trailing_slash() -> None:
     parts = parse_mqtt_uri("mqtt://broker.example.com:1883/")
     assert parts.host == "broker.example.com"
     assert parts.port == 1883
 
 
-def test_parse_mqtt_uri_rejects_query():
+def test_parse_mqtt_uri_rejects_query() -> None:
     with pytest.raises(ValueError, match="query"):
         parse_mqtt_uri("mqtt://broker.example.com?clientId=foo")
 
 
-def test_parse_mqtt_uri_rejects_fragment():
+def test_parse_mqtt_uri_rejects_fragment() -> None:
     with pytest.raises(ValueError, match="fragment"):
         parse_mqtt_uri("mqtt://broker.example.com#frag")
 
 
-def test_create_mqtt_powermeter_with_uri():
+def test_create_mqtt_powermeter_with_uri() -> None:
     config = configparser.ConfigParser()
     config["MQTT"] = {
         "URI": "mqtts://alice:secret@broker.example.com:8884",
         "TOPIC": "home/power",
     }
     pm = create_mqtt_powermeter("MQTT", config)
+    assert isinstance(pm, MqttPowermeter)
     assert pm.broker == "broker.example.com"
     assert pm.port == 8884
     assert pm.username == "alice"
@@ -424,7 +447,7 @@ def test_create_mqtt_powermeter_with_uri():
     assert pm.tls is True
 
 
-def test_read_mqtt_insights_config_with_uri():
+def test_read_mqtt_insights_config_with_uri() -> None:
     config = configparser.ConfigParser()
     config["MQTT_INSIGHTS"] = {
         "URI": "mqtt://bob:pw@192.168.1.50:1885",
@@ -438,7 +461,7 @@ def test_read_mqtt_insights_config_with_uri():
     assert cfg.tls is False
 
 
-def test_read_mqtt_insights_config_with_mqtts_uri():
+def test_read_mqtt_insights_config_with_mqtts_uri() -> None:
     config = configparser.ConfigParser()
     config["MQTT_INSIGHTS"] = {
         "URI": "mqtts://broker.example.com",
@@ -451,7 +474,7 @@ def test_read_mqtt_insights_config_with_mqtts_uri():
     assert cfg.password is None
 
 
-def test_read_mqtt_insights_config_without_uri():
+def test_read_mqtt_insights_config_without_uri() -> None:
     """Plain BROKER/PORT/USERNAME/PASSWORD/TLS still works."""
     config = configparser.ConfigParser()
     config["MQTT_INSIGHTS"] = {
@@ -470,7 +493,7 @@ def test_read_mqtt_insights_config_without_uri():
     assert cfg.tls is True
 
 
-def test_create_mqtt_powermeter_topics_takes_precedence_over_topic():
+def test_create_mqtt_powermeter_topics_takes_precedence_over_topic() -> None:
     """Test that TOPICS takes precedence over TOPIC when both are set."""
     config = configparser.ConfigParser()
     config["MQTT"] = {
@@ -479,12 +502,13 @@ def test_create_mqtt_powermeter_topics_takes_precedence_over_topic():
         "TOPICS": "home/l1, home/l2",
     }
     pm = create_mqtt_powermeter("MQTT", config)
+    assert isinstance(pm, MqttPowermeter)
     assert len(pm._subscriptions) == 2
     assert pm._subscriptions[0][0] == "home/l1"
     assert pm._subscriptions[1][0] == "home/l2"
 
 
-def test_create_json_http_powermeter():
+def test_create_json_http_powermeter() -> None:
     """Test JSON HTTP powermeter creation."""
     config = configparser.ConfigParser()
     config["JSON_HTTP"] = {"URL": "http://localhost", "JSON_PATHS": "$.power"}
@@ -496,7 +520,7 @@ def test_create_json_http_powermeter():
             raise
 
 
-def test_create_tq_em_powermeter():
+def test_create_tq_em_powermeter() -> None:
     """Test TQ Energy Manager powermeter creation."""
     config = configparser.ConfigParser()
     config["TQ_EM"] = {"IP": "127.0.0.1"}
@@ -508,7 +532,7 @@ def test_create_tq_em_powermeter():
             raise
 
 
-def test_create_homewizard_powermeter():
+def test_create_homewizard_powermeter() -> None:
     """Test HomeWizard powermeter creation."""
     config = configparser.ConfigParser()
     config["HOMEWIZARD"] = {
@@ -524,7 +548,7 @@ def test_create_homewizard_powermeter():
             raise
 
 
-def test_create_fritz_powermeter():
+def test_create_fritz_powermeter() -> None:
     """Test FRITZ!Smart Energy powermeter creation and AIN suffix defaulting."""
     config = configparser.ConfigParser()
     config["FRITZ"] = {
@@ -534,43 +558,49 @@ def test_create_fritz_powermeter():
         "AIN": "12345 0123456",
     }
     pm = create_fritz_powermeter("FRITZ", config)
+    assert isinstance(pm, FritzSmartEnergy)
     assert pm._base_url == "http://fritz.box"
     assert pm._ain == "123450123456-1"
 
 
-def test_create_fronius_powermeter():
+def test_create_fronius_powermeter() -> None:
     """Test Fronius powermeter creation and DeviceId defaulting."""
     config = configparser.ConfigParser()
     config["FRONIUS"] = {"IP": "127.0.0.1"}
     pm = create_fronius_powermeter("FRONIUS", config)
+    assert isinstance(pm, Fronius)
     assert pm.ip == "127.0.0.1"
     assert pm.device_id == "0"
     assert pm.per_phase is False
 
     config["FRONIUS_2"] = {"IP": "127.0.0.1", "DEVICE_ID": "1", "PER_PHASE": "True"}
     pm = create_fronius_powermeter("FRONIUS_2", config)
+    assert isinstance(pm, Fronius)
     assert pm.device_id == "1"
     assert pm.per_phase is True
 
 
-def test_create_refoss_powermeter():
+def test_create_refoss_powermeter() -> None:
     """Test Refoss/Meross powermeter creation and CHANNELS parsing."""
     config = configparser.ConfigParser()
     config["REFOSS"] = {"IP": "192.168.1.150"}
     pm = create_refoss_powermeter("REFOSS", config)
+    assert isinstance(pm, Refoss)
     assert pm.ip == "192.168.1.150"
     assert pm.channels == [1]
 
     config["MEROSS"] = {"IP": "192.168.1.150", "CHANNELS": "1,2,3"}
     pm = create_refoss_powermeter("MEROSS", config)
+    assert isinstance(pm, Refoss)
     assert pm.channels == [1, 2, 3]
 
 
-def test_create_tibber_pulse_powermeter():
+def test_create_tibber_pulse_powermeter() -> None:
     """Test Tibber Pulse powermeter creation, defaults, and OBIS overrides."""
     config = configparser.ConfigParser()
     config["TIBBER_PULSE"] = {"IP": "127.0.0.1", "PASSWORD": "AD56-54BA"}
     pm = create_tibber_pulse_powermeter("TIBBER_PULSE", config)
+    assert isinstance(pm, TibberPulse)
     assert pm.ip == "127.0.0.1"
     assert pm.password == "AD56-54BA"
     assert pm.node_id == "1"
@@ -586,17 +616,19 @@ def test_create_tibber_pulse_powermeter():
         "OBIS_POWER_CURRENT": "0100100700ff",
     }
     pm = create_tibber_pulse_powermeter("TIBBER_PULSE_2", config)
+    assert isinstance(pm, TibberPulse)
     assert pm.node_id == "2"
     assert pm.user == "root"
     assert pm.timeout == 10.0
     assert pm._obis_current == "0100100700ff"
 
 
-def test_create_sml_powermeter():
+def test_create_sml_powermeter() -> None:
     """Test SML powermeter creation: SERIAL required, OBIS overrides applied."""
     config = configparser.ConfigParser()
     config["SML"] = {"SERIAL": "/dev/ttyUSB0"}
     pm = create_sml_powermeter("SML", config)
+    assert isinstance(pm, Sml)
     assert pm._serial_device == "/dev/ttyUSB0"
 
     config = configparser.ConfigParser()
@@ -605,10 +637,11 @@ def test_create_sml_powermeter():
         "OBIS_POWER_CURRENT": "0100100700ff",
     }
     pm = create_sml_powermeter("SML", config)
+    assert isinstance(pm, Sml)
     assert pm._obis_current == "0100100700ff"
 
 
-def test_create_sml_powermeter_requires_serial():
+def test_create_sml_powermeter_requires_serial() -> None:
     """Section [SML] must define non-empty SERIAL."""
     config = configparser.ConfigParser()
     config["SML"] = {}
@@ -621,7 +654,7 @@ def test_create_sml_powermeter_requires_serial():
         create_sml_powermeter("SML", config)
 
 
-def test_create_powermeter():
+def test_create_powermeter() -> None:
     """Test the main create_powermeter function."""
     config = configparser.ConfigParser()
 
@@ -673,7 +706,7 @@ def test_create_powermeter():
                 raise
 
 
-def test_read_all_powermeter_configs():
+def test_read_all_powermeter_configs() -> None:
     """Test reading all powermeter configs."""
     config = configparser.ConfigParser()
     config["SHELLY_1"] = {"TYPE": "1PM", "IP": "127.0.0.1"}
@@ -693,7 +726,7 @@ def test_read_all_powermeter_configs():
             raise
 
 
-def test_parse_float_list():
+def test_parse_float_list() -> None:
     """Test parsing comma-separated float lists."""
     assert parse_float_list("10", "KEY", "SECTION") == [10.0]
     assert parse_float_list("1.5, 2.5, 3.5", "KEY", "SECTION") == [1.5, 2.5, 3.5]
@@ -702,13 +735,13 @@ def test_parse_float_list():
     assert parse_float_list("", "KEY", "SECTION") == [0.0]
 
 
-def test_parse_float_list_invalid():
+def test_parse_float_list_invalid() -> None:
     """Test that invalid float values raise ValueError with clear message."""
     with pytest.raises(ValueError, match="Invalid POWER_OFFSET value 'abc'"):
         parse_float_list("abc", "POWER_OFFSET", "SHELLY_1")
 
 
-def test_read_all_configs_with_power_transform():
+def test_read_all_configs_with_power_transform() -> None:
     """Test that POWER_OFFSET and POWER_MULTIPLIER wrap the powermeter."""
     config = configparser.ConfigParser()
     config["SCRIPT_1"] = {
@@ -720,13 +753,14 @@ def test_read_all_configs_with_power_transform():
     powermeters = read_all_powermeter_configs(config)
     assert len(powermeters) == 1
     pm, _, _ = powermeters[0]
+    assert isinstance(pm, PowermeterWrapper)
     pm = pm.wrapped_powermeter  # unwrap outermost HealthTrackingPowermeter
     assert isinstance(pm, TransformedPowermeter)
     assert pm.offsets == [-50.0]
     assert pm.multipliers == [1.05]
 
 
-def test_read_all_configs_with_per_phase_transform():
+def test_read_all_configs_with_per_phase_transform() -> None:
     """Test per-phase offset and multiplier values."""
     config = configparser.ConfigParser()
     config["SCRIPT_1"] = {
@@ -738,13 +772,14 @@ def test_read_all_configs_with_per_phase_transform():
     powermeters = read_all_powermeter_configs(config)
     assert len(powermeters) == 1
     pm, _, _ = powermeters[0]
+    assert isinstance(pm, PowermeterWrapper)
     pm = pm.wrapped_powermeter  # unwrap outermost HealthTrackingPowermeter
     assert isinstance(pm, TransformedPowermeter)
     assert pm.offsets == [-10.0, -20.0, -30.0]
     assert pm.multipliers == [1.05, 1.02, 1.03]
 
 
-def test_read_all_configs_offset_only():
+def test_read_all_configs_offset_only() -> None:
     """Test that setting only POWER_OFFSET wraps with default multiplier."""
     config = configparser.ConfigParser()
     config["SCRIPT_1"] = {
@@ -755,13 +790,14 @@ def test_read_all_configs_offset_only():
     powermeters = read_all_powermeter_configs(config)
     assert len(powermeters) == 1
     pm, _, _ = powermeters[0]
+    assert isinstance(pm, PowermeterWrapper)
     pm = pm.wrapped_powermeter  # unwrap outermost HealthTrackingPowermeter
     assert isinstance(pm, TransformedPowermeter)
     assert pm.offsets == [10.0]
     assert pm.multipliers == [1.0]
 
 
-def test_read_all_configs_zero_multiplier_accepted():
+def test_read_all_configs_zero_multiplier_accepted() -> None:
     """Test that a multiplier of 0 is accepted (e.g. to null a phase)."""
     config = configparser.ConfigParser()
     config["SCRIPT_1"] = {
@@ -772,15 +808,15 @@ def test_read_all_configs_zero_multiplier_accepted():
     powermeters = read_all_powermeter_configs(config)
     assert len(powermeters) == 1
     pm, _, _ = powermeters[0]
+    assert isinstance(pm, PowermeterWrapper)
     pm = pm.wrapped_powermeter  # unwrap outermost HealthTrackingPowermeter
     assert isinstance(pm, TransformedPowermeter)
     assert pm.multipliers == [0.0]
 
 
-def test_read_all_configs_wraps_with_health_tracking_named_by_section():
+def test_read_all_configs_wraps_with_health_tracking_named_by_section() -> None:
     """Every powermeter is wrapped outermost in HealthTrackingPowermeter and
     labelled with its config section for the MQTT Insights Online sensor."""
-    from astrameter.powermeter.wrappers.health import HealthTrackingPowermeter
 
     config = configparser.ConfigParser()
     config["SCRIPT_1"] = {"COMMAND": 'echo "100"'}
@@ -788,11 +824,11 @@ def test_read_all_configs_wraps_with_health_tracking_named_by_section():
     powermeters = read_all_powermeter_configs(config)
     assert len(powermeters) == 1
     pm, _, _ = powermeters[0]
-    assert isinstance(pm, HealthTrackingPowermeter)
+    assert isinstance(pm, PowermeterWrapper)
     assert pm.name == "SCRIPT_1"
 
 
-def test_read_all_configs_no_transform_when_not_configured():
+def test_read_all_configs_no_transform_when_not_configured() -> None:
     """Test that no transform wrapper is applied when keys are absent."""
     config = configparser.ConfigParser()
     config["SCRIPT_1"] = {
@@ -802,11 +838,12 @@ def test_read_all_configs_no_transform_when_not_configured():
     powermeters = read_all_powermeter_configs(config)
     assert len(powermeters) == 1
     pm, _, _ = powermeters[0]
+    assert isinstance(pm, PowermeterWrapper)
     pm = pm.wrapped_powermeter  # unwrap outermost HealthTrackingPowermeter
     assert not isinstance(pm, TransformedPowermeter)
 
 
-def test_read_all_configs_wait_for_next_message_default_true():
+def test_read_all_configs_wait_for_next_message_default_true() -> None:
     """No config means waiting is enabled (preserves PR #322 behaviour)."""
     config = configparser.ConfigParser()
     config["SCRIPT_1"] = {"COMMAND": 'echo "100"'}
@@ -816,7 +853,7 @@ def test_read_all_configs_wait_for_next_message_default_true():
     assert wait_for_next is True
 
 
-def test_read_all_configs_wait_for_next_message_global_off():
+def test_read_all_configs_wait_for_next_message_global_off() -> None:
     """[GENERAL] WAIT_FOR_NEXT_MESSAGE=false applies to every section."""
     config = configparser.ConfigParser()
     config["GENERAL"] = {"WAIT_FOR_NEXT_MESSAGE": "false"}
@@ -827,7 +864,7 @@ def test_read_all_configs_wait_for_next_message_global_off():
     assert all(wait is False for _, _, wait in powermeters)
 
 
-def test_read_all_configs_wait_for_next_message_section_override():
+def test_read_all_configs_wait_for_next_message_section_override() -> None:
     """Per-section WAIT_FOR_NEXT_MESSAGE overrides the global default."""
     config = configparser.ConfigParser()
     config["GENERAL"] = {"WAIT_FOR_NEXT_MESSAGE": "true"}

--- a/src/astrameter/config/ini_config_test.py
+++ b/src/astrameter/config/ini_config_test.py
@@ -4,6 +4,8 @@ from io import StringIO
 from astrameter.config.config_loader import new_config_parser
 from astrameter.config.ini_config import IniAppConfig, render_ini
 from astrameter.config.settings import CtSettings, GeneralSettings
+from astrameter.powermeter import ThrottledPowermeter
+from astrameter.powermeter.wrappers.base import PowermeterWrapper
 
 
 def config(text: str) -> IniAppConfig:
@@ -12,14 +14,14 @@ def config(text: str) -> IniAppConfig:
     return IniAppConfig(parser)
 
 
-def test_empty_config_yields_the_defaults():
+def test_empty_config_yields_the_defaults() -> None:
     cfg = config("")
     assert cfg.general() == GeneralSettings()
     assert cfg.ct("ct002") == CtSettings()
     assert cfg.marstek().enable is False
 
 
-def test_the_dashboard_is_served_and_writable_unless_the_file_says_otherwise():
+def test_the_dashboard_is_served_and_writable_unless_the_file_says_otherwise() -> None:
     """Both on by default; each takes its own key to switch off."""
     assert config("").general().dashboard is True
     assert config("").general().dashboard_allow_write is True
@@ -32,7 +34,7 @@ def test_the_dashboard_is_served_and_writable_unless_the_file_says_otherwise():
     )
 
 
-def test_general_section_is_read_into_settings():
+def test_general_section_is_read_into_settings() -> None:
     general = config(
         """
 [GENERAL]
@@ -57,7 +59,7 @@ THROTTLE_INTERVAL = 2
     assert general.signal.throttle_interval == 2.0
 
 
-def test_the_config_editor_flag_keeps_unset_apart_from_off():
+def test_the_config_editor_flag_keeps_unset_apart_from_off() -> None:
     """Absent has to stay absent rather than collapsing to False: the web
     server reads "off" as an opt-out that overrides the dashboard, and a file
     that never mentioned the key never asked for that."""
@@ -72,7 +74,7 @@ def test_the_config_editor_flag_keeps_unset_apart_from_off():
     assert _round_trip(off).general().web_config_enabled is False
 
 
-def test_ct_section_is_read_into_settings():
+def test_ct_section_is_read_into_settings() -> None:
     ct = config(
         """
 [CT002]
@@ -97,7 +99,7 @@ CLOUD_REPORTING = true
     assert ct.fair_distribution is CtSettings().fair_distribution
 
 
-def test_ct003_reads_its_own_section_only_when_it_exists():
+def test_ct003_reads_its_own_section_only_when_it_exists() -> None:
     both = config("[CT002]\nCT_MAC = aa\n\n[CT003]\nCT_MAC = bb\n")
     assert both.ct("ct002").ct_mac == "aa"
     assert both.ct("ct003").ct_mac == "bb"
@@ -106,7 +108,7 @@ def test_ct003_reads_its_own_section_only_when_it_exists():
     assert shared.ct("ct003").ct_mac == "aa"
 
 
-def test_ct_dedupe_window_falls_back_to_the_global_one():
+def test_ct_dedupe_window_falls_back_to_the_global_one() -> None:
     inherited = config("[GENERAL]\nDEDUPE_TIME_WINDOW = 2\n\n[CT002]\n")
     assert inherited.ct("ct002").dedupe_time_window == 2.0
 
@@ -116,7 +118,7 @@ def test_ct_dedupe_window_falls_back_to_the_global_one():
     assert overridden.ct("ct002").dedupe_time_window == 0.5
 
 
-def test_marstek_section_is_read_into_settings():
+def test_marstek_section_is_read_into_settings() -> None:
     marstek = config(
         """
 [MARSTEK]
@@ -134,7 +136,7 @@ TIMEZONE = Europe/Madrid
     assert marstek.timezone == "Europe/Madrid"
 
 
-def test_powermeters_inherit_the_global_conditioning():
+def test_powermeters_inherit_the_global_conditioning() -> None:
     cfg = config(
         """
 [GENERAL]
@@ -146,7 +148,8 @@ IP = 192.168.1.10
 """
     )
     meter, _, _ = cfg.powermeters(cfg.general())[0]
-    assert type(meter.wrapped_powermeter).__name__ == "ThrottledPowermeter"
+    assert isinstance(meter, PowermeterWrapper)
+    assert isinstance(meter.wrapped_powermeter, ThrottledPowermeter)
 
 
 # -- rendering ---------------------------------------------------------------
@@ -156,7 +159,9 @@ IP = 192.168.1.10
 # file" from handing someone a file that silently drops a setting.
 
 
-def _round_trip(cfg: IniAppConfig, device_types: list[str] | None = None):
+def _round_trip(
+    cfg: IniAppConfig, device_types: list[str] | None = None
+) -> IniAppConfig:
     return config(render_ini(cfg, device_types))
 
 
@@ -172,14 +177,14 @@ def _sample(field: dataclasses.Field) -> str:
     return f"{default}-changed" if default else "changed"
 
 
-def test_rendering_the_defaults_writes_nothing_to_carry():
+def test_rendering_the_defaults_writes_nothing_to_carry() -> None:
     """Only what the user changed is worth putting in their file."""
     cfg = config("")
     assert render_ini(cfg).strip() == ""
     assert _round_trip(cfg).general() == GeneralSettings()
 
 
-def test_general_settings_survive_the_round_trip():
+def test_general_settings_survive_the_round_trip() -> None:
     cfg = config(
         """
 [GENERAL]
@@ -211,7 +216,7 @@ PID_MODE = replace
     assert _round_trip(cfg).general() == cfg.general()
 
 
-def test_ct_settings_survive_the_round_trip():
+def test_ct_settings_survive_the_round_trip() -> None:
     """Every CT field, so a key written under the wrong name is caught."""
     body = "\n".join(
         f"{f.name.upper()} = {_sample(f)}"
@@ -222,7 +227,7 @@ def test_ct_settings_survive_the_round_trip():
     assert _round_trip(cfg).ct("ct002") == cfg.ct("ct002")
 
 
-def test_both_ct_sections_are_rendered():
+def test_both_ct_sections_are_rendered() -> None:
     cfg = config(
         """
 [GENERAL]
@@ -240,7 +245,7 @@ BALANCE_GAIN = 0.6
     assert written.ct("ct003").balance_gain == 0.6
 
 
-def test_marstek_credentials_survive_the_round_trip():
+def test_marstek_credentials_survive_the_round_trip() -> None:
     cfg = config(
         """
 [MARSTEK]
@@ -254,19 +259,19 @@ TIMEZONE = Europe/Madrid
     assert _round_trip(cfg).marstek() == cfg.marstek()
 
 
-def test_a_disabled_marstek_section_is_not_written():
+def test_a_disabled_marstek_section_is_not_written() -> None:
     """Credentials that are not in use do not get copied into a new file."""
     cfg = config("[MARSTEK]\nENABLE = false\nPASSWORD = secret\n")
     assert "secret" not in render_ini(cfg)
 
 
-def test_the_device_types_to_render_can_be_given():
+def test_the_device_types_to_render_can_be_given() -> None:
     """The add-on backend answers ct() for a type its own list may not name."""
     cfg = config("")
     assert "[CT003]" in render_ini(cfg, ["ct003"])
 
 
-def test_an_all_default_ct003_does_not_inherit_ct002s_settings():
+def test_an_all_default_ct003_does_not_inherit_ct002s_settings() -> None:
     """`ct_section` falls back to [CT002], so [CT003] has to be written."""
     cfg = config(
         """
@@ -283,7 +288,7 @@ BALANCE_GAIN = 0.44
     assert _round_trip(cfg).ct("ct003") == CtSettings()
 
 
-def test_declared_general_keys_reports_only_what_the_file_sets():
+def test_declared_general_keys_reports_only_what_the_file_sets() -> None:
     """`dashboard` is not `DASHBOARD`, so the lookup goes through the map."""
     cfg = config("[GENERAL]\nDASHBOARD_ENABLED = False\n")
 

--- a/src/astrameter/config/logger.py
+++ b/src/astrameter/config/logger.py
@@ -93,7 +93,7 @@ levels = {
 }
 
 
-def setLogLevel(inLevel: str):
+def setLogLevel(inLevel: str) -> None:
     level = levels.get(inLevel.lower())
     if level is None:
         level = logging.WARNING

--- a/src/astrameter/config/logger_test.py
+++ b/src/astrameter/config/logger_test.py
@@ -31,7 +31,7 @@ logger_module = importlib.import_module("astrameter.config.logger")
         ('{"marstek_mailbox": "me@example.com"}', '{"marstek_mailbox": "***"}'),
     ],
 )
-def test_redact_secrets_masks_credentials(raw, expected):
+def test_redact_secrets_masks_credentials(raw: str, expected: str) -> None:
     assert redact_secrets(raw) == expected
 
 
@@ -44,7 +44,7 @@ def test_redact_secrets_masks_credentials(raw, expected):
         "CT002 consumer 60323bd11234 phase detected: A",
     ],
 )
-def test_redact_secrets_leaves_benign_messages_untouched(benign):
+def test_redact_secrets_leaves_benign_messages_untouched(benign: str) -> None:
     assert redact_secrets(benign) == benign
 
 
@@ -52,7 +52,9 @@ def test_redact_secrets_leaves_benign_messages_untouched(benign):
     ("level_name", "expected_level"),
     [("info", logging.INFO), ("debug", logging.DEBUG), ("invalid", logging.WARNING)],
 )
-def test_set_log_level_configures_expected_level(level_name, expected_level):
+def test_set_log_level_configures_expected_level(
+    level_name: str, expected_level: int
+) -> None:
     with patch.object(logger_module.logging, "basicConfig") as basic_config:
         setLogLevel(level_name)
 
@@ -60,7 +62,7 @@ def test_set_log_level_configures_expected_level(level_name, expected_level):
     assert basic_config.call_args.kwargs["level"] == expected_level
 
 
-def test_set_log_level_configures_timestamped_log_output():
+def test_set_log_level_configures_timestamped_log_output() -> None:
     with patch.object(logger_module.logging, "basicConfig") as basic_config:
         setLogLevel("info")
 
@@ -91,12 +93,12 @@ def test_set_log_level_configures_timestamped_log_output():
     ("level_name", "expected"),
     [("debug", True), ("info", False), ("warning", False)],
 )
-def test_debug_traceback_reflects_log_level(level_name, expected):
+def test_debug_traceback_reflects_log_level(level_name: str, expected: bool) -> None:
     setLogLevel(level_name)
     assert logger_module.debug_traceback() is expected
 
 
-def test_warning_inside_except_block_includes_traceback():
+def test_warning_inside_except_block_includes_traceback() -> None:
     setLogLevel("warning")
     root = logging.getLogger()
     buffer = io.StringIO()
@@ -122,7 +124,7 @@ def test_warning_inside_except_block_includes_traceback():
     assert "RuntimeError: boom" in output
 
 
-def test_warning_outside_except_block_has_no_traceback():
+def test_warning_outside_except_block_has_no_traceback() -> None:
     setLogLevel("warning")
     root = logging.getLogger()
     buffer = io.StringIO()
@@ -142,7 +144,7 @@ def test_warning_outside_except_block_has_no_traceback():
     assert "Traceback" not in output
 
 
-def test_exc_info_false_opts_out_of_auto_traceback():
+def test_exc_info_false_opts_out_of_auto_traceback() -> None:
     setLogLevel("warning")
     root = logging.getLogger()
     buffer = io.StringIO()
@@ -167,7 +169,7 @@ def test_exc_info_false_opts_out_of_auto_traceback():
     assert "Traceback" not in output
 
 
-def test_set_log_level_installs_redacting_formatter_on_root_handlers():
+def test_set_log_level_installs_redacting_formatter_on_root_handlers() -> None:
     setLogLevel("debug")
     root = logging.getLogger()
     assert root.handlers
@@ -175,7 +177,9 @@ def test_set_log_level_installs_redacting_formatter_on_root_handlers():
         assert isinstance(handler.formatter, logger_module._RedactingFormatter)
 
 
-def test_root_logger_redacts_secrets_end_to_end(capsys):
+def test_root_logger_redacts_secrets_end_to_end(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     setLogLevel("info")
     logging.getLogger("astrameter.test").info(
         "broker mqtt://alice:s3cret@example.com PASSWORD=hunter2"
@@ -188,7 +192,7 @@ def test_root_logger_redacts_secrets_end_to_end(capsys):
     assert "PASSWORD=***" in combined
 
 
-def test_redaction_covers_traceback_text():
+def test_redaction_covers_traceback_text() -> None:
     setLogLevel("warning")
     root = logging.getLogger()
     buffer = io.StringIO()

--- a/src/astrameter/config/settings_test.py
+++ b/src/astrameter/config/settings_test.py
@@ -4,13 +4,13 @@ from astrameter.config.settings import DEFAULT_CT_UDP_PORT, CtSettings
 from astrameter.ct002 import UDP_PORT
 
 
-def test_default_ct_udp_port_matches_the_emulator():
+def test_default_ct_udp_port_matches_the_emulator() -> None:
     """The config layer cannot import the emulator, so pin the two together."""
     assert DEFAULT_CT_UDP_PORT == UDP_PORT
     assert CtSettings().udp_port == UDP_PORT
 
 
-def test_ct_settings_defaults_match_the_balancer():
+def test_ct_settings_defaults_match_the_balancer() -> None:
     """``main._balancer_config`` wires the balancer by field name, so a default
     that drifts here would silently re-tune every install."""
     from astrameter.ct002.balancer import BalancerConfig

--- a/src/astrameter/conftest.py
+++ b/src/astrameter/conftest.py
@@ -6,6 +6,7 @@ import socket
 import subprocess
 import tempfile
 import time
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -23,7 +24,7 @@ def find_free_port() -> int:
 
 
 @pytest.fixture(scope="session")
-def mqtt_broker():
+def mqtt_broker() -> Iterator[int]:
     if shutil.which("mosquitto") is None:
         pytest.skip("mosquitto not installed")
     port = find_free_port()

--- a/src/astrameter/ct002/controls.py
+++ b/src/astrameter/ct002/controls.py
@@ -86,7 +86,9 @@ class ConsumerControl:
             raise ValueError(f"{self.field} must be a number") from exc
         return self.coerce(number)
 
-    def apply(self, device: ControllableDevice, consumer_id: str, value: object):
+    def apply(
+        self, device: ControllableDevice, consumer_id: str, value: object
+    ) -> None:
         getattr(device, self.setter)(consumer_id, value)
 
 
@@ -127,7 +129,7 @@ def coerce_consumer_control(field: str, value: object) -> bool | float:
     return CONSUMER_CONTROLS_BY_FIELD[field].coerce(value)
 
 
-def apply_device_control(device: ControllableDevice, field: str, value: object):
+def apply_device_control(device: ControllableDevice, field: str, value: object) -> None:
     """Apply a device-wide control.  ``force_rotation`` is a button and
     carries no value; ``active_control`` is a switch."""
     if field == "force_rotation":

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -5,14 +5,14 @@ import contextlib
 import dataclasses
 import math
 import time
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Iterable, Sequence
 from datetime import datetime, timezone
 from typing import Any, Literal, NamedTuple, cast
 
 from astrameter.config.logger import debug_traceback, logger
 from astrameter.power_units import three_phases
 from astrameter.request_dedupe import RequestDeduplicator
-from astrameter.udp_server import UdpServer
+from astrameter.udp_server import DatagramSink, UdpServer
 
 from .balancer import (
     SATURATION_GRACE_SECONDS,
@@ -22,6 +22,7 @@ from .balancer import (
     BalancerSnapshot,
     ConsumerMode,
     ConsumerReport,
+    ControlQualitySnapshot,
     LoadBalancer,
     _needs_dc_output_floor,
     device_capabilities,
@@ -117,7 +118,7 @@ def _bucket_for_phase(phase: str) -> str:
     return p
 
 
-def _control_quality_evidence(quality) -> dict[str, Any]:
+def _control_quality_evidence(quality: ControlQualitySnapshot) -> dict[str, Any]:
     """The numbers behind a control-quality verdict, for the MQTT payload.
 
     Percentages rather than 0..1 fractions, and crossings per minute rather
@@ -141,7 +142,7 @@ def _control_quality_evidence(quality) -> dict[str, Any]:
     }
 
 
-def _values_finite(values) -> bool:
+def _values_finite(values: Iterable[Any]) -> bool:
     """True iff every meter value coerces to a finite number.
 
     Numeric strings are tolerated (some sources deliver them); NaN/Inf or
@@ -228,7 +229,7 @@ class Consumer:
 
     consumer_id: str
     # Meter readings (set externally, e.g. by powermeter integration)
-    values: list | None = None
+    values: list[float] | None = None
     # Report data (updated each UDP request)
     phase: str = "A"
     power: int = 0
@@ -423,27 +424,27 @@ class CT002Snapshot:
 class CT002:
     def __init__(
         self,
-        udp_port=UDP_PORT,
-        ct_mac="",
-        ct_type="HME-4",
-        wifi_rssi=-50,
-        dedupe_time_window=0.0,
+        udp_port: int = UDP_PORT,
+        ct_mac: str = "",
+        ct_type: str = "HME-4",
+        wifi_rssi: int = -50,
+        dedupe_time_window: float = 0.0,
         # None (default) = adaptive eviction: a consumer expires after missing
         # ~2 of its own poll cycles, like the real CT.  A number = fixed TTL
         # in seconds (set CONSUMER_TTL to get this).
-        consumer_ttl=None,
-        debug_status=False,
-        active_control=True,
+        consumer_ttl: int | None = None,
+        debug_status: bool = False,
+        active_control: bool = True,
         balancer: BalancerConfig | None = None,
-        saturation_detection=True,
-        saturation_alpha=0.15,
-        min_target_for_saturation=20,
-        saturation_decay_factor=0.995,
-        saturation_grace_seconds=SATURATION_GRACE_SECONDS,
-        saturation_stall_timeout_seconds=SATURATION_STALL_TIMEOUT_SECONDS,
-        device_id="",
-        clock=None,
-        reset_fn=None,
+        saturation_detection: bool = True,
+        saturation_alpha: float = 0.15,
+        min_target_for_saturation: float = 20,
+        saturation_decay_factor: float = 0.995,
+        saturation_grace_seconds: float = SATURATION_GRACE_SECONDS,
+        saturation_stall_timeout_seconds: float = SATURATION_STALL_TIMEOUT_SECONDS,
+        device_id: str = "",
+        clock: Callable[[], float] | None = None,
+        reset_fn: Callable[[], None] | None = None,
     ) -> None:
         self.udp_port = udp_port
         self.ct_mac = ct_mac
@@ -481,7 +482,7 @@ class CT002:
             dedupe_time_window, clock=clock or time.time
         )
         self._server: UdpServer | None = None
-        self._cleanup_task = None
+        self._cleanup_task: asyncio.Task[None] | None = None
         self._stopped = asyncio.Event()
         # Clock used for rate-limiting ``before_send`` warning logs.
         # Defaults to wall time but tests may inject a fake clock so
@@ -571,10 +572,10 @@ class CT002:
             min_dc_output=consumer.min_dc_output,
         )
 
-    def set_consumer_value(self, consumer_id, values):
+    def set_consumer_value(self, consumer_id: str, values: list[float]) -> None:
         self._get_consumer(consumer_id).values = values
 
-    def _get_consumer_value(self, consumer_id):
+    def _get_consumer_value(self, consumer_id: str) -> list[float] | None:
         consumer = self._consumers.get(consumer_id)
         return consumer.values if consumer else None
 
@@ -695,14 +696,14 @@ class CT002:
 
     def _update_consumer_report(
         self,
-        consumer_id,
-        phase,
-        power,
-        device_type="",
+        consumer_id: str,
+        phase: str,
+        power: object,
+        device_type: str = "",
         *,
         source_ip: str | None = None,
         participates: bool = True,
-    ):
+    ) -> None:
         normalized_phase = normalize_phase(phase)
         consumer = self._get_consumer(consumer_id)
         previous_phase = consumer.phase if consumer.timestamp > 0 else None
@@ -756,7 +757,7 @@ class CT002:
             and now - consumer.timestamp > self._consumer_ttl_seconds(consumer)
         )
 
-    def _cleanup_consumers(self):
+    def _cleanup_consumers(self) -> None:
         now = self._clock()
         stale = [
             key
@@ -794,7 +795,9 @@ class CT002:
             return ConsumerMode("manual", consumer.manual_target)
         return ConsumerMode("auto")
 
-    def _compute_smooth_target(self, values, consumer_id=None):
+    def _compute_smooth_target(
+        self, values: list[float], consumer_id: str | None = None
+    ) -> list[float]:
         """Active control: smooth the raw grid reading and delegate
         target allocation to the load balancer."""
         if not self.active_control or not values:
@@ -1025,7 +1028,13 @@ class CT002:
             )
         return tuple(out)
 
-    def _format_status(self, values, phase_values, consumer_id=None, meter_value=None):
+    def _format_status(
+        self,
+        values: list[float],
+        phase_values: dict[str, PhaseBucket],
+        consumer_id: str | None = None,
+        meter_value: float | None = None,
+    ) -> str:
         """Concise one-line status: phase consumption and consumer charge/discharge reports."""
         if not values or len(values) != 3:
             values = [0, 0, 0]
@@ -1059,7 +1068,9 @@ class CT002:
         )
         return " | ".join(parts)
 
-    def _build_response_fields(self, request: CT002Request, values):
+    def _build_response_fields(
+        self, request: CT002Request, values: list[float]
+    ) -> list[str]:
         if not values or len(values) != 3:
             values = [0, 0, 0]
         phase_a, phase_b, phase_c = values
@@ -1145,7 +1156,9 @@ class CT002:
         self._info_idx_counter = (self._info_idx_counter + 1) % 256
         return response_fields
 
-    async def _call_before_send(self, request: CT002Request):
+    async def _call_before_send(
+        self, request: CT002Request
+    ) -> tuple[list[float] | None, bool]:
         """Invoke the ``before_send`` powermeter hook.
 
         Returns ``(result, failed)``.  ``failed`` is ``True`` only when the
@@ -1201,13 +1214,17 @@ class CT002:
             return True
         return bool(request.ct_mac) and request.ct_mac.lower() == self.ct_mac.lower()
 
-    async def _safe_handle_request(self, data, addr, transport):
+    async def _safe_handle_request(
+        self, data: bytes, addr: tuple[str, int], transport: DatagramSink
+    ) -> None:
         try:
             await self._handle_request(data, addr, transport)
         except Exception:
             logger.exception("Error handling CT002 request from %s", addr)
 
-    async def _handle_request(self, data, addr, transport):
+    async def _handle_request(
+        self, data: bytes, addr: tuple[str, int], transport: DatagramSink
+    ) -> None:
         request = self._decode_request(data, addr)
         if request is None:
             return
@@ -1242,7 +1259,9 @@ class CT002:
         finally:
             self._inflight_consumers.discard(consumer_id)
 
-    def _decode_request(self, data, addr) -> CT002Request | None:
+    def _decode_request(
+        self, data: bytes, addr: tuple[str, int]
+    ) -> CT002Request | None:
         """Decode one datagram, or ``None`` when it is not ours to answer."""
         logger.debug("CT002 request from %s: %s", addr, data.hex())
         fields, error = parse_request(data)
@@ -1323,7 +1342,7 @@ class CT002:
             return False
         return True
 
-    async def _serve(self, request: CT002Request, transport) -> None:
+    async def _serve(self, request: CT002Request, transport: DatagramSink) -> None:
         """Read the meter, answer the poll, and publish what we served."""
         consumer_id = request.consumer_id
         updated, meter_failed = await self._call_before_send(request)
@@ -1393,13 +1412,12 @@ class CT002:
         (issue #403).  The ESPHome component does the same when its sensor ages
         out (see esphome/components/ct002/ct002.cpp).
         """
-        if meter_failed:
-            values: list = [0, 0, 0]
-        else:
-            values = self._get_consumer_value(request.consumer_id)
-            if values is None:
-                values = [0, 0, 0]
-            elif not _values_finite(values):
+        values: list[float] = [0.0, 0.0, 0.0]
+        stored = None if meter_failed else self._get_consumer_value(request.consumer_id)
+        if stored is not None:
+            if _values_finite(stored):
+                values = stored
+            else:
                 # A non-finite reading (NaN/Inf from a flaky source or a filter
                 # chain fed one) is a meter failure, not a sample.  One NaN fed
                 # into the stateful controller poisons the grid-state predictor
@@ -1408,7 +1426,6 @@ class CT002:
                 # pinned at the ramp-pacing base step until restart (issue #548).
                 # Take the same hold path as an unavailable meter.
                 meter_failed = True
-                values = [0, 0, 0]
 
         raw_values = three_phases(values)
         # The hold above is a *sentinel*, not a real reading, so active control
@@ -1422,7 +1439,9 @@ class CT002:
             values = self._compute_smooth_target(values, request.consumer_id)
         return _ServedTarget(raw_values, three_phases(values), meter_failed)
 
-    def _record_instructed_power(self, request: CT002Request, values: list) -> None:
+    def _record_instructed_power(
+        self, request: CT002Request, values: list[float]
+    ) -> None:
         """Book the net power we expect this battery to reach.
 
         Its reported output plus the delta we deliver — the firmware computes
@@ -1508,7 +1527,7 @@ class CT002:
             **_control_quality_evidence(quality),
         }
 
-    async def _cleanup_loop(self):
+    async def _cleanup_loop(self) -> None:
         try:
             while True:
                 await asyncio.sleep(CLEANUP_INTERVAL_SECONDS)
@@ -1516,7 +1535,7 @@ class CT002:
         except asyncio.CancelledError:
             pass
 
-    async def start(self):
+    async def start(self) -> None:
         self._server = await UdpServer.serve(self.udp_port, self._safe_handle_request)
         # Read the bound port back: a configured 0 asks the OS to pick one, and
         # the log line and status document below would otherwise both say "0".
@@ -1528,10 +1547,10 @@ class CT002:
         self._rev += 1
         logger.info("CT002 UDP server listening on port %s", self.udp_port)
 
-    async def wait(self):
+    async def wait(self) -> None:
         await self._stopped.wait()
 
-    async def stop(self):
+    async def stop(self) -> None:
         if self._cleanup_task:
             self._cleanup_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -1246,7 +1246,7 @@ class CT002:
         """Decode one datagram, or ``None`` when it is not ours to answer."""
         logger.debug("CT002 request from %s: %s", addr, data.hex())
         fields, error = parse_request(data)
-        if error:
+        if fields is None:
             logger.debug("Invalid CT002 request from %s: %s", addr, error)
             return None
         if len(fields) < 4:

--- a/src/astrameter/ct002/ct002_test.py
+++ b/src/astrameter/ct002/ct002_test.py
@@ -12,7 +12,7 @@ class _RecordingTransport:
     def __init__(self) -> None:
         self.sent: list[bytes] = []
 
-    def sendto(self, data: bytes, addr) -> None:
+    def sendto(self, data: bytes, addr: tuple) -> None:
         self.sent.append(data)
 
 
@@ -230,7 +230,9 @@ async def _gated_before_send(ct: CT002, gate: asyncio.Event) -> list[int]:
     returns a fixed grid reading.  Returns a one-element call counter list."""
     calls = [0]
 
-    async def before_send(_addr, _request=None, _consumer_id=None):
+    async def before_send(
+        _addr: tuple, _request: object = None, _consumer_id: str | None = None
+    ) -> list[float]:
         calls[0] += 1
         await gate.wait()
         return [150.0, 0.0, 0.0]
@@ -334,7 +336,9 @@ async def test_non_finite_reading_holds_and_control_recovers(bad: float) -> None
     ct = CT002(ct_mac="", active_control=True, clock=clock)
     grid = [300.0]
 
-    async def before_send(_addr, _request=None, _consumer_id=None):
+    async def before_send(
+        _addr: tuple, _request: object = None, _consumer_id: str | None = None
+    ) -> list[float]:
         return [grid[0], 0.0, 0.0]
 
     ct.before_send = before_send

--- a/src/astrameter/ct002/ct002_test.py
+++ b/src/astrameter/ct002/ct002_test.py
@@ -345,7 +345,7 @@ async def test_non_finite_reading_holds_and_control_recovers(bad: float) -> None
         clock.now += 15.0
         await ct._handle_request(_poll("02b250b26777", power=0), addr, transport)
         fields, err = parse_request(transport.sent[-1])
-        assert err is None
+        assert fields is not None, err
         return fields
 
     # Warm poll: import drives a positive (discharge) target.

--- a/src/astrameter/ct002/protocol.py
+++ b/src/astrameter/ct002/protocol.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 SOH = 0x01
 STX = 0x02
 ETX = 0x03
@@ -35,21 +37,26 @@ RESPONSE_LABELS = [
 ]
 
 
-def calculate_checksum(data_bytes):
+def calculate_checksum(data_bytes: bytes | bytearray) -> int:
     xor = 0
     for b in data_bytes:
         xor ^= b
     return xor
 
 
-def parse_int(value, default=0):
+def parse_int(value: object, default: int = 0) -> int:
+    """The integer *value* denotes, or *default* when it denotes none.
+
+    Takes ``object`` because it reads both wire strings and already-parsed
+    numbers; the ``TypeError`` below is what covers everything else.
+    """
     try:
-        return int(value)
+        return int(value)  # type: ignore[call-overload]
     except (TypeError, ValueError):
         return default
 
 
-def compute_length(payload_without_length):
+def compute_length(payload_without_length: bytes) -> int:
     base_size = 1 + 1 + len(payload_without_length) + 1 + 2
     for length_digits in range(1, 5):
         total_length = base_size + length_digits
@@ -58,7 +65,7 @@ def compute_length(payload_without_length):
     raise ValueError("Payload length too large")
 
 
-def build_payload(fields):
+def build_payload(fields: Sequence[str]) -> bytearray:
     message_str = SEPARATOR + SEPARATOR.join(fields)
     message_bytes = message_str.encode("ascii")
     total_length = compute_length(message_bytes)
@@ -72,7 +79,13 @@ def build_payload(fields):
     return payload
 
 
-def parse_request(data):
+def parse_request(data: bytes) -> tuple[list[str], None] | tuple[None, str]:
+    """The request's fields, or ``None`` and why the datagram was not one.
+
+    Mirrors ``protocol.cpp``'s ``std::optional<std::vector<std::string>>``:
+    the absent fields are the signal, and the string beside them is for the
+    log.
+    """
     if len(data) < 10:
         return None, "Too short"
     if data[0] != SOH or data[1] != STX:
@@ -104,7 +117,8 @@ def parse_request(data):
         else:
             return (
                 None,
-                f"Checksum mismatch (expected {expected_checksum}, got {actual_checksum})",
+                "Checksum mismatch (expected "
+                f"{expected_checksum.decode()}, got {actual_checksum.decode(errors='replace')})",
             )
     try:
         message = data[sep_index:-3].decode("ascii")

--- a/src/astrameter/main.py
+++ b/src/astrameter/main.py
@@ -28,6 +28,7 @@ from astrameter.config.settings import (
 )
 from astrameter.ct002 import CT002
 from astrameter.ct002.balancer import BalancerConfig
+from astrameter.ct002.ct002 import CT002Request
 from astrameter.marstek_api import (
     MarstekApiError,
     MarstekConfig,
@@ -119,7 +120,7 @@ def _build_ct002(
     ct_type: str,
     device_id: str,
     debug_status: bool,
-    reset_fn,
+    reset_fn: Callable[[], None],
 ) -> CT002:
     """Create the emulator a :class:`CtSettings` describes."""
     return CT002(
@@ -175,7 +176,9 @@ def _log_ct_settings(ct: CtSettings, device_type: str, device_id: str) -> None:
     logger.info("Active control enabled: %s", " + ".join(["load split", *extras]))
 
 
-def _forward_events(insights: MqttInsightsService, device: CT002 | Shelly):
+def _forward_events(
+    insights: MqttInsightsService, device: CT002 | Shelly
+) -> Callable[[str, str, dict[str, Any]], None]:
     """Route a device's per-battery events to MQTT Insights.  A battery that
     the device evicted arrives as ``{"_removed": True}``."""
     on_update: Callable[[str, str, dict[str, Any]], None]
@@ -217,7 +220,11 @@ def _build_device(
             lambda: _reset_all_powermeters(powermeters),
         )
 
-        async def update_readings(addr, _request=None, _consumer_id=None):
+        async def update_readings(
+            addr: tuple[str, int],
+            _request: CT002Request | None = None,
+            _consumer_id: str | None = None,
+        ) -> list[float] | None:
             return await read_ct_powermeter(addr, powermeters)
 
         device.before_send = update_readings
@@ -361,7 +368,7 @@ async def run_device(
     marstek_mac: str = "",
     marstek_ver_v: int | None = None,
     registry: StatusRegistry | None = None,
-):
+) -> None:
     """Run one emulated device until it stops, wiring it to the optional
     integrations (MQTT Insights, the Marstek responder, cloud reporting)."""
     logger.debug("Starting device: %s", device_type)
@@ -438,7 +445,7 @@ async def async_main(
     skip_test: bool,
     managed_marstek: dict[str, tuple[str, int]] | None = None,
     registry: StatusRegistry | None = None,
-):
+) -> None:
     managed_marstek = managed_marstek or {}
 
     powermeters: list[ConfiguredPowermeter] = []
@@ -734,7 +741,7 @@ def _adopt_config(
     registry.config_mode = detect_config_mode(addon=args.addon, config_path=config.path)
 
 
-def main():
+def main() -> None:
     args = _build_arg_parser().parse_args()
 
     # In add-on mode the log level is an add-on option, so the options have to

--- a/src/astrameter/main.py
+++ b/src/astrameter/main.py
@@ -5,7 +5,7 @@ import os
 import signal
 from collections.abc import Callable, Sequence
 from dataclasses import fields, replace
-from typing import Any, cast
+from typing import Any
 
 from astrameter.cloud_reporting import (
     CloudReporter,
@@ -33,6 +33,7 @@ from astrameter.marstek_api import (
     MarstekConfig,
     ensure_managed_fake_device,
 )
+from astrameter.meter_pool import powermeter_for, powermeter_name, read_fresh
 from astrameter.mqtt_insights import (
     MarstekMqttBinding,
     MqttInsightsService,
@@ -42,7 +43,6 @@ from astrameter.mqtt_insights import (
 )
 from astrameter.power_units import three_phases
 from astrameter.powermeter import Powermeter
-from astrameter.powermeter.wrappers.health import HealthTrackingPowermeter
 from astrameter.shelly import Shelly
 from astrameter.status import StatusRegistry, detect_config_mode
 from astrameter.version_info import get_git_commit_sha, get_version
@@ -52,47 +52,16 @@ from astrameter.web_server import WebServer, parse_allowed_hosts
 FRESH_READING_TIMEOUT_S = 2.0
 
 
-def _powermeter_log_name(powermeter: Powermeter) -> str:
-    """The meter class behind the health wrapper every configured meter gets."""
-    inner = (
-        powermeter.wrapped_powermeter
-        if isinstance(powermeter, HealthTrackingPowermeter)
-        else powermeter
-    )
-    return type(inner).__name__
-
-
 async def read_ct_powermeter(
     addr: tuple[str, int],
     powermeters: list[ConfiguredPowermeter],
 ) -> list[float] | None:
-    """Pick the powermeter matching *addr* and return up to three phase values.
-
-    Optionally awaits a fresh push (with a 2 s cap) when the matched
-    powermeter has ``WAIT_FOR_NEXT_MESSAGE`` enabled. A timeout there is
-    swallowed so the cached value is still served — `update_readings`
-    callers should never see a stale-meter `TimeoutError`.
-    """
-    powermeter = None
-    wait_for_next = False
-    for configured in powermeters:
-        if configured.client_filter.matches(addr[0]):
-            powermeter = configured.powermeter
-            wait_for_next = configured.wait_for_next_message
-            break
-    if powermeter is None:
-        logger.debug(f"No powermeter found for client {addr[0]}")
+    """Pick the powermeter matching *addr* and return up to three phase values."""
+    configured = powermeter_for(powermeters, addr[0])
+    if configured is None:
+        logger.debug("No powermeter found for client %s", addr[0])
         return None
-    if wait_for_next:
-        try:
-            await powermeter.wait_for_next_message(timeout=2)
-        except TimeoutError:
-            logger.debug(
-                "Powermeter %s produced no fresh message within 2s; "
-                "serving last known value",
-                _powermeter_log_name(powermeter),
-            )
-    return three_phases(await powermeter.get_powermeter_watts())
+    return three_phases(await read_fresh(configured))
 
 
 async def _read_grid_phases(powermeters: list[ConfiguredPowermeter]) -> list[float]:
@@ -113,7 +82,7 @@ async def _read_grid_phases(powermeters: list[ConfiguredPowermeter]) -> list[flo
     return [float(v) for v in three_phases(await chosen.get_powermeter_watts_raw())]
 
 
-async def check_powermeter(powermeter: Powermeter, client_filter: ClientFilter):
+async def check_powermeter(powermeter: Powermeter, client_filter: ClientFilter) -> None:
     """Prove the meter delivers a reading before any battery is served."""
     attempts = 4
     retry_delay_s = 5
@@ -133,7 +102,7 @@ async def check_powermeter(powermeter: Powermeter, client_filter: ClientFilter):
             continue
         logger.info(
             "Successfully fetched %s powermeter value (filter %s): %s",
-            _powermeter_log_name(powermeter),
+            powermeter_name(powermeter),
             ", ".join(str(n) for n in client_filter.netmasks),
             " | ".join(f"{v}W" for v in values),
         )
@@ -259,12 +228,7 @@ def _build_device(
     if udp_port is not None:
         logger.debug("Shelly settings: device id %s, type %s", device_id, device_type)
         return Shelly(
-            # `Shelly` still declares the positional triple this named tuple
-            # replaced; the cast goes away once it takes a
-            # `Sequence[ConfiguredPowermeter]` too.
-            powermeters=cast(
-                "list[tuple[Powermeter, ClientFilter, bool]]", powermeters
-            ),
+            powermeters=powermeters,
             device_id=device_id,
             device_type=device_type,
             udp_port=udp_port,
@@ -673,8 +637,8 @@ def _resolve_device_config(
             "Set UDP_PORT in [CT002]/[CT003] to avoid conflicts."
         )
 
-    logger.info(f"Device Types: {device_types}")
-    logger.info(f"Device IDs: {device_ids}")
+    logger.info("Device Types: %s", device_types)
+    logger.info("Device IDs: %s", device_ids)
     logger.info(f"Skip Test: {skip_test}")
 
     return device_types, device_ids, skip_test

--- a/src/astrameter/main_test.py
+++ b/src/astrameter/main_test.py
@@ -16,7 +16,7 @@ class _StubPowermeter(Powermeter):
         values: list[float],
         wait_raises: BaseException | None = None,
         wait_calls: list[float] | None = None,
-    ):
+    ) -> None:
         self._values = values
         self._wait_raises = wait_raises
         self._wait_calls = wait_calls if wait_calls is not None else []
@@ -27,7 +27,7 @@ class _StubPowermeter(Powermeter):
     async def get_powermeter_watts_raw(self) -> list[float]:
         return list(self._values)
 
-    async def wait_for_next_message(self, timeout=5):
+    async def wait_for_next_message(self, timeout: float = 5) -> None:
         self._wait_calls.append(timeout)
         if self._wait_raises is not None:
             raise self._wait_raises
@@ -36,19 +36,19 @@ class _StubPowermeter(Powermeter):
 _LOCAL = ClientFilter([IPv4Network("127.0.0.1/32")])
 
 
-async def test_read_ct_powermeter_returns_none_when_no_match():
+async def test_read_ct_powermeter_returns_none_when_no_match() -> None:
     pm = _StubPowermeter([10.0])
     powermeters = [ConfiguredPowermeter(pm, _LOCAL, True)]
     assert await read_ct_powermeter(("10.0.0.1", 0), powermeters) is None
 
 
-async def test_read_ct_powermeter_pads_to_three_phases():
+async def test_read_ct_powermeter_pads_to_three_phases() -> None:
     pm = _StubPowermeter([42.0])
     powermeters = [ConfiguredPowermeter(pm, _LOCAL, False)]
     assert await read_ct_powermeter(("127.0.0.1", 0), powermeters) == [42.0, 0, 0]
 
 
-async def test_read_ct_powermeter_skips_wait_when_disabled():
+async def test_read_ct_powermeter_skips_wait_when_disabled() -> None:
     pm = _StubPowermeter([1.0, 2.0, 3.0])
     powermeters = [ConfiguredPowermeter(pm, _LOCAL, False)]
     result = await read_ct_powermeter(("127.0.0.1", 0), powermeters)
@@ -56,14 +56,14 @@ async def test_read_ct_powermeter_skips_wait_when_disabled():
     assert pm._wait_calls == []
 
 
-async def test_read_ct_powermeter_calls_wait_with_2s_when_enabled():
+async def test_read_ct_powermeter_calls_wait_with_2s_when_enabled() -> None:
     pm = _StubPowermeter([1.0, 2.0, 3.0])
     powermeters = [ConfiguredPowermeter(pm, _LOCAL, True)]
     await read_ct_powermeter(("127.0.0.1", 0), powermeters)
     assert pm._wait_calls == [2]
 
 
-async def test_stub_powermeter_raw_matches_watts():
+async def test_stub_powermeter_raw_matches_watts() -> None:
     pm = _StubPowermeter([3.0, 4.0, 5.0])
     assert (
         await pm.get_powermeter_watts_raw()
@@ -76,7 +76,7 @@ async def test_stub_powermeter_raw_matches_watts():
     )
 
 
-async def test_read_ct_powermeter_swallows_timeout_and_serves_cached():
+async def test_read_ct_powermeter_swallows_timeout_and_serves_cached() -> None:
     """Issue #327: a slow push meter must not break CT002 responses."""
     pm = _StubPowermeter(
         [11.0, 22.0, 33.0],
@@ -99,20 +99,20 @@ def _resolve(device_type: str) -> tuple[list[str], list[str]]:
     return device_types, device_ids
 
 
-def test_resolve_device_config_shellypro3em_new_gets_shelly_id():
+def test_resolve_device_config_shellypro3em_new_gets_shelly_id() -> None:
     """Issue #389: explicit shellypro3em_new must use a shellypro3em-* id."""
     device_types, device_ids = _resolve("shellypro3em_new")
     assert device_types == ["shellypro3em_new"]
     assert device_ids == ["shellypro3em-ec4609c439c1"]
 
 
-def test_resolve_device_config_shellypro3em_old_gets_shelly_id():
+def test_resolve_device_config_shellypro3em_old_gets_shelly_id() -> None:
     device_types, device_ids = _resolve("shellypro3em_old")
     assert device_types == ["shellypro3em_old"]
     assert device_ids == ["shellypro3em-ec4609c439c1"]
 
 
-def test_resolve_device_config_shellypro3em_expands_to_old_and_new():
+def test_resolve_device_config_shellypro3em_expands_to_old_and_new() -> None:
     device_types, device_ids = _resolve("shellypro3em")
     assert device_types == ["shellypro3em_old", "shellypro3em_new"]
     assert device_ids == ["shellypro3em-ec4609c439c1", "shellypro3em-ec4609c439c1"]

--- a/src/astrameter/marstek_api.py
+++ b/src/astrameter/marstek_api.py
@@ -39,7 +39,7 @@ def _translate_marstek_message(code: Any, msg: Any) -> str:
 
 def _http_get_json(
     url: str, params: dict[str, Any], headers: dict[str, str] | None = None
-):
+) -> Any:
     query = urllib.parse.urlencode(params)
     full_url = f"{url}?{query}"
     req = urllib.request.Request(full_url, headers=headers or {}, method="GET")
@@ -189,7 +189,7 @@ def _add_device(
     token: str,
     device_type: str,
     devid_mac: str,
-):
+) -> Any:
     add_url = f"{cfg.base_url.rstrip('/')}/app/Solar/v2_add_device.php"
     type_value = _desired_type(device_type)
     suffix = devid_mac[-4:]

--- a/src/astrameter/meter_pool.py
+++ b/src/astrameter/meter_pool.py
@@ -1,0 +1,60 @@
+"""Picking the power source that answers a given client, and reading it.
+
+Both emulators are handed the same list of configured sources and the address
+of the battery polling them, and both have to answer from the one whose
+``NETMASK`` covers that address — pausing first, when that source asked to be
+read on its own cadence, for something newer than the value the previous poll
+already served.
+"""
+
+from __future__ import annotations
+
+from astrameter.config.logger import logger
+from astrameter.config.settings import ConfiguredPowermeter
+from astrameter.powermeter import Powermeter
+from astrameter.powermeter.wrappers.health import HealthTrackingPowermeter
+
+#: How long a poll waits for a pushed reading before serving the last one.
+#: Batteries poll about once a second, so a longer wait would answer after the
+#: poll it is answering has already been retried.
+FRESH_MESSAGE_TIMEOUT_S = 2.0
+
+
+def powermeter_name(powermeter: Powermeter) -> str:
+    """The meter class behind the health wrapper every configured meter gets."""
+    inner = (
+        powermeter.wrapped_powermeter
+        if isinstance(powermeter, HealthTrackingPowermeter)
+        else powermeter
+    )
+    return type(inner).__name__
+
+
+def powermeter_for(
+    pool: list[ConfiguredPowermeter], client_ip: str
+) -> ConfiguredPowermeter | None:
+    """The first source in *pool* whose client filter covers *client_ip*."""
+    for configured in pool:
+        if configured.client_filter.matches(client_ip):
+            return configured
+    return None
+
+
+async def read_fresh(configured: ConfiguredPowermeter) -> list[float]:
+    """Per-phase watts, waiting out one push first when the source asked for it.
+
+    A timed-out wait serves the cached value rather than raising: a meter that
+    has gone quiet is a stale reading, not a failed poll.
+    """
+    powermeter = configured.powermeter
+    if configured.wait_for_next_message:
+        try:
+            await powermeter.wait_for_next_message(timeout=FRESH_MESSAGE_TIMEOUT_S)
+        except TimeoutError:
+            logger.debug(
+                "Powermeter %s produced no fresh message within %.0fs; "
+                "serving last known value",
+                powermeter_name(powermeter),
+                FRESH_MESSAGE_TIMEOUT_S,
+            )
+    return await powermeter.get_powermeter_watts()

--- a/src/astrameter/mqtt_insights/mqtt_insights_test.py
+++ b/src/astrameter/mqtt_insights/mqtt_insights_test.py
@@ -8,6 +8,8 @@ import contextlib
 import json
 import re
 import time
+from collections.abc import AsyncIterator, Callable
+from typing import Any
 from unittest.mock import AsyncMock
 
 import aiomqtt
@@ -68,7 +70,7 @@ def _assert_discovery_structure(topic: str, payload: dict) -> None:
         _assert_valid_node_id(_sanitize_id(comp["unique_id"]))
 
 
-def test_ct002_consumer_discovery_structure():
+def test_ct002_consumer_discovery_structure() -> None:
     topic, payload = build_ct002_consumer_discovery(
         "astrameter", "dev1", "aabbccddeeff", "homeassistant", device_type="HMJ-2"
     )
@@ -193,7 +195,7 @@ def test_ct002_consumer_discovery_structure():
     assert min_dc["entity_category"] == "config"
 
 
-def test_min_dc_output_entity_only_for_external_inverter_types():
+def test_min_dc_output_entity_only_for_external_inverter_types() -> None:
     """The Min DC Output number is gated on the device-capabilities classifier."""
 
     def _components(device_type: str) -> dict:
@@ -214,7 +216,7 @@ def test_min_dc_output_entity_only_for_external_inverter_types():
         assert "min_dc_output" not in _components(dt), dt
 
 
-def test_ct002_consumer_discovery_no_device_type():
+def test_ct002_consumer_discovery_no_device_type() -> None:
     """Name omits device_type when empty."""
     _, payload = build_ct002_consumer_discovery(
         "astrameter", "dev1", "aabbccddeeff", "homeassistant"
@@ -224,7 +226,7 @@ def test_ct002_consumer_discovery_no_device_type():
     assert "model_id" not in dev
 
 
-def test_ct002_consumer_discovery_non_mac_consumer():
+def test_ct002_consumer_discovery_non_mac_consumer() -> None:
     """Non-MAC consumer_id has no connections but is still linked via via_device."""
     _, payload = build_ct002_consumer_discovery(
         "astrameter", "dev1", "192.168.1.1:12345", "homeassistant"
@@ -233,7 +235,7 @@ def test_ct002_consumer_discovery_non_mac_consumer():
     assert payload["device"]["via_device"] == "astrameter_ct002_dev1"
 
 
-def test_ct002_consumer_discovery_emits_no_connections_issue_438():
+def test_ct002_consumer_discovery_emits_no_connections_issue_438() -> None:
     """The consumer device advertises NO ``connections`` at all.
 
     Advertising the battery's own MAC (bluetooth or mac) would make HA merge
@@ -256,7 +258,7 @@ def test_ct002_consumer_discovery_emits_no_connections_issue_438():
     assert dev["via_device"] == "astrameter_ct002_dev1"
 
 
-def test_ct002_device_discovery_structure():
+def test_ct002_device_discovery_structure() -> None:
     topic, payload = build_ct002_device_discovery(
         "astrameter",
         "dev1",
@@ -328,7 +330,7 @@ def test_ct002_device_discovery_structure():
     assert btn["entity_category"] == "config"
 
 
-def test_ct002_device_discovery_omits_force_rotation_without_efficiency():
+def test_ct002_device_discovery_omits_force_rotation_without_efficiency() -> None:
     """The Force Rotation button is only surfaced when efficiency rotation is
     enabled (the default omits it — there's nothing to rotate)."""
     _, default_payload = build_ct002_device_discovery(
@@ -346,7 +348,7 @@ def test_ct002_device_discovery_omits_force_rotation_without_efficiency():
     assert "force_rotation" in enabled_payload["components"]
 
 
-def test_ct002_consumer_discovery_gates_efficiency_window_weight():
+def test_ct002_consumer_discovery_gates_efficiency_window_weight() -> None:
     """The Efficiency Window Weight number is only surfaced when efficiency
     rotation is enabled (the default omits it — every battery stays active)."""
     _, default_payload = build_ct002_consumer_discovery(
@@ -377,7 +379,7 @@ def test_ct002_consumer_discovery_gates_efficiency_window_weight():
     assert "* 100" in eww["value_template"]
 
 
-def test_shelly_battery_discovery_structure():
+def test_shelly_battery_discovery_structure() -> None:
     topic, payload = build_shelly_battery_discovery(
         "astrameter", "shelly1", "192.168.1.100", "homeassistant"
     )
@@ -416,7 +418,7 @@ def test_shelly_battery_discovery_structure():
     ],
     ids=["ct002_consumer", "shelly_battery"],
 )
-def test_retirement_payload_removes_retired_entities(build):
+def test_retirement_payload_removes_retired_entities(build: Callable[..., Any]) -> None:
     """The retirement variant deletes dropped entities, keeps the rest intact."""
     _topic, payload = build()
     retirement = build_retirement_payload(payload)
@@ -436,7 +438,7 @@ def test_retirement_payload_removes_retired_entities(build):
     assert "last_seen" not in payload["components"]
 
 
-def test_shelly_device_discovery_structure():
+def test_shelly_device_discovery_structure() -> None:
     topic, payload = build_shelly_device_discovery(
         "astrameter", "shelly1", "homeassistant", addon_slug="34dea19a_astrameter"
     )
@@ -446,7 +448,7 @@ def test_shelly_device_discovery_structure():
     assert "battery_count" in payload["components"]
 
 
-def test_powermeter_device_discovery_structure():
+def test_powermeter_device_discovery_structure() -> None:
     topic, payload = build_powermeter_device_discovery(
         "astrameter",
         "MQTT_1",
@@ -489,26 +491,26 @@ def test_powermeter_device_discovery_structure():
     assert "value_json.grid_power.total" in comps["grid_power_total"]["value_template"]
 
 
-def test_powermeter_device_discovery_capital_cases_multiword_section():
+def test_powermeter_device_discovery_capital_cases_multiword_section() -> None:
     _, payload = build_powermeter_device_discovery(
         "astrameter", "SMA_ENERGY_METER", "SMA_ENERGY_METER", "homeassistant"
     )
     assert payload["device"]["name"] == "AstraMeter Powermeter Sma Energy Meter"
 
 
-def test_powermeter_device_discovery_omits_via_device_without_addon_slug():
+def test_powermeter_device_discovery_omits_via_device_without_addon_slug() -> None:
     _, payload = build_powermeter_device_discovery(
         "astrameter", "HOMEWIZARD", "HOMEWIZARD", "homeassistant"
     )
     assert "via_device" not in payload["device"]
 
 
-def test_meter_device_discovery_omits_via_device_without_addon_slug():
+def test_meter_device_discovery_omits_via_device_without_addon_slug() -> None:
     _, ct002 = build_ct002_device_discovery("astrameter", "dev1", "homeassistant")
     assert "via_device" not in ct002["device"]
 
 
-def test_addon_device_discovery_structure():
+def test_addon_device_discovery_structure() -> None:
     topic, payload = build_addon_device_discovery(
         "astrameter", "34dea19a_astrameter", "homeassistant"
     )
@@ -550,7 +552,7 @@ def test_addon_device_discovery_structure():
         ]
 
 
-def test_addon_device_discovery_links_meter_via_device():
+def test_addon_device_discovery_links_meter_via_device() -> None:
     """The hub's identifiers must equal the slug used as meter via_device."""
     _, hub = build_addon_device_discovery(
         "astrameter", "abc123_astrameter", "homeassistant"
@@ -563,7 +565,7 @@ def test_addon_device_discovery_links_meter_via_device():
     assert "via_device" not in shelly["device"]
 
 
-def test_unique_ids_are_unique():
+def test_unique_ids_are_unique() -> None:
     """All unique_ids within a single discovery payload must be distinct."""
     _, payload = build_ct002_consumer_discovery(
         "astrameter", "dev1", "cons1", "homeassistant"
@@ -572,7 +574,7 @@ def test_unique_ids_are_unique():
     assert len(uids) == len(set(uids))
 
 
-def test_sanitize_id():
+def test_sanitize_id() -> None:
     assert _sanitize_id("192.168.1.100") == "192_168_1_100"
     assert _sanitize_id("AA:BB:CC") == "AA_BB_CC"
     assert _sanitize_id("normal-id_123") == "normal-id_123"
@@ -581,7 +583,7 @@ def test_sanitize_id():
 # ── Config tests ──────────────────────────────────────────────────────────
 
 
-def test_config_guard_mqtt_vs_mqtt_insights():
+def test_config_guard_mqtt_vs_mqtt_insights() -> None:
     """[MQTT] creates a powermeter, [MQTT_INSIGHTS] does not."""
     cfg = configparser.ConfigParser()
     cfg.read_string(
@@ -605,7 +607,7 @@ PORT = 1883
     assert pm2 is None
 
 
-def test_read_mqtt_insights_config_present():
+def test_read_mqtt_insights_config_present() -> None:
     cfg = configparser.ConfigParser()
     cfg.read_string(
         """
@@ -634,7 +636,7 @@ ADDON_SLUG = 34dea19a_astrameter
     assert result.addon_slug == "34dea19a_astrameter"
 
 
-def test_read_mqtt_insights_config_defaults():
+def test_read_mqtt_insights_config_defaults() -> None:
     cfg = configparser.ConfigParser()
     cfg.read_string(
         """
@@ -652,7 +654,7 @@ BROKER = localhost
     assert result.addon_slug is None
 
 
-def test_read_mqtt_insights_config_empty_values():
+def test_read_mqtt_insights_config_empty_values() -> None:
     cfg = configparser.ConfigParser()
     cfg.read_string(
         """
@@ -681,7 +683,7 @@ ADDON_SLUG =
     assert result.addon_slug is None
 
 
-def test_read_mqtt_insights_config_whitespace_addon_slug():
+def test_read_mqtt_insights_config_whitespace_addon_slug() -> None:
     """Whitespace-only ADDON_SLUG values must be normalised to None."""
     cfg = configparser.ConfigParser()
     cfg.add_section("MQTT_INSIGHTS")
@@ -692,13 +694,13 @@ def test_read_mqtt_insights_config_whitespace_addon_slug():
     assert result.addon_slug is None
 
 
-def test_read_mqtt_insights_config_absent():
+def test_read_mqtt_insights_config_absent() -> None:
     cfg = configparser.ConfigParser()
     cfg.read_string("[GENERAL]\nDEVICE_TYPE=ct002\n")
     assert read_mqtt_insights_config(cfg) is None
 
 
-def test_read_mqtt_insights_config_marstek_mqtt_default_true():
+def test_read_mqtt_insights_config_marstek_mqtt_default_true() -> None:
     cfg = configparser.ConfigParser()
     cfg.read_string("[MQTT_INSIGHTS]\nBROKER = localhost\n")
     result = read_mqtt_insights_config(cfg)
@@ -706,7 +708,7 @@ def test_read_mqtt_insights_config_marstek_mqtt_default_true():
     assert result.marstek_mqtt_enabled is True
 
 
-def test_read_mqtt_insights_config_marstek_mqtt_opt_out():
+def test_read_mqtt_insights_config_marstek_mqtt_opt_out() -> None:
     cfg = configparser.ConfigParser()
     cfg.read_string(
         "[MQTT_INSIGHTS]\nBROKER = localhost\nMARSTEK_MQTT_ENABLED = false\n"
@@ -716,7 +718,7 @@ def test_read_mqtt_insights_config_marstek_mqtt_opt_out():
     assert result.marstek_mqtt_enabled is False
 
 
-def test_read_mqtt_insights_config_marstek_mqtt_interval_default():
+def test_read_mqtt_insights_config_marstek_mqtt_interval_default() -> None:
     cfg = configparser.ConfigParser()
     cfg.read_string("[MQTT_INSIGHTS]\nBROKER = localhost\n")
     result = read_mqtt_insights_config(cfg)
@@ -724,7 +726,7 @@ def test_read_mqtt_insights_config_marstek_mqtt_interval_default():
     assert result.marstek_mqtt_interval == 300
 
 
-def test_read_mqtt_insights_config_marstek_mqtt_interval_custom():
+def test_read_mqtt_insights_config_marstek_mqtt_interval_custom() -> None:
     cfg = configparser.ConfigParser()
     cfg.read_string("[MQTT_INSIGHTS]\nBROKER = localhost\nMARSTEK_MQTT_INTERVAL = 60\n")
     result = read_mqtt_insights_config(cfg)
@@ -732,7 +734,7 @@ def test_read_mqtt_insights_config_marstek_mqtt_interval_custom():
     assert result.marstek_mqtt_interval == 60
 
 
-def test_read_mqtt_insights_config_marstek_mqtt_interval_zero():
+def test_read_mqtt_insights_config_marstek_mqtt_interval_zero() -> None:
     cfg = configparser.ConfigParser()
     cfg.read_string("[MQTT_INSIGHTS]\nBROKER = localhost\nMARSTEK_MQTT_INTERVAL = 0\n")
     result = read_mqtt_insights_config(cfg)
@@ -740,7 +742,7 @@ def test_read_mqtt_insights_config_marstek_mqtt_interval_zero():
     assert result.marstek_mqtt_interval == 0
 
 
-def test_read_mqtt_insights_config_powermeter_health_interval_default():
+def test_read_mqtt_insights_config_powermeter_health_interval_default() -> None:
     cfg = configparser.ConfigParser()
     cfg.read_string("[MQTT_INSIGHTS]\nBROKER = localhost\n")
     result = read_mqtt_insights_config(cfg)
@@ -748,7 +750,7 @@ def test_read_mqtt_insights_config_powermeter_health_interval_default():
     assert result.powermeter_health_interval == 30.0
 
 
-def test_read_mqtt_insights_config_powermeter_health_interval_custom():
+def test_read_mqtt_insights_config_powermeter_health_interval_custom() -> None:
     cfg = configparser.ConfigParser()
     cfg.read_string(
         "[MQTT_INSIGHTS]\nBROKER = localhost\nPOWERMETER_HEALTH_INTERVAL = 15\n"
@@ -758,7 +760,7 @@ def test_read_mqtt_insights_config_powermeter_health_interval_custom():
     assert result.powermeter_health_interval == 15.0
 
 
-def test_read_mqtt_insights_config_powermeter_health_interval_zero():
+def test_read_mqtt_insights_config_powermeter_health_interval_zero() -> None:
     cfg = configparser.ConfigParser()
     cfg.read_string(
         "[MQTT_INSIGHTS]\nBROKER = localhost\nPOWERMETER_HEALTH_INTERVAL = 0\n"
@@ -771,7 +773,7 @@ def test_read_mqtt_insights_config_powermeter_health_interval_zero():
 # ── Service unit tests (no broker) ───────────────────────────────────────
 
 
-def test_queue_overflow_does_not_raise():
+def test_queue_overflow_does_not_raise() -> None:
     """Overflowing the queue should not raise."""
     service = MqttInsightsService(MqttInsightsConfig(broker="localhost"))
     for i in range(200):
@@ -779,7 +781,7 @@ def test_queue_overflow_does_not_raise():
     # No exception raised
 
 
-def test_queue_dropped_counter():
+def test_queue_dropped_counter() -> None:
     """Every drop-oldest overflow is counted, so the dashboard can show that
     events were lost rather than silently under-reporting."""
     service = MqttInsightsService(MqttInsightsConfig(broker="localhost"))
@@ -828,7 +830,7 @@ def _health_service() -> MqttInsightsService:
     return MqttInsightsService(MqttInsightsConfig(broker="localhost"))
 
 
-async def test_powermeter_status_push_reports_stream_state_and_readings():
+async def test_powermeter_status_push_reports_stream_state_and_readings() -> None:
     service = _health_service()
     online, values = await service._powermeter_status(_PushMeter(True, [1.0, 2.0, 3.0]))
     assert online is True
@@ -837,7 +839,7 @@ async def test_powermeter_status_push_reports_stream_state_and_readings():
     assert online is False
 
 
-async def test_powermeter_status_push_exception_reports_offline():
+async def test_powermeter_status_push_exception_reports_offline() -> None:
     """A meter whose stream_online() raises must report offline, not crash the
     health loop (which would tear down the gather and force a reconnect)."""
 
@@ -854,7 +856,7 @@ async def test_powermeter_status_push_exception_reports_offline():
     assert values is None
 
 
-async def test_powermeter_status_pull_reuses_recent_control_read():
+async def test_powermeter_status_pull_reuses_recent_control_read() -> None:
     """A pull meter read by the control loop within the idle window is reused
     without issuing a probe."""
     inner = _PullMeter([42.0])
@@ -869,7 +871,7 @@ async def test_powermeter_status_pull_reuses_recent_control_read():
     assert inner.probes == 1  # reused, no extra probe
 
 
-async def test_powermeter_status_pull_reuses_recent_failure():
+async def test_powermeter_status_pull_reuses_recent_failure() -> None:
     inner = _PullMeter(raises=True)
     pm = HealthTrackingPowermeter(inner, name="SCRIPT_1")
     with contextlib.suppress(ValueError):
@@ -883,7 +885,7 @@ async def test_powermeter_status_pull_reuses_recent_failure():
     assert inner.probes == probes_after_control  # reused failure, no probe
 
 
-async def test_powermeter_status_idle_pull_is_probed_once():
+async def test_powermeter_status_idle_pull_is_probed_once() -> None:
     inner = _PullMeter([7.0])
     pm = HealthTrackingPowermeter(inner, name="SCRIPT_1")
     # No control-loop read recorded -> idle -> probe.
@@ -894,7 +896,7 @@ async def test_powermeter_status_idle_pull_is_probed_once():
     assert inner.probes == 1
 
 
-async def test_powermeter_status_idle_pull_probe_failure_is_offline():
+async def test_powermeter_status_idle_pull_probe_failure_is_offline() -> None:
     inner = _PullMeter(raises=True)
     pm = HealthTrackingPowermeter(inner, name="SCRIPT_1")
     service = _health_service()
@@ -904,7 +906,7 @@ async def test_powermeter_status_idle_pull_probe_failure_is_offline():
     assert inner.probes == 1
 
 
-async def test_powermeter_status_stale_control_read_falls_back_to_probe():
+async def test_powermeter_status_stale_control_read_falls_back_to_probe() -> None:
     inner = _PullMeter([5.0])
     pm = HealthTrackingPowermeter(inner, name="SCRIPT_1")
     await pm.get_powermeter_watts()
@@ -918,7 +920,7 @@ async def test_powermeter_status_stale_control_read_falls_back_to_probe():
     assert inner.probes == 2  # one control read + one fallback probe
 
 
-def test_grid_power_payload_phase_counts():
+def test_grid_power_payload_phase_counts() -> None:
     assert MqttInsightsService._grid_power_payload([1.0, 2.0, 3.0]) == {
         "l1": 1.0,
         "l2": 2.0,
@@ -939,7 +941,7 @@ def test_grid_power_payload_phase_counts():
     }
 
 
-async def test_publish_powermeter_health_state_and_discovery_once():
+async def test_publish_powermeter_health_state_and_discovery_once() -> None:
     service = MqttInsightsService(
         MqttInsightsConfig(
             broker="localhost", base_topic="am", ha_discovery_prefix="ha"
@@ -971,7 +973,7 @@ async def test_publish_powermeter_health_state_and_discovery_once():
     assert topics2 == ["am/powermeter/MQTT_1"]
 
 
-def test_hub_identifier_uses_addon_slug_when_set():
+def test_hub_identifier_uses_addon_slug_when_set() -> None:
     svc = MqttInsightsService(
         MqttInsightsConfig(
             broker="localhost", base_topic="am", addon_slug="34dea19a_astrameter"
@@ -980,14 +982,14 @@ def test_hub_identifier_uses_addon_slug_when_set():
     assert svc._hub_identifier() == "34dea19a_astrameter"
 
 
-def test_hub_identifier_falls_back_to_base_topic_without_addon_slug():
+def test_hub_identifier_falls_back_to_base_topic_without_addon_slug() -> None:
     svc = MqttInsightsService(
         MqttInsightsConfig(broker="localhost", base_topic="astra")
     )
     assert svc._hub_identifier() == "astrameter_astra"
 
 
-async def test_publish_powermeter_health_links_hub_via_fallback():
+async def test_publish_powermeter_health_links_hub_via_fallback() -> None:
     """Without ADDON_SLUG the powermeter device still links to the AstraMeter
     hub via the base-topic fallback identifier (standalone/Docker)."""
     service = MqttInsightsService(
@@ -1009,7 +1011,13 @@ async def test_publish_powermeter_health_links_hub_via_fallback():
 # ── E2E helpers ──────────────────────────────────────────────────────────
 
 
-async def _collect_messages(sub, target, *, timeout=5, stop=None):
+async def _collect_messages(
+    sub: Any,
+    target: list[Any],
+    *,
+    timeout: float = 5,
+    stop: Callable[[Any], bool] | None = None,
+) -> None:
     """Collect messages from *sub* into *target* list.
 
     *stop* is an optional callable(msg) → bool that ends collection early.
@@ -1017,7 +1025,7 @@ async def _collect_messages(sub, target, *, timeout=5, stop=None):
     Compatible with Python 3.10 (no asyncio.timeout).
     """
 
-    async def _inner():
+    async def _inner() -> None:
         async for msg in sub.messages:
             target.append(msg)
             if stop is not None:
@@ -1030,10 +1038,12 @@ async def _collect_messages(sub, target, *, timeout=5, stop=None):
         await asyncio.wait_for(_inner(), timeout=timeout)
 
 
-async def _poll(predicate, *, timeout=5, interval=0.05):
+async def _poll(
+    predicate: Callable[[], bool], *, timeout: float = 5, interval: float = 0.05
+) -> None:
     """Poll *predicate* until it returns True, or raise on timeout."""
 
-    async def _inner():
+    async def _inner() -> None:
         while not predicate():
             await asyncio.sleep(interval)
 
@@ -1108,7 +1118,7 @@ SAMPLE_SHELLY_DATA = {
 
 
 @needs_mosquitto
-async def test_publishes_state_on_ct002_event(mqtt_broker):
+async def test_publishes_state_on_ct002_event(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     base = service._config.base_topic
@@ -1117,7 +1127,7 @@ async def test_publishes_state_on_ct002_event(mqtt_broker):
     try:
         await service.wait_connected()
 
-        received = []
+        received: list[Any] = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
             await sub.subscribe(f"{base}/ct002/+/consumer/+")
             service.on_ct002_response("dev1", "consumer1", SAMPLE_CT002_DATA)
@@ -1141,7 +1151,7 @@ async def test_publishes_state_on_ct002_event(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_publishes_device_status(mqtt_broker):
+async def test_publishes_device_status(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     base = service._config.base_topic
@@ -1150,7 +1160,7 @@ async def test_publishes_device_status(mqtt_broker):
     try:
         await service.wait_connected()
 
-        received = []
+        received: list[Any] = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
             await sub.subscribe(f"{base}/ct002/+/status")
             service.on_ct002_response("dev1", "consumer1", SAMPLE_CT002_DATA)
@@ -1172,7 +1182,9 @@ async def test_publishes_device_status(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_device_status_defaults_control_quality_when_absent(mqtt_broker):
+async def test_device_status_defaults_control_quality_when_absent(
+    mqtt_broker: int,
+) -> None:
     """An event from an older/reduced producer must not break the entity.
 
     HA's enum sensor rejects a state outside its ``options``, so the fallback
@@ -1186,7 +1198,7 @@ async def test_device_status_defaults_control_quality_when_absent(mqtt_broker):
     try:
         await service.wait_connected()
 
-        received = []
+        received: list[Any] = []
         data = {
             k: v
             for k, v in SAMPLE_CT002_DATA.items()
@@ -1213,7 +1225,7 @@ async def test_device_status_defaults_control_quality_when_absent(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_publishes_ha_discovery_on_first_event(mqtt_broker):
+async def test_publishes_ha_discovery_on_first_event(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     ha_prefix = service._config.ha_discovery_prefix
@@ -1222,7 +1234,7 @@ async def test_publishes_ha_discovery_on_first_event(mqtt_broker):
     try:
         await service.wait_connected()
 
-        discovery_msgs = []
+        discovery_msgs: list[Any] = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
             await sub.subscribe(f"{ha_prefix}/device/#")
             # First event for consumer1
@@ -1274,7 +1286,7 @@ async def test_publishes_ha_discovery_on_first_event(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_publishes_addon_hub_device_and_bridge(mqtt_broker):
+async def test_publishes_addon_hub_device_and_bridge(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port, addon_slug="abc123_astrameter")
     cfg = service._config
@@ -1370,7 +1382,7 @@ class _FakeDevice:
 
 
 @needs_mosquitto
-async def test_active_toggle_via_mqtt(mqtt_broker):
+async def test_active_toggle_via_mqtt(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     base = service._config.base_topic
@@ -1402,7 +1414,7 @@ async def test_active_toggle_via_mqtt(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_consumer_removal_publishes_offline(mqtt_broker):
+async def test_consumer_removal_publishes_offline(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     base = service._config.base_topic
@@ -1415,7 +1427,7 @@ async def test_consumer_removal_publishes_offline(mqtt_broker):
         service.on_ct002_response("dev1", "consumer1", SAMPLE_CT002_DATA)
         await _poll(lambda: (CT002_CONSUMER, "dev1/consumer1") in service._discovered)
 
-        received = []
+        received: list[Any] = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
             await sub.subscribe(f"{base}/ct002/dev1/consumer/consumer1/availability")
             service.on_ct002_consumer_removed("dev1", "consumer1")
@@ -1432,7 +1444,7 @@ async def test_consumer_removal_publishes_offline(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_lwt_online_offline(mqtt_broker):
+async def test_lwt_online_offline(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     base = service._config.base_topic
@@ -1442,7 +1454,7 @@ async def test_lwt_online_offline(mqtt_broker):
         await service.wait_connected()
 
         # Check online status
-        received = []
+        received: list[Any] = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
             await sub.subscribe(f"{base}/status")
             # The retained "online" message should arrive
@@ -1455,7 +1467,7 @@ async def test_lwt_online_offline(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_shelly_event_flow(mqtt_broker):
+async def test_shelly_event_flow(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     base = service._config.base_topic
@@ -1464,7 +1476,7 @@ async def test_shelly_event_flow(mqtt_broker):
     try:
         await service.wait_connected()
 
-        received = []
+        received: list[Any] = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
             await sub.subscribe(f"{base}/shelly/+/battery/+")
             service.on_shelly_response("shelly1", "192.168.1.100", SAMPLE_SHELLY_DATA)
@@ -1481,7 +1493,7 @@ async def test_shelly_event_flow(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_manual_target_command_via_mqtt(mqtt_broker) -> None:
+async def test_manual_target_command_via_mqtt(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     base = service._config.base_topic
@@ -1506,7 +1518,7 @@ async def test_manual_target_command_via_mqtt(mqtt_broker) -> None:
 
 
 @needs_mosquitto
-async def test_auto_target_command_via_mqtt(mqtt_broker) -> None:
+async def test_auto_target_command_via_mqtt(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     base = service._config.base_topic
@@ -1531,7 +1543,7 @@ async def test_auto_target_command_via_mqtt(mqtt_broker) -> None:
 
 
 @needs_mosquitto
-async def test_distribution_weight_command_via_mqtt(mqtt_broker) -> None:
+async def test_distribution_weight_command_via_mqtt(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     base = service._config.base_topic
@@ -1696,7 +1708,7 @@ def test_invalid_or_unknown_retained_command_not_buffered() -> None:
 
 
 @needs_mosquitto
-async def test_retained_command_redelivered_on_restart(mqtt_broker) -> None:
+async def test_retained_command_redelivered_on_restart(mqtt_broker: int) -> None:
     """End-to-end: a retained command sitting on the broker is applied on the
     next connect even though the handler registers *after* start()/subscribe —
     the ordering that occurs on an app restart."""
@@ -1728,7 +1740,7 @@ async def test_retained_command_redelivered_on_restart(mqtt_broker) -> None:
 
 
 @needs_mosquitto
-async def test_force_rotation_command_via_mqtt(mqtt_broker) -> None:
+async def test_force_rotation_command_via_mqtt(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     base = service._config.base_topic
@@ -1752,7 +1764,7 @@ async def test_force_rotation_command_via_mqtt(mqtt_broker) -> None:
         await service.stop()
 
 
-def test_active_control_device_command_dispatch():
+def test_active_control_device_command_dispatch() -> None:
     """The device-level active_control field routes booleans to the handler
     and rejects non-boolean payloads."""
     service = _make_service(1883)
@@ -1775,7 +1787,7 @@ def test_active_control_device_command_dispatch():
 
 
 @needs_mosquitto
-async def test_active_control_toggle_via_mqtt(mqtt_broker) -> None:
+async def test_active_control_toggle_via_mqtt(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     base = service._config.base_topic
@@ -1800,7 +1812,7 @@ async def test_active_control_toggle_via_mqtt(mqtt_broker) -> None:
 
 
 @needs_mosquitto
-async def test_shelly_battery_removal_publishes_offline(mqtt_broker):
+async def test_shelly_battery_removal_publishes_offline(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     base = service._config.base_topic
@@ -1815,7 +1827,7 @@ async def test_shelly_battery_removal_publishes_offline(mqtt_broker):
             lambda: (SHELLY_BATTERY, "shelly1/192_168_1_100") in service._discovered
         )
 
-        received = []
+        received: list[Any] = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as sub:
             await sub.subscribe(
                 f"{base}/shelly/shelly1/battery/192_168_1_100/availability"
@@ -1833,7 +1845,7 @@ async def test_shelly_battery_removal_publishes_offline(mqtt_broker):
         await service.stop()
 
 
-def test_consumer_state_includes_manual_target_fields():
+def test_consumer_state_includes_manual_target_fields() -> None:
     """Consumer state published to MQTT includes manual_target and auto_target."""
     data = dict(SAMPLE_CT002_DATA)
     consumer_state = {
@@ -1894,7 +1906,7 @@ def _make_binding(
     )
 
 
-def test_register_marstek_while_disconnected_stores_binding():
+def test_register_marstek_while_disconnected_stores_binding() -> None:
     """register_marstek before start() only populates the dict."""
     service = MqttInsightsService(MqttInsightsConfig(broker="localhost"))
     binding, _ = _make_binding()
@@ -1906,7 +1918,7 @@ def test_register_marstek_while_disconnected_stores_binding():
     assert service._marstek_bindings["ct002-dev1"] is binding
 
 
-def test_register_marstek_no_op_when_disabled():
+def test_register_marstek_no_op_when_disabled() -> None:
     service = MqttInsightsService(
         MqttInsightsConfig(broker="localhost", marstek_mqtt_enabled=False)
     )
@@ -1920,7 +1932,7 @@ def test_register_marstek_no_op_when_disabled():
 
 
 @needs_mosquitto
-async def test_marstek_poll_responds_on_both_topics(mqtt_broker):
+async def test_marstek_poll_responds_on_both_topics(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     binding, calls = _make_binding(values=[100.0, 200.0, 300.0])
@@ -1931,7 +1943,7 @@ async def test_marstek_poll_responds_on_both_topics(mqtt_broker):
         await service.wait_connected()
         await _poll(lambda: service._client is not None)
 
-        received = []
+        received: list[Any] = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as client:
             await client.subscribe(f"hame_energy/HME-4/device/{binding.mac}/ctrl")
             await client.subscribe(f"marstek_energy/HME-4/device/{binding.mac}/ctrl")
@@ -1958,7 +1970,7 @@ async def test_marstek_poll_responds_on_both_topics(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_marstek_poll_cd4_responds_with_slave_list(mqtt_broker):
+async def test_marstek_poll_cd4_responds_with_slave_list(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     inner = (
@@ -1976,7 +1988,7 @@ async def test_marstek_poll_cd4_responds_with_slave_list(mqtt_broker):
         await service.wait_connected()
         await _poll(lambda: service._client is not None)
 
-        received = []
+        received: list[Any] = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as client:
             await client.subscribe(f"hame_energy/HME-4/device/{binding.mac}/ctrl")
             await client.subscribe(f"marstek_energy/HME-4/device/{binding.mac}/ctrl")
@@ -1998,7 +2010,7 @@ async def test_marstek_poll_cd4_responds_with_slave_list(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_marstek_ignores_non_poll_payload(mqtt_broker):
+async def test_marstek_ignores_non_poll_payload(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     binding, calls = _make_binding()
@@ -2009,7 +2021,7 @@ async def test_marstek_ignores_non_poll_payload(mqtt_broker):
         await service.wait_connected()
         await _poll(lambda: service._client is not None)
 
-        received = []
+        received: list[Any] = []
         async with aiomqtt.Client(hostname="127.0.0.1", port=port) as client:
             await client.subscribe(f"hame_energy/HME-4/device/{binding.mac}/ctrl")
             await client.publish(
@@ -2024,7 +2036,7 @@ async def test_marstek_ignores_non_poll_payload(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_marstek_unregister_stops_replies(mqtt_broker):
+async def test_marstek_unregister_stops_replies(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     binding, _ = _make_binding()
@@ -2039,7 +2051,7 @@ async def test_marstek_unregister_stops_replies(mqtt_broker):
             await client.subscribe(f"hame_energy/HME-4/device/{binding.mac}/ctrl")
 
             # Initial poll — expect one reply
-            first = []
+            first: list[Any] = []
             await client.publish(
                 f"hame_energy/HME-4/App/{binding.mac}/ctrl", payload=b"cd=1"
             )
@@ -2050,7 +2062,7 @@ async def test_marstek_unregister_stops_replies(mqtt_broker):
 
             # Unregister and poll again — expect no reply
             await service.unregister_marstek(binding.device_id)
-            second = []
+            second: list[Any] = []
             await client.publish(
                 f"hame_energy/HME-4/App/{binding.mac}/ctrl", payload=b"cd=1"
             )
@@ -2061,7 +2073,7 @@ async def test_marstek_unregister_stops_replies(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_marstek_opt_out_disables_subscription(mqtt_broker):
+async def test_marstek_opt_out_disables_subscription(mqtt_broker: int) -> None:
     port = mqtt_broker
     global _test_counter
     _test_counter += 1
@@ -2087,7 +2099,7 @@ async def test_marstek_opt_out_disables_subscription(mqtt_broker):
             await client.publish(
                 f"hame_energy/HME-4/App/{binding.mac}/ctrl", payload=b"cd=1"
             )
-            received = []
+            received: list[Any] = []
             await _collect_messages(client, received, timeout=1)
             assert received == []
             assert calls == []
@@ -2096,7 +2108,7 @@ async def test_marstek_opt_out_disables_subscription(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_marstek_get_values_failure_suppressed(mqtt_broker):
+async def test_marstek_get_values_failure_suppressed(mqtt_broker: int) -> None:
     port = mqtt_broker
     service = _make_service(port)
     binding, calls = _make_binding(raises=RuntimeError("powermeter offline"))
@@ -2112,7 +2124,7 @@ async def test_marstek_get_values_failure_suppressed(mqtt_broker):
             await client.publish(
                 f"hame_energy/HME-4/App/{binding.mac}/ctrl", payload=b"cd=1"
             )
-            received = []
+            received: list[Any] = []
             await _collect_messages(client, received, timeout=1)
             assert received == []
         # get_values was called but no reply was published
@@ -2123,7 +2135,9 @@ async def test_marstek_get_values_failure_suppressed(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_marstek_register_before_start_subscribes_on_connect(mqtt_broker):
+async def test_marstek_register_before_start_subscribes_on_connect(
+    mqtt_broker: int,
+) -> None:
     """A binding registered before start() must get its App topics
     subscribed on the first connect."""
     port = mqtt_broker
@@ -2142,7 +2156,7 @@ async def test_marstek_register_before_start_subscribes_on_connect(mqtt_broker):
             await client.publish(
                 f"hame_energy/HME-4/App/{binding.mac}/ctrl", payload=b"cd=1"
             )
-            received = []
+            received: list[Any] = []
             await _collect_messages(
                 client, received, timeout=5, stop=lambda _: len(received) >= 1
             )
@@ -2155,7 +2169,7 @@ async def test_marstek_register_before_start_subscribes_on_connect(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_marstek_periodic_broadcast(mqtt_broker) -> None:
+async def test_marstek_periodic_broadcast(mqtt_broker: int) -> None:
     """When marstek_mqtt_interval > 0, responses are published periodically
     without requiring a poll request from the app."""
     port = mqtt_broker
@@ -2198,7 +2212,7 @@ async def test_marstek_periodic_broadcast(mqtt_broker) -> None:
 
 
 @needs_mosquitto
-async def test_marstek_broadcast_disabled_when_interval_zero(mqtt_broker) -> None:
+async def test_marstek_broadcast_disabled_when_interval_zero(mqtt_broker: int) -> None:
     """marstek_mqtt_interval=0 disables the periodic broadcast loop; only
     explicit poll requests trigger a response."""
     port = mqtt_broker
@@ -2234,7 +2248,7 @@ async def test_marstek_broadcast_disabled_when_interval_zero(mqtt_broker) -> Non
 
 
 @needs_mosquitto
-async def test_marstek_slow_handler_does_not_stall_listener(mqtt_broker):
+async def test_marstek_slow_handler_does_not_stall_listener(mqtt_broker: int) -> None:
     """A slow get_values for one binding must not block polls for another.
 
     With the offload-to-task design, the listener stays responsive even
@@ -2281,7 +2295,7 @@ async def test_marstek_slow_handler_does_not_stall_listener(mqtt_broker):
             await client.publish(
                 f"hame_energy/HME-4/App/{fast.mac}/ctrl", payload=b"cd=1"
             )
-            received = []
+            received: list[Any] = []
             await _collect_messages(
                 client, received, timeout=5, stop=lambda _: len(received) >= 1
             )
@@ -2298,8 +2312,8 @@ async def test_marstek_slow_handler_does_not_stall_listener(mqtt_broker):
 # ── Status snapshot & dashboard writes (no broker) ───────────────────────
 
 
-def _async_iter(messages):
-    async def _gen():
+def _async_iter(messages: list[Any]) -> AsyncIterator[Any]:
+    async def _gen() -> AsyncIterator[Any]:
         for message in messages:
             yield message
 
@@ -2312,7 +2326,7 @@ class _FakeMessage:
         self.payload = payload
 
 
-def test_status_snapshot_shape():
+def test_status_snapshot_shape() -> None:
     service = MqttInsightsService(
         MqttInsightsConfig(
             broker="broker.local",
@@ -2361,7 +2375,7 @@ def test_status_snapshot_shape():
     assert snapshot.marstek_bindings == ()
 
 
-def test_status_snapshot_connected_tracks_the_connected_flag():
+def test_status_snapshot_connected_tracks_the_connected_flag() -> None:
     service = MqttInsightsService(MqttInsightsConfig(broker="localhost"))
     assert service.connected is False
     service._connected.set()
@@ -2369,7 +2383,7 @@ def test_status_snapshot_connected_tracks_the_connected_flag():
     assert service.status_snapshot().connected is True
 
 
-def test_status_snapshot_carries_no_credentials():
+def test_status_snapshot_carries_no_credentials() -> None:
     service = MqttInsightsService(
         MqttInsightsConfig(
             broker="broker.local", username="grid-user", password="s3cret"
@@ -2385,7 +2399,7 @@ def test_status_snapshot_carries_no_credentials():
     assert "s3cret" not in rendered
 
 
-async def test_status_snapshot_reports_marstek_bindings():
+async def test_status_snapshot_reports_marstek_bindings() -> None:
     service = MqttInsightsService(MqttInsightsConfig(broker="localhost"))
     binding, _ = _make_binding()
     await service.register_marstek(binding)
@@ -2401,7 +2415,7 @@ async def test_status_snapshot_reports_marstek_bindings():
     assert row.value_fetch_failing is True
 
 
-async def test_status_snapshot_no_lock():
+async def test_status_snapshot_no_lock() -> None:
     """The snapshot must read the bindings without ``_marstek_lock`` — taking
     it would need an await, and an await tears the surrounding snapshot."""
     service = MqttInsightsService(MqttInsightsConfig(broker="localhost"))
@@ -2414,7 +2428,7 @@ async def test_status_snapshot_no_lock():
     assert [row.device_id for row in snapshot.marstek_bindings] == ["ct002-dev1"]
 
 
-async def test_publish_consumer_command_lands_where_the_replay_path_reads():
+async def test_publish_consumer_command_lands_where_the_replay_path_reads() -> None:
     """A dashboard write must target the same retained topic the broker
     redelivers on reconnect, or the next reconnect reverts it."""
     service = MqttInsightsService(
@@ -2442,7 +2456,9 @@ async def test_publish_consumer_command_lands_where_the_replay_path_reads():
     assert calls == [("c1", 150.0)]
 
 
-async def test_publish_consumer_command_accepts_the_native_scalars_it_is_given():
+async def test_publish_consumer_command_accepts_the_native_scalars_it_is_given() -> (
+    None
+):
     """The dashboard hands this the JSON value it received — a float or a
     bool, not a string. Requiring a string made every mirrored write raise
     inside the caller's ``except Exception``, so nothing was ever published
@@ -2461,7 +2477,7 @@ async def test_publish_consumer_command_accepts_the_native_scalars_it_is_given()
     assert parse_bool(payload.decode()) is False
 
 
-async def test_publish_device_command_lands_where_the_listener_reads():
+async def test_publish_device_command_lands_where_the_listener_reads() -> None:
     service = MqttInsightsService(
         MqttInsightsConfig(broker="localhost", base_topic="am")
     )
@@ -2485,7 +2501,7 @@ async def test_publish_device_command_lands_where_the_listener_reads():
     assert seen == [False]
 
 
-async def test_publish_command_without_a_connection_raises():
+async def test_publish_command_without_a_connection_raises() -> None:
     service = MqttInsightsService(MqttInsightsConfig(broker="localhost"))
     with pytest.raises(RuntimeError):
         await service.publish_device_command("dev1", {"force_rotation": True})

--- a/src/astrameter/mqtt_insights/topics_test.py
+++ b/src/astrameter/mqtt_insights/topics_test.py
@@ -12,7 +12,7 @@ from .topics import (
 )
 
 
-def test_consumer_command_topic_round_trips():
+def test_consumer_command_topic_round_trips() -> None:
     topic = consumer_command_topic("am", "dev1", "aabbcc", "manual_target")
     assert topic == "am/ct002/dev1/consumer/aabbcc/manual_target/set"
     assert parse_command_topic("am", topic) == ConsumerCommandTopic(
@@ -20,18 +20,18 @@ def test_consumer_command_topic_round_trips():
     )
 
 
-def test_device_command_topic_round_trips():
+def test_device_command_topic_round_trips() -> None:
     topic = device_command_topic("am", "dev1")
     assert topic == "am/ct002/dev1/set"
     assert parse_command_topic("am", topic) == DeviceCommandTopic(device_id="dev1")
 
 
-def test_consumer_frame_without_a_field_is_malformed():
+def test_consumer_frame_without_a_field_is_malformed() -> None:
     parsed = parse_command_topic("am", "am/ct002/dev1/consumer/aabbcc/set")
     assert isinstance(parsed, MalformedCommandTopic)
 
 
-def test_foreign_topics_are_not_commands():
+def test_foreign_topics_are_not_commands() -> None:
     for topic in (
         "am/ct002/dev1/status",
         "am/shelly/dev1/status",
@@ -41,7 +41,7 @@ def test_foreign_topics_are_not_commands():
         assert parse_command_topic("am", topic) is None, topic
 
 
-def test_ids_spanning_several_topic_levels_are_not_commands():
+def test_ids_spanning_several_topic_levels_are_not_commands() -> None:
     # The subscription filters bind each id to a single "+" level, so these
     # never arrive from a broker -- but the grammar has to agree with them.
     for topic in (

--- a/src/astrameter/power_units.py
+++ b/src/astrameter/power_units.py
@@ -13,6 +13,8 @@ through the config loader.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 #: Multiplier from a declared unit to watts. Case matters: "mW" is
 #: milliwatts, "MW" megawatts. Any *other* declared unit (°C, %, kWh, ...) is
 #: not a power reading — see issues #39 / #572, where kW values were silently
@@ -28,7 +30,7 @@ POWER_UNIT_SCALE = {
 POWER_UNITS = tuple(POWER_UNIT_SCALE)
 
 
-def three_phases(values) -> list:
+def three_phases(values: Iterable[float]) -> list[float]:
     """Pad or trim a reading to the three phase values the CT protocol carries."""
     phases = list(values)[:3]
     return phases + [0.0] * (3 - len(phases))

--- a/src/astrameter/powermeter/amisreader.py
+++ b/src/astrameter/powermeter/amisreader.py
@@ -2,7 +2,7 @@ from .http_client import HttpPowermeter
 
 
 class AmisReader(HttpPowermeter):
-    def __init__(self, ip: str):
+    def __init__(self, ip: str) -> None:
         self.ip = ip
 
     async def get_powermeter_watts(self) -> list[float]:

--- a/src/astrameter/powermeter/amisreader_test.py
+++ b/src/astrameter/powermeter/amisreader_test.py
@@ -1,9 +1,9 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from astrameter.powermeter import AmisReader
 
 
-async def test_amisreader_get_powermeter_watts(mock_aiohttp_session):
+async def test_amisreader_get_powermeter_watts(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_json({"saldo": 1200})
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         amisreader = AmisReader("192.168.1.10")

--- a/src/astrameter/powermeter/conftest.py
+++ b/src/astrameter/powermeter/conftest.py
@@ -1,12 +1,13 @@
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 
 @pytest.fixture
-def mock_aiohttp_session():
+def mock_aiohttp_session() -> MagicMock:
     """Create a mock aiohttp.ClientSession that returns configurable JSON."""
-    json_data = {}
+    json_data: dict[str, Any] = {}
 
     mock_resp = MagicMock()
     mock_resp.json = AsyncMock(return_value=json_data)
@@ -16,7 +17,7 @@ def mock_aiohttp_session():
     mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
     mock_resp.__aexit__ = AsyncMock(return_value=False)
 
-    post_json_data = {}
+    post_json_data: dict[str, Any] = {}
 
     mock_post_resp = MagicMock()
     mock_post_resp.json = AsyncMock(return_value=post_json_data)
@@ -30,13 +31,13 @@ def mock_aiohttp_session():
     session.post = MagicMock(return_value=mock_post_resp)
     session.close = AsyncMock()
 
-    def set_json(data):
+    def set_json(data: Any) -> None:
         mock_resp.json.return_value = data
 
-    def set_post_json(data):
+    def set_post_json(data: Any) -> None:
         mock_post_resp.json.return_value = data
 
-    def set_read(data):
+    def set_read(data: bytes) -> None:
         mock_resp.read.return_value = data
 
     session.set_json = set_json

--- a/src/astrameter/powermeter/emlog.py
+++ b/src/astrameter/powermeter/emlog.py
@@ -2,7 +2,7 @@ from .http_client import HttpPowermeter
 
 
 class Emlog(HttpPowermeter):
-    def __init__(self, ip: str, meterindex: str, json_power_calculate: bool):
+    def __init__(self, ip: str, meterindex: str, json_power_calculate: bool) -> None:
         self.ip = ip
         self.meterindex = meterindex
         self.json_power_calculate = json_power_calculate

--- a/src/astrameter/powermeter/emlog_test.py
+++ b/src/astrameter/powermeter/emlog_test.py
@@ -1,9 +1,11 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from astrameter.powermeter import Emlog
 
 
-async def test_get_powermeter_watts_no_calculate(mock_aiohttp_session):
+async def test_get_powermeter_watts_no_calculate(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     mock_aiohttp_session.set_json({"Leistung170": "200"})
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         emlog = Emlog("127.0.0.1", "1", json_power_calculate=False)
@@ -12,7 +14,9 @@ async def test_get_powermeter_watts_no_calculate(mock_aiohttp_session):
         await emlog.stop()
 
 
-async def test_get_powermeter_watts_with_calculate(mock_aiohttp_session):
+async def test_get_powermeter_watts_with_calculate(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     mock_aiohttp_session.set_json({"Leistung170": "400", "Leistung270": "150"})
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         emlog = Emlog("127.0.0.1", "1", json_power_calculate=True)

--- a/src/astrameter/powermeter/envoy_test.py
+++ b/src/astrameter/powermeter/envoy_test.py
@@ -1,4 +1,5 @@
 import ssl
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -23,7 +24,9 @@ SAMPLE_LINES_RESPONSE = {
 }
 
 
-def _mock_response(json_data: dict | None = None, *, raise_status: int | None = None):
+def _mock_response(
+    json_data: dict | None = None, *, raise_status: int | None = None
+) -> AsyncMock:
     response = AsyncMock()
     response.json = AsyncMock(return_value=json_data or {})
     if raise_status is not None:
@@ -40,7 +43,7 @@ def _mock_response(json_data: dict | None = None, *, raise_status: int | None = 
     return response
 
 
-def _ctx(response) -> MagicMock:
+def _ctx(response: Any) -> MagicMock:
     ctx = MagicMock()
     ctx.__aenter__ = AsyncMock(return_value=response)
     ctx.__aexit__ = AsyncMock(return_value=False)
@@ -128,7 +131,7 @@ async def test_static_token_header() -> None:
 
 
 # 7. Auto-obtain when no static token: monkeypatch _obtain_token.
-async def test_auto_obtain_when_no_token(monkeypatch) -> None:
+async def test_auto_obtain_when_no_token(monkeypatch: pytest.MonkeyPatch) -> None:
     obtain = AsyncMock(return_value="fresh-jwt")
     monkeypatch.setattr(envoy_module, "_obtain_token", obtain)
     envoy = _make_envoy(token="", username="u@example.com", password="pw", serial="123")
@@ -142,7 +145,7 @@ async def test_auto_obtain_when_no_token(monkeypatch) -> None:
 
 
 # 8. 401 refresh: first .get() yields 401, second yields data; obtain awaited once.
-async def test_refreshes_on_401(monkeypatch) -> None:
+async def test_refreshes_on_401(monkeypatch: pytest.MonkeyPatch) -> None:
     obtain = AsyncMock(return_value="new-jwt")
     monkeypatch.setattr(envoy_module, "_obtain_token", obtain)
     envoy = _make_envoy(
@@ -165,7 +168,9 @@ async def test_refreshes_on_401(monkeypatch) -> None:
 
 
 # 9. 401 with no credentials configured (static token only) -> propagates.
-async def test_401_without_credentials_propagates(monkeypatch) -> None:
+async def test_401_without_credentials_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     obtain = AsyncMock()
     monkeypatch.setattr(envoy_module, "_obtain_token", obtain)
     envoy = _make_envoy(token="static-only")
@@ -188,11 +193,13 @@ def test_init_without_host_raises() -> None:
 
 # 11. Cloud session ignores VERIFY_SSL: spy on TCPConnector to confirm only the
 # local session gets the no-verify SSLContext; the cloud session uses defaults.
-async def test_cloud_session_ignores_verify_ssl(monkeypatch) -> None:
+async def test_cloud_session_ignores_verify_ssl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured: list[dict] = []
     real_connector = aiohttp.TCPConnector
 
-    def spy(**kwargs):
+    def spy(**kwargs: Any) -> Any:
         captured.append(kwargs)
         return real_connector(**kwargs)
 
@@ -270,7 +277,9 @@ async def test_get_without_start_raises_runtime_error() -> None:
 
 # Thundering-herd guard: if another coroutine already refreshed the token while
 # we were awaiting the 401 response, skip our own refresh and just retry.
-async def test_401_skips_refresh_if_token_changed(monkeypatch) -> None:
+async def test_401_skips_refresh_if_token_changed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     obtain = AsyncMock(return_value="should-not-be-used")
     monkeypatch.setattr(envoy_module, "_obtain_token", obtain)
     envoy = _make_envoy(
@@ -284,7 +293,7 @@ async def test_401_skips_refresh_if_token_changed(monkeypatch) -> None:
         ]
     )
 
-    def fake_get(*_args, **_kwargs):
+    def fake_get(*_args: Any, **_kwargs: Any) -> Any:
         resp = next(calls)
         if resp.raise_for_status.side_effect is not None:
             # Simulate another coroutine having refreshed between the 401

--- a/src/astrameter/powermeter/esphome.py
+++ b/src/astrameter/powermeter/esphome.py
@@ -2,7 +2,7 @@ from .http_client import HttpPowermeter
 
 
 class ESPHome(HttpPowermeter):
-    def __init__(self, ip: str, port: str, domain: str, id: str):
+    def __init__(self, ip: str, port: str, domain: str, id: str) -> None:
         self.ip = ip
         self.port = port
         self.domain = domain

--- a/src/astrameter/powermeter/esphome_native.py
+++ b/src/astrameter/powermeter/esphome_native.py
@@ -94,7 +94,7 @@ class ESPHomeNative(PushPowermeter):
 
     async def connect_error_callback(self, err: Exception):
         self.reset_connection_state()
-        logger.error(f"Connection failed: {err}")
+        logger.error("ESPHome native: connection failed: %s", err)
 
     async def disconnect_callback(self, expected_disconnect: bool):
         self.reset_connection_state()
@@ -112,7 +112,7 @@ class ESPHomeNative(PushPowermeter):
             return
 
         if not isinstance(state, SensorState):
-            logger.error(f"Subscribed EntityState {state} is not a SensorState")
+            logger.error("ESPHome native: subscribed entity %s is not a sensor", state)
             return
 
         # When the upstream sensor goes unavailable, aioesphomeapi delivers a
@@ -126,7 +126,7 @@ class ESPHomeNative(PushPowermeter):
         self.last_value = state.state
         self._message_event.set()
         self._any_message_event.set()
-        logger.debug(f"Got new sensor state: {state.state}")
+        logger.debug("ESPHome native: new sensor state %s", state.state)
 
     async def get_powermeter_watts(self) -> list[float]:
         if self._any_message_event.is_set():

--- a/src/astrameter/powermeter/esphome_native.py
+++ b/src/astrameter/powermeter/esphome_native.py
@@ -16,7 +16,7 @@ class ESPHomeNative(PushPowermeter):
 
     def __init__(
         self, address: str, port: str, api_key: str, object_id: str, client_info: str
-    ):
+    ) -> None:
         super().__init__()
         self.object_id = object_id
         self.address = address
@@ -51,7 +51,7 @@ class ESPHomeNative(PushPowermeter):
             self.object_id,
         )
 
-    def reset_connection_state(self):
+    def reset_connection_state(self) -> None:
         self.is_connected = False
         self._any_message_event.clear()
         self._message_event.clear()
@@ -65,7 +65,7 @@ class ESPHomeNative(PushPowermeter):
         await self.api.disconnect()
         self.reset_connection_state()
 
-    async def connect_callback(self):
+    async def connect_callback(self) -> None:
         self.is_connected = True
         logger.debug(
             "ESPHome native: connected to %s:%s, API version %s",
@@ -106,11 +106,11 @@ class ESPHomeNative(PushPowermeter):
         )
         self.api.subscribe_states(self.change_callback)
 
-    async def connect_error_callback(self, err: Exception):
+    async def connect_error_callback(self, err: Exception) -> None:
         self.reset_connection_state()
         logger.error("ESPHome native: connection failed: %s", err)
 
-    async def disconnect_callback(self, expected_disconnect: bool):
+    async def disconnect_callback(self, expected_disconnect: bool) -> None:
         self.reset_connection_state()
 
         if expected_disconnect:
@@ -118,7 +118,7 @@ class ESPHomeNative(PushPowermeter):
         else:
             logger.warning("Unexpected disconnect. Trying to reconnect")
 
-    def change_callback(self, state: EntityState):
+    def change_callback(self, state: EntityState) -> None:
         if self.entity_info is None:
             return
 

--- a/src/astrameter/powermeter/esphome_native.py
+++ b/src/astrameter/powermeter/esphome_native.py
@@ -44,7 +44,11 @@ class ESPHomeNative(PushPowermeter):
         # Stays set across messages; only a (re)connect clears it.
         self._any_message_event = asyncio.Event()
         logger.debug(
-            f"Initialized ESPHomeNative Api: Connection: {address}:{port} ClientInfo: {client_info} ObjectId: {self.object_id}"
+            "ESPHome native: %s:%s as %s, object id %s",
+            address,
+            port,
+            client_info,
+            self.object_id,
         )
 
     def reset_connection_state(self):
@@ -64,12 +68,17 @@ class ESPHomeNative(PushPowermeter):
     async def connect_callback(self):
         self.is_connected = True
         logger.debug(
-            f"Connected to {self.address}:{self.port}. Api version: {self.api.api_version}"
+            "ESPHome native: connected to %s:%s, API version %s",
+            self.address,
+            self.port,
+            self.api.api_version,
         )
 
         device_info = await self.api.device_info()
         logger.info(
-            f"Connected to {device_info.name} (EspHome: {device_info.esphome_version})"
+            "ESPHome native: device %s runs ESPHome %s",
+            device_info.name,
+            device_info.esphome_version,
         )
 
         entity_infos, _ = await self.api.list_entities_services()
@@ -83,12 +92,17 @@ class ESPHomeNative(PushPowermeter):
             # trigger an immediate reconnect + relist loop that never resolves the
             # misconfiguration. Stay connected instead and just log it clearly.
             logger.error(
-                f"Cannot subscribe to objectId {self.object_id}. ObjectId is not provided by the device. Available objectIds are: {[e.object_id for e in entity_infos]}"
+                "ESPHome native: the device provides no object id %r; it offers %s",
+                self.object_id,
+                [e.object_id for e in entity_infos],
             )
             return
 
         logger.info(
-            f"Subscribing to entity ObjectId: {self.entity_info.object_id} Name:{self.entity_info.name} Key:{self.entity_info.key}"
+            "ESPHome native: subscribing to %s (name %s, key %s)",
+            self.entity_info.object_id,
+            self.entity_info.name,
+            self.entity_info.key,
         )
         self.api.subscribe_states(self.change_callback)
 

--- a/src/astrameter/powermeter/esphome_native_test.py
+++ b/src/astrameter/powermeter/esphome_native_test.py
@@ -41,12 +41,12 @@ def _state(value: float, missing_state: bool = False) -> SensorState:
     )
 
 
-async def test_no_value_before_message():
+async def test_no_value_before_message() -> None:
     pm = _subscribed_pm()
     assert await pm.get_powermeter_watts() == []
 
 
-async def test_get_powermeter_watts_returns_latest():
+async def test_get_powermeter_watts_returns_latest() -> None:
     pm = _subscribed_pm()
     pm.change_callback(_state(123.0))
     assert await pm.get_powermeter_watts() == [123.0]
@@ -54,19 +54,19 @@ async def test_get_powermeter_watts_returns_latest():
     assert await pm.get_powermeter_watts() == [456.0]
 
 
-async def test_change_callback_ignores_other_entities():
+async def test_change_callback_ignores_other_entities() -> None:
     pm = _subscribed_pm()
     pm.change_callback(SensorState(key=ENTITY_KEY + 1, state=999.0))  # type: ignore[call-arg]
     assert await pm.get_powermeter_watts() == []
 
 
-async def test_change_callback_ignores_before_subscribe():
+async def test_change_callback_ignores_before_subscribe() -> None:
     pm = _make_pm()  # entity_info is None until connect_callback runs
     pm.change_callback(_state(123.0))
     assert await pm.get_powermeter_watts() == []
 
 
-async def test_change_callback_drops_missing_state():
+async def test_change_callback_drops_missing_state() -> None:
     pm = _subscribed_pm()
     pm.change_callback(_state(100.0))
     pm.change_callback(_state(math.nan, missing_state=True))
@@ -74,26 +74,26 @@ async def test_change_callback_drops_missing_state():
     assert await pm.get_powermeter_watts() == [100.0]
 
 
-async def test_change_callback_drops_nan_without_missing_flag():
+async def test_change_callback_drops_nan_without_missing_flag() -> None:
     pm = _subscribed_pm()
     pm.change_callback(_state(100.0))
     pm.change_callback(_state(math.nan))
     assert await pm.get_powermeter_watts() == [100.0]
 
 
-async def test_wait_for_message_returns_after_message():
+async def test_wait_for_message_returns_after_message() -> None:
     pm = _subscribed_pm()
     pm.change_callback(_state(10.0))
     await pm.wait_for_message(timeout=0.1)
 
 
-async def test_wait_for_message_times_out_without_message():
+async def test_wait_for_message_times_out_without_message() -> None:
     pm = _subscribed_pm()
     with pytest.raises(TimeoutError):
         await pm.wait_for_message(timeout=0.05)
 
 
-async def test_wait_for_next_message_blocks_until_new():
+async def test_wait_for_next_message_blocks_until_new() -> None:
     pm = _subscribed_pm()
     pm.change_callback(_state(10.0))
     # wait_for_next_message must wait for the *next* update, not return on the
@@ -102,7 +102,7 @@ async def test_wait_for_next_message_blocks_until_new():
         await pm.wait_for_next_message(timeout=0.05)
 
 
-async def test_disconnect_clears_value():
+async def test_disconnect_clears_value() -> None:
     pm = _subscribed_pm()
     pm.change_callback(_state(50.0))
     assert await pm.get_powermeter_watts() == [50.0]
@@ -115,14 +115,14 @@ async def test_disconnect_clears_value():
     assert pm.entity_info is None
 
 
-async def test_stream_online_reflects_connection():
+async def test_stream_online_reflects_connection() -> None:
     pm = _make_pm()
     assert pm.stream_online() is False
     pm.is_connected = True
     assert pm.stream_online() is True
 
 
-async def test_connect_error_resets_state():
+async def test_connect_error_resets_state() -> None:
     pm = _subscribed_pm()
     pm.change_callback(_state(50.0))
     await pm.connect_error_callback(RuntimeError("boom"))

--- a/src/astrameter/powermeter/esphome_test.py
+++ b/src/astrameter/powermeter/esphome_test.py
@@ -1,9 +1,9 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from astrameter.powermeter import ESPHome
 
 
-async def test_esphome_get_powermeter_watts(mock_aiohttp_session):
+async def test_esphome_get_powermeter_watts(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_json({"value": 234})
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         esphome = ESPHome("192.168.1.4", "80", "sensor", "power")

--- a/src/astrameter/powermeter/fritz_test.py
+++ b/src/astrameter/powermeter/fritz_test.py
@@ -55,7 +55,7 @@ def _session(get_responses: list[tuple[str, int]]) -> MagicMock:
     return session
 
 
-async def test_reads_import_branch_as_signed_net_power():
+async def test_reads_import_branch_as_signed_net_power() -> None:
     session = _session(
         [(CHALLENGE_XML, 200), (SID_XML, 200), (_device_list(power1="-71000"), 200)]
     )
@@ -66,7 +66,7 @@ async def test_reads_import_branch_as_signed_net_power():
         await meter.stop()
 
 
-async def test_explicit_export_branch_suffix():
+async def test_explicit_export_branch_suffix() -> None:
     session = _session(
         [(CHALLENGE_XML, 200), (SID_XML, 200), (_device_list(power2="120000"), 200)]
     )
@@ -77,7 +77,7 @@ async def test_explicit_export_branch_suffix():
         await meter.stop()
 
 
-async def test_relogin_on_expired_sid():
+async def test_relogin_on_expired_sid() -> None:
     session = _session(
         [
             (CHALLENGE_XML, 200),
@@ -95,7 +95,7 @@ async def test_relogin_on_expired_sid():
         await meter.stop()
 
 
-async def test_login_failure_raises():
+async def test_login_failure_raises() -> None:
     session = _session([(CHALLENGE_XML, 200), (LOGIN_FAILED_XML, 200)])
     with patch("aiohttp.ClientSession", return_value=session):
         meter = FritzSmartEnergy("fritz.box", "user", "wrong", "12345 0123456")
@@ -105,7 +105,7 @@ async def test_login_failure_raises():
         await meter.stop()
 
 
-async def test_unknown_ain_raises():
+async def test_unknown_ain_raises() -> None:
     session = _session([(CHALLENGE_XML, 200), (SID_XML, 200), (_device_list(), 200)])
     with patch("aiohttp.ClientSession", return_value=session):
         meter = FritzSmartEnergy("fritz.box", "user", "pass", "99999 9999999")
@@ -115,43 +115,43 @@ async def test_unknown_ain_raises():
         await meter.stop()
 
 
-async def test_get_before_start_raises():
+async def test_get_before_start_raises() -> None:
     meter = FritzSmartEnergy("fritz.box", "user", "pass", "12345 0123456")
     with pytest.raises(RuntimeError, match="not started"):
         await meter.get_powermeter_watts()
 
 
-def test_ain_suffix_appended_by_default():
+def test_ain_suffix_appended_by_default() -> None:
     meter = FritzSmartEnergy("fritz.box", "user", "pass", "12345 0123456")
     assert meter._ain == "123450123456-1"
 
 
-def test_ain_suffix_preserved():
+def test_ain_suffix_preserved() -> None:
     meter = FritzSmartEnergy("fritz.box", "user", "pass", "123450123456-2")
     assert meter._ain == "123450123456-2"
 
 
-def test_empty_ain_raises():
+def test_empty_ain_raises() -> None:
     with pytest.raises(ValueError, match="requires an AIN"):
         FritzSmartEnergy("fritz.box", "user", "pass", "")
 
 
-def test_base_url_defaults_to_http():
+def test_base_url_defaults_to_http() -> None:
     meter = FritzSmartEnergy("192.168.1.1", "u", "p", "12345 0123456")
     assert meter._base_url == "http://192.168.1.1"
 
 
-def test_base_url_https_when_tls():
+def test_base_url_https_when_tls() -> None:
     meter = FritzSmartEnergy("fritz.box", "u", "p", "12345 0123456", use_tls=True)
     assert meter._base_url == "https://fritz.box"
 
 
-def test_base_url_explicit_scheme_preserved():
+def test_base_url_explicit_scheme_preserved() -> None:
     meter = FritzSmartEnergy("https://fritz.box:443/", "u", "p", "12345 0123456")
     assert meter._base_url == "https://fritz.box:443"
 
 
-def test_https_host_honors_verify_ssl_false():
+def test_https_host_honors_verify_ssl_false() -> None:
     # An explicit https:// HOST (without use_tls) must still disable verification.
     meter = FritzSmartEnergy(
         "https://fritz.box", "u", "p", "12345 0123456", verify_ssl=False
@@ -159,13 +159,13 @@ def test_https_host_honors_verify_ssl_false():
     assert meter._ssl is False
 
 
-def test_http_host_ignores_verify_ssl():
+def test_http_host_ignores_verify_ssl() -> None:
     # Plain http: verification flag is irrelevant, leave aiohttp defaults.
     meter = FritzSmartEnergy("fritz.box", "u", "p", "12345 0123456", verify_ssl=False)
     assert meter._ssl is None
 
 
-def test_compute_login_response_pbkdf2():
+def test_compute_login_response_pbkdf2() -> None:
     challenge = "2$10000$5A1711$2000$5A1722"
     password = "1example!"
     hash1 = hashlib.pbkdf2_hmac(
@@ -175,7 +175,7 @@ def test_compute_login_response_pbkdf2():
     assert compute_login_response(challenge, password) == f"5A1722${hash2.hex()}"
 
 
-def test_compute_login_response_md5_legacy():
+def test_compute_login_response_md5_legacy() -> None:
     # AVM-documented legacy challenge/response example.
     assert (
         compute_login_response("1234567z", "äbc")

--- a/src/astrameter/powermeter/fronius.py
+++ b/src/astrameter/powermeter/fronius.py
@@ -16,7 +16,7 @@ class Fronius(HttpPowermeter):
     enabling it; otherwise stick with the always-signed sum (the default).
     """
 
-    def __init__(self, ip: str, device_id: str = "0", per_phase: bool = False):
+    def __init__(self, ip: str, device_id: str = "0", per_phase: bool = False) -> None:
         self.ip = ip
         self.device_id = device_id
         self.per_phase = per_phase

--- a/src/astrameter/powermeter/fronius_test.py
+++ b/src/astrameter/powermeter/fronius_test.py
@@ -1,18 +1,19 @@
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from astrameter.powermeter import Fronius
 
 
-def _meter_response(power):
+def _meter_response(power: float) -> dict[str, Any]:
     return {
         "Head": {"Status": {"Code": 0, "Reason": "", "UserMessage": ""}},
         "Body": {"Data": {"PowerReal_P_Sum": power}},
     }
 
 
-async def test_get_powermeter_watts_import(mock_aiohttp_session):
+async def test_get_powermeter_watts_import(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_json(_meter_response(562.93))
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         fronius = Fronius("127.0.0.1")
@@ -21,7 +22,7 @@ async def test_get_powermeter_watts_import(mock_aiohttp_session):
         await fronius.stop()
 
 
-async def test_get_powermeter_watts_export(mock_aiohttp_session):
+async def test_get_powermeter_watts_export(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_json(_meter_response(-834.13))
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         fronius = Fronius("127.0.0.1", device_id="1")
@@ -30,7 +31,7 @@ async def test_get_powermeter_watts_export(mock_aiohttp_session):
         await fronius.stop()
 
 
-async def test_get_powermeter_watts_per_phase(mock_aiohttp_session):
+async def test_get_powermeter_watts_per_phase(mock_aiohttp_session: MagicMock) -> None:
     response = _meter_response(600.0)
     response["Body"]["Data"].update(
         {
@@ -48,8 +49,8 @@ async def test_get_powermeter_watts_per_phase(mock_aiohttp_session):
 
 
 async def test_get_powermeter_watts_per_phase_missing_phase_defaults_zero(
-    mock_aiohttp_session,
-):
+    mock_aiohttp_session: MagicMock,
+) -> None:
     response = _meter_response(150.0)
     response["Body"]["Data"]["PowerReal_P_Phase_1"] = 150.0
     mock_aiohttp_session.set_json(response)
@@ -60,7 +61,9 @@ async def test_get_powermeter_watts_per_phase_missing_phase_defaults_zero(
         await fronius.stop()
 
 
-async def test_get_powermeter_watts_raises_on_api_error(mock_aiohttp_session):
+async def test_get_powermeter_watts_raises_on_api_error(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     mock_aiohttp_session.set_json(
         {
             "Head": {"Status": {"Code": 1, "Reason": "device not available"}},

--- a/src/astrameter/powermeter/homeassistant.py
+++ b/src/astrameter/powermeter/homeassistant.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 from collections.abc import Callable
-from contextlib import AbstractAsyncContextManager
 from typing import Any
 
 import aiohttp
@@ -10,7 +9,13 @@ import aiohttp
 from astrameter.power_units import POWER_UNIT_SCALE, POWER_UNITS
 
 from .base import as_list
-from .ws_client import WS_HEARTBEAT_SECONDS, WebSocket, WebSocketPowermeter, cancel
+from .ws_client import (
+    WS_HEARTBEAT_SECONDS,
+    WebSocket,
+    WebSocketConnect,
+    WebSocketPowermeter,
+    cancel,
+)
 
 # Stdlib logger: avoid importing astrameter.config (config_loader imports powermeter).
 logger = logging.getLogger("astrameter")
@@ -102,9 +107,7 @@ class HomeAssistant(WebSocketPowermeter):
         self._fetch_states_task = None
         await super().stop()
 
-    def _connect(
-        self, session: aiohttp.ClientSession
-    ) -> AbstractAsyncContextManager[WebSocket]:
+    def _connect(self, session: aiohttp.ClientSession) -> WebSocketConnect:
         return session.ws_connect(self._build_ws_url(), heartbeat=WS_HEARTBEAT_SECONDS)
 
     def _on_disconnect(self) -> None:

--- a/src/astrameter/powermeter/homeassistant.py
+++ b/src/astrameter/powermeter/homeassistant.py
@@ -255,7 +255,9 @@ class HomeAssistant(WebSocketPowermeter):
             # ``unavailable`` / ``unknown`` (or any non-numeric state) —
             # the integration is telling us the value isn't usable.
             logger.warning(
-                f"Home Assistant sensor {entity_id} state '{state_val}' is not numeric"
+                "Home Assistant sensor %s state %r is not numeric",
+                entity_id,
+                state_val,
             )
             self._entity_values[entity_id] = None
         self._check_entities_ready()
@@ -292,14 +294,17 @@ class HomeAssistant(WebSocketPowermeter):
             return
         if unit in POWER_UNIT_SCALE:
             logger.info(
-                f"Home Assistant sensor {entity_id} reports {unit}; "
-                f"converting to W automatically"
+                "Home Assistant sensor %s reports %s; converting to W automatically",
+                entity_id,
+                unit,
             )
         else:
             logger.error(
-                f"Home Assistant sensor {entity_id} reports unit "
-                f"'{unit}', which is not a power unit — expected one of "
-                f"{', '.join(POWER_UNITS)}. Its values will be rejected."
+                "Home Assistant sensor %s reports unit %r, which is not a power "
+                "unit — expected one of %s. Its values will be rejected.",
+                entity_id,
+                unit,
+                ", ".join(POWER_UNITS),
             )
 
     def _check_entities_ready(self) -> None:

--- a/src/astrameter/powermeter/homeassistant.py
+++ b/src/astrameter/powermeter/homeassistant.py
@@ -1,15 +1,16 @@
 import asyncio
-import contextlib
 import json
 import logging
 from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
 from typing import Any
 
 import aiohttp
 
 from astrameter.power_units import POWER_UNIT_SCALE, POWER_UNITS
 
-from .base import PushPowermeter, as_list
+from .base import as_list
+from .ws_client import WS_HEARTBEAT_SECONDS, WebSocket, WebSocketPowermeter, cancel
 
 # Stdlib logger: avoid importing astrameter.config (config_loader imports powermeter).
 logger = logging.getLogger("astrameter")
@@ -23,12 +24,10 @@ _HA_DIFF_ADD = "+"
 
 _ATTR_UNIT_OF_MEASUREMENT = "unit_of_measurement"
 
-# WebSocket heartbeat (seconds) — same rationale as HomeWizard.
-WS_HEARTBEAT_SECONDS = 30.0
 
-
-class HomeAssistant(PushPowermeter):
+class HomeAssistant(WebSocketPowermeter):
     _TIMEOUT_MESSAGE = "Timeout waiting for Home Assistant state"
+    _LOG_NAME = "Home Assistant"
 
     def __init__(
         self,
@@ -74,13 +73,8 @@ class HomeAssistant(PushPowermeter):
         self._tracked_entities = self._collect_entities()
         self._msg_id = 0
         self._subscribe_entities_id: int | None = None
-        self._session: aiohttp.ClientSession | None = None
-        self._ws_task: asyncio.Task[None] | None = None
         self._fetch_states_task: asyncio.Task[None] | None = None
         self._entities_ready = asyncio.Event()
-        # Read-only health flag for stream_online(): set on auth_ok, cleared on
-        # disconnect (via _reset_for_reconnect).
-        self._connected = False
 
     def _collect_entities(self) -> set[str]:
         if self.power_calculate:
@@ -103,59 +97,22 @@ class HomeAssistant(PushPowermeter):
         self._msg_id += 1
         return self._msg_id
 
-    async def start(self) -> None:
-        if self._session:
-            return
-        self._session = aiohttp.ClientSession()
-        self._ws_task = asyncio.create_task(self._ws_loop())
-
     async def stop(self) -> None:
-        if self._fetch_states_task:
-            self._fetch_states_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._fetch_states_task
-            self._fetch_states_task = None
-        if self._ws_task:
-            self._ws_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._ws_task
-            self._ws_task = None
-        if self._session:
-            await self._session.close()
-            self._session = None
+        await cancel(self._fetch_states_task)
+        self._fetch_states_task = None
+        await super().stop()
 
-    async def _ws_loop(self) -> None:
-        url = self._build_ws_url()
-        while True:
-            try:
-                assert self._session is not None
-                async with self._session.ws_connect(
-                    url, heartbeat=WS_HEARTBEAT_SECONDS
-                ) as ws:
-                    logger.info(f"Home Assistant WebSocket connected to {self.ip}")
-                    async for msg in ws:
-                        if msg.type == aiohttp.WSMsgType.TEXT:
-                            await self._handle_message(ws, msg.data)
-                        elif msg.type in (
-                            aiohttp.WSMsgType.ERROR,
-                            aiohttp.WSMsgType.CLOSE,
-                            aiohttp.WSMsgType.CLOSING,
-                            aiohttp.WSMsgType.CLOSED,
-                        ):
-                            break
-                    logger.info("Home Assistant WebSocket closed")
-            except Exception as e:
-                logger.error("Home Assistant WebSocket error: %s", e, exc_info=True)
-            self._reset_for_reconnect()
-            await asyncio.sleep(5)
+    def _connect(
+        self, session: aiohttp.ClientSession
+    ) -> AbstractAsyncContextManager[WebSocket]:
+        return session.ws_connect(self._build_ws_url(), heartbeat=WS_HEARTBEAT_SECONDS)
 
-    def _reset_for_reconnect(self) -> None:
+    def _on_disconnect(self) -> None:
         """Reset protocol state and invalidate cached values so
         ``get_powermeter_watts`` raises (and ``wait_for_message`` blocks)
         until the reconnected ``subscribe_entities`` snapshot repopulates
         them.
         """
-        self._connected = False
         self._msg_id = 0
         self._subscribe_entities_id = None
         if self._fetch_states_task and not self._fetch_states_task.done():
@@ -206,13 +163,11 @@ class HomeAssistant(PushPowermeter):
                 if eid in self._tracked_entities:
                     self._update_entity_value(eid, None)
 
-    async def _handle_message(
-        self, ws: aiohttp.ClientWebSocketResponse[bool], raw: str
-    ) -> None:
+    async def _on_text(self, ws: WebSocket, raw: str) -> None:
         try:
             msg = json.loads(raw)
         except json.JSONDecodeError:
-            logger.error(f"Home Assistant: failed to decode message: {raw}")
+            logger.error("Home Assistant: failed to decode message: %s", raw)
             return
 
         msg_type = msg.get("type")
@@ -246,11 +201,11 @@ class HomeAssistant(PushPowermeter):
                 self._fetch_states_task.cancel()
             self._fetch_states_task = asyncio.create_task(self._fetch_initial_states())
         elif msg_type == "auth_invalid":
-            logger.error(f"Home Assistant auth failed: {msg.get('message', '')}")
+            logger.error("Home Assistant auth failed: %s", msg.get("message", ""))
         elif msg_type == "result":
             if msg.get("id") == self._subscribe_entities_id and not msg.get("success"):
                 logger.error(
-                    f"Home Assistant subscribe_entities failed: {msg.get('error')}"
+                    "Home Assistant subscribe_entities failed: %s", msg.get("error")
                 )
                 # No live stream after a failed subscription — clear so a
                 # REST-seeded snapshot can't keep stream_online() reporting

--- a/src/astrameter/powermeter/homeassistant.py
+++ b/src/astrameter/powermeter/homeassistant.py
@@ -244,7 +244,7 @@ class HomeAssistant(WebSocketPowermeter):
                 self._update_entity_value(eid, data.get("state"))
 
     def _update_entity_value(self, entity_id: str, state_val: object) -> None:
-        logger.debug(f"Home Assistant: update_entity_value: {entity_id}, {state_val}")
+        logger.debug("Home Assistant: %s = %s", entity_id, state_val)
         if state_val is None:
             self._entity_values[entity_id] = None
             self._check_entities_ready()

--- a/src/astrameter/powermeter/homeassistant.py
+++ b/src/astrameter/powermeter/homeassistant.py
@@ -40,7 +40,7 @@ class HomeAssistant(WebSocketPowermeter):
         power_input_alias: str | list[str],
         power_output_alias: str | list[str],
         path_prefix: str | None,
-    ):
+    ) -> None:
         super().__init__()
         self.ip = ip
         self.port = port

--- a/src/astrameter/powermeter/homeassistant_test.py
+++ b/src/astrameter/powermeter/homeassistant_test.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -7,8 +8,8 @@ import pytest
 from .homeassistant import HomeAssistant
 
 
-def _create_powermeter(**overrides):
-    defaults = dict(
+def _create_powermeter(**overrides: Any) -> HomeAssistant:
+    defaults: dict[str, Any] = dict(
         ip="192.168.1.8",
         port="8123",
         use_https=False,
@@ -36,7 +37,7 @@ def _compressed_initial_payload(states: list[dict]) -> dict:
     return {"a": a}
 
 
-async def _simulate_auth_and_states(pm, states):
+async def _simulate_auth_and_states(pm: HomeAssistant, states: list[dict]) -> AsyncMock:
     ws = AsyncMock()
     await pm._on_text(ws, json.dumps({"type": "auth_required"}))
     await pm._on_text(ws, json.dumps({"type": "auth_ok"}))
@@ -57,14 +58,14 @@ async def _simulate_auth_and_states(pm, states):
 # Auth flow tests
 
 
-async def test_auth_required_sends_token():
+async def test_auth_required_sends_token() -> None:
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._on_text(ws, json.dumps({"type": "auth_required"}))
     ws.send_json.assert_called_once_with({"type": "auth", "access_token": "token"})
 
 
-async def test_auth_ok_subscribes_entities():
+async def test_auth_ok_subscribes_entities() -> None:
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._on_text(ws, json.dumps({"type": "auth_required"}))
@@ -82,7 +83,7 @@ async def test_auth_ok_subscribes_entities():
     assert "sensor.current_power" in subscribe_msg["entity_ids"]
 
 
-async def test_auth_invalid_does_not_crash():
+async def test_auth_invalid_does_not_crash() -> None:
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._on_text(
@@ -95,7 +96,7 @@ async def test_auth_invalid_does_not_crash():
 # subscribe_entities initial snapshot tests
 
 
-async def test_initial_snapshot_populates_value():
+async def test_initial_snapshot_populates_value() -> None:
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "1000"}]
@@ -103,7 +104,7 @@ async def test_initial_snapshot_populates_value():
     assert await pm.get_powermeter_watts() == [1000.0]
 
 
-async def test_no_initial_event_leaves_values_missing():
+async def test_no_initial_event_leaves_values_missing() -> None:
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._on_text(ws, json.dumps({"type": "auth_required"}))
@@ -113,7 +114,7 @@ async def test_no_initial_event_leaves_values_missing():
         await pm.get_powermeter_watts()
 
 
-async def test_initial_snapshot_only_updates_tracked_entities():
+async def test_initial_snapshot_only_updates_tracked_entities() -> None:
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm,
@@ -128,7 +129,7 @@ async def test_initial_snapshot_only_updates_tracked_entities():
 # Trigger event tests
 
 
-async def test_trigger_event_updates_value():
+async def test_trigger_event_updates_value() -> None:
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "100"}]
@@ -155,7 +156,7 @@ async def test_trigger_event_updates_value():
     assert await pm.get_powermeter_watts() == [200.0]
 
 
-async def test_trigger_event_ignores_untracked_entity():
+async def test_trigger_event_ignores_untracked_entity() -> None:
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "100"}]
@@ -184,7 +185,7 @@ async def test_trigger_event_ignores_untracked_entity():
 # Unit conversion / rejection tests (issues #39 / #572)
 
 
-async def test_kw_unit_converted_to_watts():
+async def test_kw_unit_converted_to_watts() -> None:
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm,
@@ -199,7 +200,7 @@ async def test_kw_unit_converted_to_watts():
     assert await pm.get_powermeter_watts() == [215.0]
 
 
-async def test_w_unit_passes_through_unscaled():
+async def test_w_unit_passes_through_unscaled() -> None:
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm,
@@ -214,7 +215,7 @@ async def test_w_unit_passes_through_unscaled():
     assert await pm.get_powermeter_watts() == [1500.0]
 
 
-async def test_missing_unit_assumes_watts():
+async def test_missing_unit_assumes_watts() -> None:
     """No unit attribute → historical behavior: the value is taken as W."""
     pm = _create_powermeter()
     await _simulate_auth_and_states(
@@ -230,7 +231,7 @@ async def test_missing_unit_assumes_watts():
     assert await pm.get_powermeter_watts() == [300.0]
 
 
-async def test_non_power_unit_rejected():
+async def test_non_power_unit_rejected() -> None:
     """A sensor with a non-power unit (e.g. a temperature entity wired in by
     mistake) must fail loudly instead of feeding garbage watts downstream.
     """
@@ -254,7 +255,7 @@ async def test_non_power_unit_rejected():
     )
 
 
-async def test_energy_unit_rejected():
+async def test_energy_unit_rejected() -> None:
     """kWh is energy, not power — a classic mis-wiring that must be rejected."""
     pm = _create_powermeter()
     await _simulate_auth_and_states(
@@ -271,7 +272,7 @@ async def test_energy_unit_rejected():
         await pm.get_powermeter_watts()
 
 
-async def test_kw_unit_survives_state_only_diffs():
+async def test_kw_unit_survives_state_only_diffs() -> None:
     """State diffs usually omit attributes; the kW unit learned from the
     initial snapshot must keep applying to later state-only updates.
     """
@@ -302,7 +303,7 @@ async def test_kw_unit_survives_state_only_diffs():
     assert await pm.get_powermeter_watts() == [-600.0]
 
 
-async def test_unit_change_via_attribute_diff():
+async def test_unit_change_via_attribute_diff() -> None:
     """A `+`/`a` attribute diff carrying a new unit_of_measurement must
     update the conversion; one without the key must not clobber it.
     """
@@ -357,7 +358,7 @@ async def test_unit_change_via_attribute_diff():
     assert await pm.get_powermeter_watts() == [200.0]
 
 
-async def test_reconnect_snapshot_without_unit_resets_to_watts():
+async def test_reconnect_snapshot_without_unit_resets_to_watts() -> None:
     """A unit learned before a reconnect must not survive a fresh snapshot
     that no longer declares one (e.g. the entity was reconfigured):
     ``_on_disconnect`` keeps ``_entity_units``, so the complete
@@ -390,7 +391,7 @@ async def test_reconnect_snapshot_without_unit_resets_to_watts():
     assert await pm.get_powermeter_watts() == [500.0]
 
 
-async def test_full_snapshot_without_unit_clears_cached_unit():
+async def test_full_snapshot_without_unit_clears_cached_unit() -> None:
     """A complete attributes payload that omits unit_of_measurement clears
     the recorded unit (back to the watts default) — unlike a partial ``+``
     diff, which leaves it untouched.
@@ -429,7 +430,7 @@ async def test_full_snapshot_without_unit_clears_cached_unit():
     assert await pm.get_powermeter_watts() == [300.0]
 
 
-async def test_power_calculate_mode_converts_per_entity():
+async def test_power_calculate_mode_converts_per_entity() -> None:
     """Mixed units in calculate mode: each alias converts independently."""
     pm = _create_powermeter(
         current_power_entity="",
@@ -455,7 +456,7 @@ async def test_power_calculate_mode_converts_per_entity():
     assert await pm.get_powermeter_watts() == [800.0]
 
 
-async def test_rest_bootstrap_applies_unit():
+async def test_rest_bootstrap_applies_unit() -> None:
     pm = _create_powermeter()
     pm._session = _make_rest_session(
         {
@@ -473,7 +474,7 @@ async def test_rest_bootstrap_applies_unit():
 # Error condition tests
 
 
-async def test_sensor_has_no_state():
+async def test_sensor_has_no_state() -> None:
     pm = _create_powermeter()
     with pytest.raises(ValueError) as exc_info:
         await pm.get_powermeter_watts()
@@ -483,7 +484,7 @@ async def test_sensor_has_no_state():
     )
 
 
-async def test_sensor_state_none():
+async def test_sensor_state_none() -> None:
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": None}]
@@ -497,7 +498,7 @@ async def test_sensor_state_none():
     )
 
 
-async def test_sensor_state_not_numeric():
+async def test_sensor_state_not_numeric() -> None:
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm,
@@ -512,7 +513,7 @@ async def test_sensor_state_not_numeric():
     )
 
 
-async def test_malformed_json_message():
+async def test_malformed_json_message() -> None:
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._on_text(ws, "not valid json")
@@ -524,7 +525,7 @@ async def test_malformed_json_message():
 # Three-phase tests
 
 
-async def test_three_phase_direct():
+async def test_three_phase_direct() -> None:
     pm = _create_powermeter(
         current_power_entity=[
             "sensor.power_phase1",
@@ -546,7 +547,7 @@ async def test_three_phase_direct():
 # Power calculate tests
 
 
-async def test_power_calculate_mode():
+async def test_power_calculate_mode() -> None:
     pm = _create_powermeter(
         current_power_entity="",
         power_calculate=True,
@@ -563,7 +564,7 @@ async def test_power_calculate_mode():
     assert await pm.get_powermeter_watts() == [800.0]
 
 
-async def test_three_phase_calculated():
+async def test_three_phase_calculated() -> None:
     pm = _create_powermeter(
         current_power_entity="",
         power_calculate=True,
@@ -592,7 +593,7 @@ async def test_three_phase_calculated():
     assert await pm.get_powermeter_watts() == [800.0, 1700.0, 2600.0]
 
 
-async def test_power_alias_length_mismatch():
+async def test_power_alias_length_mismatch() -> None:
     """A static config invariant — fail fast at construction rather than
     on every ``get_powermeter_watts`` call.
     """
@@ -612,17 +613,17 @@ async def test_power_alias_length_mismatch():
 # WebSocket URL tests
 
 
-def test_ws_url_http():
+def test_ws_url_http() -> None:
     pm = _create_powermeter()
     assert pm._build_ws_url() == "ws://192.168.1.8:8123/api/websocket"
 
 
-def test_ws_url_https():
+def test_ws_url_https() -> None:
     pm = _create_powermeter(use_https=True)
     assert pm._build_ws_url() == "wss://192.168.1.8:8123/api/websocket"
 
 
-def test_ws_url_with_path_prefix():
+def test_ws_url_with_path_prefix() -> None:
     pm = _create_powermeter(path_prefix="/prefix")
     assert pm._build_ws_url() == "ws://192.168.1.8:8123/prefix/api/websocket"
 
@@ -630,7 +631,7 @@ def test_ws_url_with_path_prefix():
 # wait_for_message tests
 
 
-async def test_wait_for_message_returns_when_data_available():
+async def test_wait_for_message_returns_when_data_available() -> None:
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "100"}]
@@ -639,7 +640,7 @@ async def test_wait_for_message_returns_when_data_available():
     await pm.wait_for_message(timeout=1)
 
 
-async def test_wait_for_message_timeout():
+async def test_wait_for_message_timeout() -> None:
     pm = _create_powermeter()
     with pytest.raises(TimeoutError):
         await pm.wait_for_message(timeout=0)
@@ -648,13 +649,13 @@ async def test_wait_for_message_timeout():
 # wait_for_next_message tests
 
 
-async def test_wait_for_next_message_blocks_until_new():
+async def test_wait_for_next_message_blocks_until_new() -> None:
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "100"}]
     )
 
-    async def _push_later():
+    async def _push_later() -> None:
         await asyncio.sleep(0.05)
         pm._update_entity_value("sensor.current_power", "200")
 
@@ -664,7 +665,7 @@ async def test_wait_for_next_message_blocks_until_new():
     assert await pm.get_powermeter_watts() == [200.0]
 
 
-async def test_wait_for_next_message_timeout():
+async def test_wait_for_next_message_timeout() -> None:
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "100"}]
@@ -676,7 +677,7 @@ async def test_wait_for_next_message_timeout():
 # subscribe_entities entity list test
 
 
-async def test_subscribe_entities_contains_all_entities_calculate_mode():
+async def test_subscribe_entities_contains_all_entities_calculate_mode() -> None:
     pm = _create_powermeter(
         current_power_entity="",
         power_calculate=True,
@@ -697,14 +698,14 @@ async def test_subscribe_entities_contains_all_entities_calculate_mode():
 # REST bootstrap tests
 
 
-def _make_rest_session(responses: dict[str, dict | None]):
+def _make_rest_session(responses: dict[str, dict | None]) -> MagicMock:
     """Build a ``ClientSession`` mock where ``session.get(url)`` returns
     the configured JSON (or 404 when the mapped value is ``None``).
     ``responses`` is keyed by full URL.
     """
     captured_headers: dict[str, str] = {}
 
-    def _get(url, headers=None):
+    def _get(url: str, headers: dict[str, str] | None = None) -> Any:
         captured_headers.clear()
         if headers:
             captured_headers.update(headers)
@@ -727,7 +728,7 @@ def _make_rest_session(responses: dict[str, dict | None]):
     return session
 
 
-async def test_fetch_initial_states_seeds_value():
+async def test_fetch_initial_states_seeds_value() -> None:
     """When ``subscribe_entities`` never pushes an initial snapshot
     (entity not yet loaded, integration warming up), the REST bootstrap
     must still populate the cache so ``wait_for_message`` can return.
@@ -746,7 +747,7 @@ async def test_fetch_initial_states_seeds_value():
     assert await pm.get_powermeter_watts() == [123.0]
 
 
-async def test_fetch_initial_states_sends_bearer_token():
+async def test_fetch_initial_states_sends_bearer_token() -> None:
     pm = _create_powermeter()
     session = _make_rest_session(
         {
@@ -761,7 +762,7 @@ async def test_fetch_initial_states_sends_bearer_token():
     assert session._captured_headers.get("Authorization") == "Bearer token"
 
 
-async def test_fetch_initial_states_uses_https_and_path_prefix():
+async def test_fetch_initial_states_uses_https_and_path_prefix() -> None:
     pm = _create_powermeter(use_https=True, path_prefix="/core")
     session = _make_rest_session(
         {
@@ -776,7 +777,7 @@ async def test_fetch_initial_states_uses_https_and_path_prefix():
     assert await pm.get_powermeter_watts() == [42.0]
 
 
-async def test_fetch_initial_states_fetches_each_tracked_entity():
+async def test_fetch_initial_states_fetches_each_tracked_entity() -> None:
     pm = _create_powermeter(
         current_power_entity=[
             "sensor.power_phase1",
@@ -807,7 +808,7 @@ async def test_fetch_initial_states_fetches_each_tracked_entity():
     assert session.get.call_count == 3
 
 
-async def test_fetch_initial_states_skips_already_populated_entity():
+async def test_fetch_initial_states_skips_already_populated_entity() -> None:
     """If the ``subscribe_entities`` snapshot arrived first and already
     seeded a value, the REST fetch shouldn't waste a request — and must
     not clobber the (potentially newer) cached value.
@@ -828,7 +829,7 @@ async def test_fetch_initial_states_skips_already_populated_entity():
     assert await pm.get_powermeter_watts() == [999.0]
 
 
-async def test_fetch_initial_states_handles_404():
+async def test_fetch_initial_states_handles_404() -> None:
     pm = _create_powermeter()
     # 404: entity doesn't exist (or normalized differently); we mustn't
     # raise — the WS stream may still deliver a value later.
@@ -841,7 +842,7 @@ async def test_fetch_initial_states_handles_404():
         await pm.get_powermeter_watts()
 
 
-async def test_fetch_initial_states_swallows_request_exceptions():
+async def test_fetch_initial_states_swallows_request_exceptions() -> None:
     pm = _create_powermeter()
     session = MagicMock()
     session.get = MagicMock(side_effect=RuntimeError("boom"))
@@ -851,7 +852,7 @@ async def test_fetch_initial_states_swallows_request_exceptions():
     assert not pm._entities_ready.is_set()
 
 
-async def test_auth_ok_schedules_rest_bootstrap():
+async def test_auth_ok_schedules_rest_bootstrap() -> None:
     pm = _create_powermeter()
     pm._session = _make_rest_session(
         {
@@ -869,7 +870,7 @@ async def test_auth_ok_schedules_rest_bootstrap():
     assert await pm.get_powermeter_watts() == [7.0]
 
 
-async def test_reconnect_cancels_in_flight_fetch():
+async def test_reconnect_cancels_in_flight_fetch() -> None:
     """An in-flight REST bootstrap from the previous connection must be
     cancelled by ``_on_disconnect``; otherwise it could resurrect
     a stale value after the reset.
@@ -878,7 +879,7 @@ async def test_reconnect_cancels_in_flight_fetch():
     started = asyncio.Event()
     release = asyncio.Event()
 
-    async def _hang():
+    async def _hang() -> None:
         started.set()
         await release.wait()
 
@@ -889,7 +890,7 @@ async def test_reconnect_cancels_in_flight_fetch():
         await pm._fetch_states_task
 
 
-async def test_reconnect_prevents_stale_bootstrap_reseed():
+async def test_reconnect_prevents_stale_bootstrap_reseed() -> None:
     """End-to-end guard on the real ``_fetch_initial_states``: when the
     REST response only resolves *after* ``_on_disconnect`` has
     cancelled the task, the post-await write must never land — the stale
@@ -898,11 +899,11 @@ async def test_reconnect_prevents_stale_bootstrap_reseed():
     pm = _create_powermeter()
     gate = asyncio.Event()
 
-    def _get(url, headers=None):
+    def _get(url: str, headers: dict[str, str] | None = None) -> Any:
         resp = MagicMock()
         resp.status = 200
 
-        async def _json():
+        async def _json() -> Any:
             await gate.wait()  # don't resolve until the test releases it
             return {"entity_id": "sensor.current_power", "state": "123"}
 
@@ -931,7 +932,7 @@ async def test_reconnect_prevents_stale_bootstrap_reseed():
 # Lifecycle tests
 
 
-async def test_start_creates_session_and_task():
+async def test_start_creates_session_and_task() -> None:
     pm = _create_powermeter()
     with patch.object(pm, "_ws_loop", new_callable=AsyncMock) as mock_loop:
         mock_loop.return_value = None
@@ -941,7 +942,7 @@ async def test_start_creates_session_and_task():
         await pm.stop()
 
 
-async def test_start_is_idempotent():
+async def test_start_is_idempotent() -> None:
     pm = _create_powermeter()
     with patch.object(pm, "_ws_loop", new_callable=AsyncMock) as mock_loop:
         mock_loop.return_value = None
@@ -952,7 +953,7 @@ async def test_start_is_idempotent():
         await pm.stop()
 
 
-async def test_stop_closes_session():
+async def test_stop_closes_session() -> None:
     pm = _create_powermeter()
     with patch.object(pm, "_ws_loop", new_callable=AsyncMock) as mock_loop:
         mock_loop.return_value = None
@@ -962,7 +963,7 @@ async def test_stop_closes_session():
         assert pm._ws_task is None
 
 
-async def test_stop_without_start():
+async def test_stop_without_start() -> None:
     pm = _create_powermeter()
     # Should not raise
     await pm.stop()
@@ -971,7 +972,7 @@ async def test_stop_without_start():
 # entities_ready event tests
 
 
-async def test_entities_ready_set_when_all_present():
+async def test_entities_ready_set_when_all_present() -> None:
     pm = _create_powermeter()
     assert not pm._entities_ready.is_set()
     await _simulate_auth_and_states(
@@ -980,7 +981,7 @@ async def test_entities_ready_set_when_all_present():
     assert pm._entities_ready.is_set()
 
 
-async def test_entities_ready_cleared_when_value_becomes_none():
+async def test_entities_ready_cleared_when_value_becomes_none() -> None:
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "100"}]
@@ -1010,7 +1011,7 @@ async def test_entities_ready_cleared_when_value_becomes_none():
 
 
 @pytest.mark.parametrize("ts_key", ["lu", "lc"])
-async def test_state_reported_event_wakes_wait_for_next_message(ts_key: str):
+async def test_state_reported_event_wakes_wait_for_next_message(ts_key: str) -> None:
     """HA's ``subscribe_entities`` omits ``s`` from the diff when a sensor
     is reported with an unchanged value (only ``lu``/``lc`` updates).
     ``wait_for_next_message`` must still wake on those so callers like the
@@ -1043,7 +1044,7 @@ async def test_state_reported_event_wakes_wait_for_next_message(ts_key: str):
     assert pm._entity_values["sensor.current_power"] == 42.0
 
 
-async def test_state_reported_before_initial_value_is_ignored():
+async def test_state_reported_before_initial_value_is_ignored() -> None:
     """A bare ``lu``/``lc`` keepalive that arrives before any state value
     must not wake ``wait_for_next_message`` — there is no usable value
     yet, so claiming the sensor is alive would be misleading.
@@ -1069,7 +1070,7 @@ async def test_state_reported_before_initial_value_is_ignored():
     assert not pm._message_event.is_set()
 
 
-async def test_reconnect_invalidates_cached_values():
+async def test_reconnect_invalidates_cached_values() -> None:
     """A websocket disconnect must invalidate cached values, clear the
     ready flag, and reset the protocol counter so the reconnected
     ``subscribe_entities`` snapshot is what callers see — not stale
@@ -1101,7 +1102,7 @@ async def test_reconnect_invalidates_cached_values():
     assert await pm.get_powermeter_watts() == [250.0]
 
 
-async def test_unavailable_blocks_wait_for_message():
+async def test_unavailable_blocks_wait_for_message() -> None:
     """When a sensor transitions to ``unavailable`` mid-stream, the ready
     flag must clear so ``wait_for_message`` blocks again — callers
     waiting for a usable reading shouldn't see the immediate return
@@ -1134,12 +1135,12 @@ async def test_unavailable_blocks_wait_for_message():
 # --- stream_online health hook ---
 
 
-async def test_stream_online_false_before_auth():
+async def test_stream_online_false_before_auth() -> None:
     pm = _create_powermeter()
     assert pm.stream_online() is False
 
 
-async def test_stream_online_true_when_connected_and_entities_ready():
+async def test_stream_online_true_when_connected_and_entities_ready() -> None:
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "123.0"}]
@@ -1147,7 +1148,7 @@ async def test_stream_online_true_when_connected_and_entities_ready():
     assert pm.stream_online() is True
 
 
-async def test_stream_online_multi_phase_quiet_phase_stays_online():
+async def test_stream_online_multi_phase_quiet_phase_stays_online() -> None:
     """A phase that stops changing (e.g. an idle oven phase reporting 0 W)
     keeps its value and must NOT mark the powermeter offline."""
     pm = _create_powermeter(
@@ -1168,7 +1169,7 @@ async def test_stream_online_multi_phase_quiet_phase_stays_online():
     assert pm.stream_online() is True
 
 
-async def test_stream_online_false_when_a_phase_goes_unavailable():
+async def test_stream_online_false_when_a_phase_goes_unavailable() -> None:
     pm = _create_powermeter(
         current_power_entity=["sensor.l1", "sensor.l2", "sensor.l3"]
     )
@@ -1186,7 +1187,7 @@ async def test_stream_online_false_when_a_phase_goes_unavailable():
     assert pm.stream_online() is False
 
 
-async def test_stream_online_false_after_reconnect_reset():
+async def test_stream_online_false_after_reconnect_reset() -> None:
     pm = _create_powermeter()
     await _simulate_auth_and_states(
         pm, [{"entity_id": "sensor.current_power", "state": "123.0"}]

--- a/src/astrameter/powermeter/homeassistant_test.py
+++ b/src/astrameter/powermeter/homeassistant_test.py
@@ -38,10 +38,10 @@ def _compressed_initial_payload(states: list[dict]) -> dict:
 
 async def _simulate_auth_and_states(pm, states):
     ws = AsyncMock()
-    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
-    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    await pm._on_text(ws, json.dumps({"type": "auth_required"}))
+    await pm._on_text(ws, json.dumps({"type": "auth_ok"}))
     sid = pm._subscribe_entities_id
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps(
             {
@@ -60,17 +60,17 @@ async def _simulate_auth_and_states(pm, states):
 async def test_auth_required_sends_token():
     pm = _create_powermeter()
     ws = AsyncMock()
-    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
+    await pm._on_text(ws, json.dumps({"type": "auth_required"}))
     ws.send_json.assert_called_once_with({"type": "auth", "access_token": "token"})
 
 
 async def test_auth_ok_subscribes_entities():
     pm = _create_powermeter()
     ws = AsyncMock()
-    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
+    await pm._on_text(ws, json.dumps({"type": "auth_required"}))
     ws.send_json.reset_mock()
 
-    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    await pm._on_text(ws, json.dumps({"type": "auth_ok"}))
     if pm._fetch_states_task:
         pm._fetch_states_task.cancel()
 
@@ -85,7 +85,7 @@ async def test_auth_ok_subscribes_entities():
 async def test_auth_invalid_does_not_crash():
     pm = _create_powermeter()
     ws = AsyncMock()
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps({"type": "auth_invalid", "message": "bad token"}),
     )
@@ -106,8 +106,8 @@ async def test_initial_snapshot_populates_value():
 async def test_no_initial_event_leaves_values_missing():
     pm = _create_powermeter()
     ws = AsyncMock()
-    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
-    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    await pm._on_text(ws, json.dumps({"type": "auth_required"}))
+    await pm._on_text(ws, json.dumps({"type": "auth_ok"}))
 
     with pytest.raises(ValueError):
         await pm.get_powermeter_watts()
@@ -136,7 +136,7 @@ async def test_trigger_event_updates_value():
     assert await pm.get_powermeter_watts() == [100.0]
 
     ws = AsyncMock()
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps(
             {
@@ -162,7 +162,7 @@ async def test_trigger_event_ignores_untracked_entity():
     )
 
     ws = AsyncMock()
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps(
             {
@@ -287,7 +287,7 @@ async def test_kw_unit_survives_state_only_diffs():
         ],
     )
     ws = AsyncMock()
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps(
             {
@@ -318,7 +318,7 @@ async def test_unit_change_via_attribute_diff():
         ],
     )
     ws = AsyncMock()
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps(
             {
@@ -339,7 +339,7 @@ async def test_unit_change_via_attribute_diff():
     assert await pm.get_powermeter_watts() == [500.0]
 
     # An attribute diff that doesn't touch the unit leaves kW in effect.
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps(
             {
@@ -360,7 +360,7 @@ async def test_unit_change_via_attribute_diff():
 async def test_reconnect_snapshot_without_unit_resets_to_watts():
     """A unit learned before a reconnect must not survive a fresh snapshot
     that no longer declares one (e.g. the entity was reconfigured):
-    ``_reset_for_reconnect`` keeps ``_entity_units``, so the complete
+    ``_on_disconnect`` keeps ``_entity_units``, so the complete
     post-reconnect snapshot must replace — here clear — the stale kW scale.
     """
     pm = _create_powermeter()
@@ -376,7 +376,7 @@ async def test_reconnect_snapshot_without_unit_resets_to_watts():
     )
     assert await pm.get_powermeter_watts() == [500.0]
 
-    pm._reset_for_reconnect()
+    pm._on_disconnect()
     await _simulate_auth_and_states(
         pm,
         [
@@ -410,7 +410,7 @@ async def test_full_snapshot_without_unit_clears_cached_unit():
 
     # Same connection: a fresh full snapshot (event.a) without the unit key.
     ws = AsyncMock()
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps(
             {
@@ -515,7 +515,7 @@ async def test_sensor_state_not_numeric():
 async def test_malformed_json_message():
     pm = _create_powermeter()
     ws = AsyncMock()
-    await pm._handle_message(ws, "not valid json")
+    await pm._on_text(ws, "not valid json")
     # Should not raise; value stays absent
     with pytest.raises(ValueError):
         await pm.get_powermeter_watts()
@@ -684,9 +684,9 @@ async def test_subscribe_entities_contains_all_entities_calculate_mode():
         power_output_alias="sensor.power_output",
     )
     ws = AsyncMock()
-    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
+    await pm._on_text(ws, json.dumps({"type": "auth_required"}))
     ws.send_json.reset_mock()
-    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    await pm._on_text(ws, json.dumps({"type": "auth_ok"}))
 
     subscribe_msg = ws.send_json.call_args_list[0][0][0]
     entity_ids = subscribe_msg["entity_ids"]
@@ -862,8 +862,8 @@ async def test_auth_ok_schedules_rest_bootstrap():
         }
     )
     ws = AsyncMock()
-    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
-    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    await pm._on_text(ws, json.dumps({"type": "auth_required"}))
+    await pm._on_text(ws, json.dumps({"type": "auth_ok"}))
     assert pm._fetch_states_task is not None
     await pm._fetch_states_task
     assert await pm.get_powermeter_watts() == [7.0]
@@ -871,7 +871,7 @@ async def test_auth_ok_schedules_rest_bootstrap():
 
 async def test_reconnect_cancels_in_flight_fetch():
     """An in-flight REST bootstrap from the previous connection must be
-    cancelled by ``_reset_for_reconnect``; otherwise it could resurrect
+    cancelled by ``_on_disconnect``; otherwise it could resurrect
     a stale value after the reset.
     """
     pm = _create_powermeter()
@@ -884,14 +884,14 @@ async def test_reconnect_cancels_in_flight_fetch():
 
     pm._fetch_states_task = asyncio.create_task(_hang())
     await started.wait()
-    pm._reset_for_reconnect()
+    pm._on_disconnect()
     with pytest.raises(asyncio.CancelledError):
         await pm._fetch_states_task
 
 
 async def test_reconnect_prevents_stale_bootstrap_reseed():
     """End-to-end guard on the real ``_fetch_initial_states``: when the
-    REST response only resolves *after* ``_reset_for_reconnect`` has
+    REST response only resolves *after* ``_on_disconnect`` has
     cancelled the task, the post-await write must never land — the stale
     value cannot reseed the cache that the reset just cleared.
     """
@@ -918,7 +918,7 @@ async def test_reconnect_prevents_stale_bootstrap_reseed():
     pm._fetch_states_task = asyncio.create_task(pm._fetch_initial_states())
     await asyncio.sleep(0)  # let the task reach `await resp.json()`
 
-    pm._reset_for_reconnect()  # cancels the in-flight task and clears cache
+    pm._on_disconnect()  # cancels the in-flight task and clears cache
     gate.set()  # the json await would resume here — but cancellation wins
 
     with pytest.raises(asyncio.CancelledError):
@@ -988,7 +988,7 @@ async def test_entities_ready_cleared_when_value_becomes_none():
     assert pm._entities_ready.is_set()
 
     ws = AsyncMock()
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps(
             {
@@ -1027,7 +1027,7 @@ async def test_state_reported_event_wakes_wait_for_next_message(ts_key: str):
     await asyncio.sleep(0)
 
     ws = AsyncMock()
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps(
             {
@@ -1050,10 +1050,10 @@ async def test_state_reported_before_initial_value_is_ignored():
     """
     pm = _create_powermeter()
     ws = AsyncMock()
-    await pm._handle_message(ws, json.dumps({"type": "auth_required"}))
-    await pm._handle_message(ws, json.dumps({"type": "auth_ok"}))
+    await pm._on_text(ws, json.dumps({"type": "auth_required"}))
+    await pm._on_text(ws, json.dumps({"type": "auth_ok"}))
     pm._message_event.clear()
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps(
             {
@@ -1073,7 +1073,7 @@ async def test_reconnect_invalidates_cached_values():
     """A websocket disconnect must invalidate cached values, clear the
     ready flag, and reset the protocol counter so the reconnected
     ``subscribe_entities`` snapshot is what callers see — not stale
-    cache. Drives the real ``_reset_for_reconnect`` method that
+    cache. Drives the real ``_on_disconnect`` method that
     ``_ws_loop`` invokes after a disconnect, so a regression in any of
     its four resets is caught here.
     """
@@ -1085,7 +1085,7 @@ async def test_reconnect_invalidates_cached_values():
     assert pm._entities_ready.is_set()
     assert await pm.get_powermeter_watts() == [100.0]
 
-    pm._reset_for_reconnect()
+    pm._on_disconnect()
 
     assert pm._msg_id == 0
     assert pm._subscribe_entities_id is None
@@ -1114,7 +1114,7 @@ async def test_unavailable_blocks_wait_for_message():
     await pm.wait_for_message(timeout=1)  # returns immediately when ready
 
     ws = AsyncMock()
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps(
             {
@@ -1192,5 +1192,5 @@ async def test_stream_online_false_after_reconnect_reset():
         pm, [{"entity_id": "sensor.current_power", "state": "123.0"}]
     )
     assert pm.stream_online() is True
-    pm._reset_for_reconnect()
+    pm._on_disconnect()
     assert pm.stream_online() is False

--- a/src/astrameter/powermeter/homewizard.py
+++ b/src/astrameter/powermeter/homewizard.py
@@ -5,12 +5,17 @@ import os
 import ssl
 import time
 from collections.abc import Callable
-from contextlib import AbstractAsyncContextManager
 
 import aiohttp
 
 from .base import stream_fresh
-from .ws_client import WS_HEARTBEAT_SECONDS, WebSocket, WebSocketPowermeter, cancel
+from .ws_client import (
+    WS_HEARTBEAT_SECONDS,
+    WebSocket,
+    WebSocketConnect,
+    WebSocketPowermeter,
+    cancel,
+)
 
 # Stdlib logger: avoid importing astrameter.config (config_loader imports powermeter).
 logger = logging.getLogger("astrameter")
@@ -92,9 +97,7 @@ class HomeWizardPowermeter(WebSocketPowermeter):
         self._fresh_measurement_event.clear()
         await super().start()
 
-    def _connect(
-        self, session: aiohttp.ClientSession
-    ) -> AbstractAsyncContextManager[WebSocket]:
+    def _connect(self, session: aiohttp.ClientSession) -> WebSocketConnect:
         return session.ws_connect(
             f"wss://{self.ip}/api/ws",
             ssl=self._build_ssl_context(),

--- a/src/astrameter/powermeter/homewizard.py
+++ b/src/astrameter/powermeter/homewizard.py
@@ -1,15 +1,16 @@
 import asyncio
-import contextlib
 import json
 import logging
 import os
 import ssl
 import time
 from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
 
 import aiohttp
 
-from .base import PushPowermeter, stream_fresh
+from .base import stream_fresh
+from .ws_client import WS_HEARTBEAT_SECONDS, WebSocket, WebSocketPowermeter, cancel
 
 # Stdlib logger: avoid importing astrameter.config (config_loader imports powermeter).
 logger = logging.getLogger("astrameter")
@@ -17,12 +18,6 @@ logger = logging.getLogger("astrameter")
 # Certificate: https://api-documentation.homewizard.com/assets/files/homewizard-ca-cert-56d062ef8e71d1038f464ea905d42fc6.pem
 # Docs: https://api-documentation.homewizard.com/docs/v2/authorization#https
 CA_CERT_PATH = os.path.join(os.path.dirname(__file__), "homewizard_ca.pem")
-
-# WebSocket heartbeat (seconds).  With this set, aiohttp sends ping
-# frames at this interval and forcibly closes the connection if no
-# pong is received within 2x the heartbeat — catches half-open TCP
-# sockets that would otherwise freeze ``async for msg in ws`` forever.
-WS_HEARTBEAT_SECONDS = 30.0
 
 # Maximum age of the last-received measurement before ``get_powermeter_watts``
 # considers the value stale and raises.  HomeWizard P1 dongles push
@@ -37,8 +32,9 @@ DEFAULT_MAX_MEASUREMENT_AGE_SECONDS = 30.0
 WATCHDOG_TIMEOUT_SECONDS = 45.0
 
 
-class HomeWizardPowermeter(PushPowermeter):
+class HomeWizardPowermeter(WebSocketPowermeter):
     _TIMEOUT_MESSAGE = "Timeout waiting for HomeWizard measurement"
+    _LOG_NAME = "HomeWizard"
 
     def __init__(
         self,
@@ -59,19 +55,14 @@ class HomeWizardPowermeter(PushPowermeter):
         self._clock = clock or time.monotonic
         self.values: list[float] | None = None
         self._last_measurement_time: float | None = None
-        # Read-only health flag for stream_online(): set once the WebSocket is
-        # up and subscribed, cleared whenever the connection drops.
-        self._connected = False
         # True only while measurements arrive as a *continuous* stream (each one
         # before the previous goes stale).  A broken P1 dongle still accepts the
         # WebSocket and replays a single cached value every time the watchdog
         # force-reconnects; that lone sample would otherwise reset the freshness
         # window and flap the "Online" sensor on/off.  See stream_online().
         self._stream_healthy = False
-        self._session: aiohttp.ClientSession | None = None
-        self._ws_task: asyncio.Task[None] | None = None
-        # Set whenever we receive a new measurement; the ws_loop watchdog
-        # clears it after checking staleness to re-arm the timer.
+        # Set whenever we receive a new measurement; the read watchdog clears it
+        # after checking staleness to re-arm the timer.
         self._fresh_measurement_event = asyncio.Event()
 
         if not verify_ssl:
@@ -96,79 +87,39 @@ class HomeWizardPowermeter(PushPowermeter):
             return
         self.values = None
         self._last_measurement_time = None
-        self._connected = False
         self._stream_healthy = False
         self._message_event.clear()
         self._fresh_measurement_event.clear()
-        self._session = aiohttp.ClientSession()
-        self._ws_task = asyncio.create_task(self._ws_loop())
+        await super().start()
 
-    async def stop(self) -> None:
-        # Clear before cancelling: cancellation leaves the ws_loop before its
-        # own reset runs, so stream_online() would otherwise stay True.
-        self._connected = False
-        if self._ws_task:
-            self._ws_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._ws_task
-            self._ws_task = None
-        if self._session:
-            await self._session.close()
-            self._session = None
+    def _connect(
+        self, session: aiohttp.ClientSession
+    ) -> AbstractAsyncContextManager[WebSocket]:
+        return session.ws_connect(
+            f"wss://{self.ip}/api/ws",
+            ssl=self._build_ssl_context(),
+            server_hostname=f"appliance/p1dongle/{self.serial}",
+            heartbeat=WS_HEARTBEAT_SECONDS,
+        )
 
-    async def _ws_loop(self) -> None:
-        url = f"wss://{self.ip}/api/ws"
-        ssl_context = self._build_ssl_context()
-        server_hostname = f"appliance/p1dongle/{self.serial}"
-        while True:
-            try:
-                assert self._session is not None
-                async with self._session.ws_connect(
-                    url,
-                    ssl=ssl_context,
-                    server_hostname=server_hostname,
-                    heartbeat=WS_HEARTBEAT_SECONDS,
-                ) as ws:
-                    logger.info(f"HomeWizard WebSocket connected to {self.ip}")
-                    # Start a watchdog that force-closes the ws if no
-                    # measurement arrives within WATCHDOG_TIMEOUT_SECONDS.
-                    # This catches the case where the dongle's TCP
-                    # keepalives succeed (so aiohttp's heartbeat doesn't
-                    # trip) but the measurement stream has stalled at
-                    # the application layer.
-                    watchdog = asyncio.create_task(self._measurement_watchdog(ws))
-                    try:
-                        async for msg in ws:
-                            if msg.type == aiohttp.WSMsgType.TEXT:
-                                await self._handle_message(ws, msg.data)
-                            elif msg.type in (
-                                aiohttp.WSMsgType.ERROR,
-                                aiohttp.WSMsgType.CLOSE,
-                                aiohttp.WSMsgType.CLOSING,
-                                aiohttp.WSMsgType.CLOSED,
-                            ):
-                                break
-                    finally:
-                        watchdog.cancel()
-                        with contextlib.suppress(asyncio.CancelledError):
-                            await watchdog
-                    logger.info("HomeWizard WebSocket closed")
-            except Exception as e:
-                logger.error("HomeWizard WebSocket error: %s", e, exc_info=True)
-            self._connected = False
-            await asyncio.sleep(5)
+    async def _read(self, ws: WebSocket) -> None:
+        # A watchdog alongside the reader force-closes the socket when no
+        # measurement arrives, which the aiohttp heartbeat cannot catch: the
+        # dongle's TCP keepalives keep answering while the measurement stream
+        # has stalled a layer above them.
+        watchdog = asyncio.create_task(self._measurement_watchdog(ws))
+        try:
+            await super()._read(ws)
+        finally:
+            await cancel(watchdog)
 
-    async def _measurement_watchdog(
-        self, ws: aiohttp.ClientWebSocketResponse[bool]
-    ) -> None:
+    async def _measurement_watchdog(self, ws: WebSocket) -> None:
         """Force-close *ws* when no measurement has arrived within
         :data:`WATCHDOG_TIMEOUT_SECONDS`.
 
-        HomeWizard P1 dongles normally push a measurement every ~1 s.
-        A dongle that stops streaming without closing the TCP connection
-        will otherwise sit forever in :meth:`_ws_loop`'s
-        ``async for msg in ws`` — the exact failure mode observed in
-        the user's report.
+        HomeWizard P1 dongles normally push a measurement every ~1 s. A dongle
+        that stops streaming without closing the TCP connection would otherwise
+        sit in the read loop forever.
         """
         while True:
             self._fresh_measurement_event.clear()
@@ -186,17 +137,15 @@ class HomeWizardPowermeter(PushPowermeter):
                 await ws.close()
                 return
 
-    async def _handle_message(
-        self, ws: aiohttp.ClientWebSocketResponse[bool], raw: str
-    ) -> None:
+    async def _on_text(self, ws: WebSocket, raw: str) -> None:
         try:
             msg = json.loads(raw)
         except json.JSONDecodeError:
-            logger.error(f"HomeWizard: failed to decode message: {raw}")
+            logger.error("HomeWizard: failed to decode message: %s", raw)
             return
 
         if not isinstance(msg, dict):
-            logger.error(f"HomeWizard: unexpected message format: {raw}")
+            logger.error("HomeWizard: unexpected message format: %s", raw)
             return
 
         msg_type = msg.get("type")
@@ -212,9 +161,9 @@ class HomeWizardPowermeter(PushPowermeter):
                 self._handle_measurement(data)
         elif msg_type == "error":
             error_data = msg.get("data", {})
-            logger.error(f"HomeWizard error: {error_data.get('message', msg)}")
+            logger.error("HomeWizard error: %s", error_data.get("message", msg))
         else:
-            logger.debug(f"HomeWizard: unknown message type: {msg_type}")
+            logger.debug("HomeWizard: unknown message type: %s", msg_type)
 
     def _handle_measurement(self, data: dict) -> None:
         if "power_l1_w" in data:

--- a/src/astrameter/powermeter/homewizard_test.py
+++ b/src/astrameter/powermeter/homewizard_test.py
@@ -72,7 +72,7 @@ def test_measurement_sets_event():
 async def test_authorization_requested_sends_token():
     pm = _create_powermeter()
     ws = AsyncMock()
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps(
             {"type": "authorization_requested", "data": {"api_version": "2.0.0"}}
@@ -84,14 +84,14 @@ async def test_authorization_requested_sends_token():
 async def test_authorized_subscribes_to_measurements():
     pm = _create_powermeter()
     ws = AsyncMock()
-    await pm._handle_message(ws, json.dumps({"type": "authorized"}))
+    await pm._on_text(ws, json.dumps({"type": "authorized"}))
     ws.send_json.assert_called_once_with({"type": "subscribe", "data": "measurement"})
 
 
 async def test_error_message_does_not_crash():
     pm = _create_powermeter()
     ws = AsyncMock()
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps({"type": "error", "data": {"message": "user:not-authorized"}}),
     )
@@ -101,39 +101,37 @@ async def test_error_message_does_not_crash():
 async def test_malformed_json_does_not_crash():
     pm = _create_powermeter()
     ws = AsyncMock()
-    await pm._handle_message(ws, "not valid json")
+    await pm._on_text(ws, "not valid json")
     assert pm.values is None
 
 
 async def test_unknown_message_type_does_not_crash():
     pm = _create_powermeter()
     ws = AsyncMock()
-    await pm._handle_message(ws, json.dumps({"type": "unknown_type"}))
+    await pm._on_text(ws, json.dumps({"type": "unknown_type"}))
     assert pm.values is None
 
 
 async def test_non_dict_json_does_not_crash():
     pm = _create_powermeter()
     ws = AsyncMock()
-    await pm._handle_message(ws, json.dumps([1, 2, 3]))
+    await pm._on_text(ws, json.dumps([1, 2, 3]))
     assert pm.values is None
-    await pm._handle_message(ws, json.dumps("just a string"))
+    await pm._on_text(ws, json.dumps("just a string"))
     assert pm.values is None
 
 
 async def test_measurement_non_dict_data_ignored():
     pm = _create_powermeter()
     ws = AsyncMock()
-    await pm._handle_message(
-        ws, json.dumps({"type": "measurement", "data": "not a dict"})
-    )
+    await pm._on_text(ws, json.dumps({"type": "measurement", "data": "not a dict"}))
     assert pm.values is None
 
 
 async def test_measurement_message_stores_values():
     pm = _create_powermeter()
     ws = AsyncMock()
-    await pm._handle_message(
+    await pm._on_text(
         ws,
         json.dumps({"type": "measurement", "data": {"power_w": 500}}),
     )
@@ -465,7 +463,7 @@ async def test_full_auth_subscribe_measurement_flow():
 
     async for msg in ws:
         if msg.type == aiohttp.WSMsgType.TEXT:
-            await pm._handle_message(ws, msg.data)
+            await pm._on_text(ws, msg.data)
 
     ws.send_json.assert_any_call({"type": "authorization", "data": "ABCD1234"})
     ws.send_json.assert_any_call({"type": "subscribe", "data": "measurement"})
@@ -473,29 +471,18 @@ async def test_full_auth_subscribe_measurement_flow():
 
 
 async def test_close_message_exits_iteration():
+    """A CLOSE frame ends the read, so nothing after it is acted on."""
     pm = _create_powermeter()
+    ws = _FakeWs(
+        [
+            _ws_text({"type": "authorized"}),
+            aiohttp.WSMessage(aiohttp.WSMsgType.CLOSE, None, None),
+            _ws_text({"type": "measurement", "data": {"power_w": 500}}),
+        ]
+    )
 
-    messages = [
-        _ws_text({"type": "authorized"}),
-        aiohttp.WSMessage(aiohttp.WSMsgType.CLOSE, None, None),
-        _ws_text({"type": "measurement", "data": {"power_w": 500}}),
-    ]
-    ws = _FakeWs(messages)
+    await pm._read(ws)
 
-    processed = []
-    async for msg in ws:
-        if msg.type == aiohttp.WSMsgType.TEXT:
-            await pm._handle_message(ws, msg.data)
-            processed.append(msg)
-        elif msg.type in (
-            aiohttp.WSMsgType.CLOSE,
-            aiohttp.WSMsgType.CLOSING,
-            aiohttp.WSMsgType.CLOSED,
-            aiohttp.WSMsgType.ERROR,
-        ):
-            break
-
-    assert len(processed) == 1
     assert pm.values is None
 
 

--- a/src/astrameter/powermeter/homewizard_test.py
+++ b/src/astrameter/powermeter/homewizard_test.py
@@ -2,6 +2,8 @@ import asyncio
 import contextlib
 import json
 import ssl
+from collections.abc import AsyncIterator
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -10,8 +12,8 @@ import pytest
 from .homewizard import HomeWizardPowermeter
 
 
-def _create_powermeter(**overrides):
-    defaults = dict(
+def _create_powermeter(**overrides: Any) -> HomeWizardPowermeter:
+    defaults: dict[str, Any] = dict(
         ip="192.168.1.1",
         token="ABCD1234",
         serial="aabbccddee",
@@ -27,7 +29,7 @@ def _ws_text(data: dict) -> aiohttp.WSMessage:
 # --- Category A: Measurement parsing ---
 
 
-def test_measurement_three_phase():
+def test_measurement_three_phase() -> None:
     pm = _create_powermeter()
     pm._handle_measurement(
         {"power_w": -543, "power_l1_w": -200, "power_l2_w": -143, "power_l3_w": -200}
@@ -35,31 +37,31 @@ def test_measurement_three_phase():
     assert pm.values == [-200, -143, -200]
 
 
-def test_measurement_single_phase():
+def test_measurement_single_phase() -> None:
     pm = _create_powermeter()
     pm._handle_measurement({"power_w": 500})
     assert pm.values == [500]
 
 
-def test_measurement_missing_phases():
+def test_measurement_missing_phases() -> None:
     pm = _create_powermeter()
     pm._handle_measurement({"power_w": -543, "power_l1_w": -543})
     assert pm.values == [-543, 0, 0]
 
 
-def test_measurement_no_power_fields():
+def test_measurement_no_power_fields() -> None:
     pm = _create_powermeter()
     pm._handle_measurement({"energy_import_kwh": 1234.5})
     assert pm.values is None
 
 
-def test_negative_power_preserved():
+def test_negative_power_preserved() -> None:
     pm = _create_powermeter()
     pm._handle_measurement({"power_w": -1500})
     assert pm.values == [-1500]
 
 
-def test_measurement_sets_event():
+def test_measurement_sets_event() -> None:
     pm = _create_powermeter()
     assert not pm._message_event.is_set()
     pm._handle_measurement({"power_w": 100})
@@ -69,7 +71,7 @@ def test_measurement_sets_event():
 # --- Category B: Auth/subscribe flow ---
 
 
-async def test_authorization_requested_sends_token():
+async def test_authorization_requested_sends_token() -> None:
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._on_text(
@@ -81,14 +83,14 @@ async def test_authorization_requested_sends_token():
     ws.send_json.assert_called_once_with({"type": "authorization", "data": "ABCD1234"})
 
 
-async def test_authorized_subscribes_to_measurements():
+async def test_authorized_subscribes_to_measurements() -> None:
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._on_text(ws, json.dumps({"type": "authorized"}))
     ws.send_json.assert_called_once_with({"type": "subscribe", "data": "measurement"})
 
 
-async def test_error_message_does_not_crash():
+async def test_error_message_does_not_crash() -> None:
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._on_text(
@@ -98,21 +100,21 @@ async def test_error_message_does_not_crash():
     assert pm.values is None
 
 
-async def test_malformed_json_does_not_crash():
+async def test_malformed_json_does_not_crash() -> None:
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._on_text(ws, "not valid json")
     assert pm.values is None
 
 
-async def test_unknown_message_type_does_not_crash():
+async def test_unknown_message_type_does_not_crash() -> None:
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._on_text(ws, json.dumps({"type": "unknown_type"}))
     assert pm.values is None
 
 
-async def test_non_dict_json_does_not_crash():
+async def test_non_dict_json_does_not_crash() -> None:
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._on_text(ws, json.dumps([1, 2, 3]))
@@ -121,14 +123,14 @@ async def test_non_dict_json_does_not_crash():
     assert pm.values is None
 
 
-async def test_measurement_non_dict_data_ignored():
+async def test_measurement_non_dict_data_ignored() -> None:
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._on_text(ws, json.dumps({"type": "measurement", "data": "not a dict"}))
     assert pm.values is None
 
 
-async def test_measurement_message_stores_values():
+async def test_measurement_message_stores_values() -> None:
     pm = _create_powermeter()
     ws = AsyncMock()
     await pm._on_text(
@@ -141,14 +143,14 @@ async def test_measurement_message_stores_values():
 # --- Category C: SSL context ---
 
 
-def test_ssl_context_verify_enabled():
+def test_ssl_context_verify_enabled() -> None:
     pm = _create_powermeter()
     ctx = pm._build_ssl_context()
     assert ctx.verify_mode == ssl.CERT_REQUIRED
     assert ctx.check_hostname is True
 
 
-def test_ssl_context_verify_disabled():
+def test_ssl_context_verify_disabled() -> None:
     pm = _create_powermeter(verify_ssl=False)
     ctx = pm._build_ssl_context()
     assert ctx.verify_mode == ssl.CERT_NONE
@@ -158,13 +160,13 @@ def test_ssl_context_verify_disabled():
 # --- Category D: get_powermeter_watts ---
 
 
-async def test_get_watts_no_data_raises():
+async def test_get_watts_no_data_raises() -> None:
     pm = _create_powermeter()
     with pytest.raises(ValueError):
         await pm.get_powermeter_watts()
 
 
-async def test_get_watts_returns_copy():
+async def test_get_watts_returns_copy() -> None:
     pm = _create_powermeter()
     pm._handle_measurement({"power_w": 100})
     result = await pm.get_powermeter_watts()
@@ -186,7 +188,7 @@ class _FakeClock:
         self.now += seconds
 
 
-async def test_get_watts_raises_when_measurement_is_stale():
+async def test_get_watts_raises_when_measurement_is_stale() -> None:
     """Staleness regression (matches the production lockup):  a
     push-based powermeter whose WebSocket has silently half-opened
     must surface an error to the caller instead of serving stale
@@ -209,7 +211,7 @@ async def test_get_watts_raises_when_measurement_is_stale():
         await pm.get_powermeter_watts()
 
 
-async def test_get_watts_staleness_disabled_when_max_age_is_zero():
+async def test_get_watts_staleness_disabled_when_max_age_is_zero() -> None:
     """A zero ``max_measurement_age_seconds`` disables the age check
     entirely — intended escape hatch for anyone with a dongle that
     genuinely updates very slowly.
@@ -221,7 +223,7 @@ async def test_get_watts_staleness_disabled_when_max_age_is_zero():
     assert await pm.get_powermeter_watts() == [100]
 
 
-async def test_fresh_measurement_clears_staleness():
+async def test_fresh_measurement_clears_staleness() -> None:
     """A new measurement after a long silence must reset the age clock."""
     clock = _FakeClock()
     pm = _create_powermeter(max_measurement_age_seconds=30.0, clock=clock)
@@ -238,13 +240,13 @@ async def test_fresh_measurement_clears_staleness():
 # --- Category D3: stream_online health hook ---------------------------------
 
 
-def test_stream_online_false_before_any_measurement():
+def test_stream_online_false_before_any_measurement() -> None:
     pm = _create_powermeter()
     # Not connected and nothing received yet.
     assert pm.stream_online() is False
 
 
-async def test_stream_online_true_when_connected_and_fresh():
+async def test_stream_online_true_when_connected_and_fresh() -> None:
     clock = _FakeClock()
     pm = _create_powermeter(max_measurement_age_seconds=30.0, clock=clock)
     pm._connected = True
@@ -258,7 +260,7 @@ async def test_stream_online_true_when_connected_and_fresh():
     assert pm.stream_online() is True
 
 
-async def test_stream_online_false_after_single_sample():
+async def test_stream_online_false_after_single_sample() -> None:
     """One sample alone is not a continuous stream — a broken dongle that
     replays a single cached value on reconnect must not read as online."""
     clock = _FakeClock()
@@ -268,7 +270,7 @@ async def test_stream_online_false_after_single_sample():
     assert pm.stream_online() is False
 
 
-async def test_stream_online_false_when_connected_but_stale():
+async def test_stream_online_false_when_connected_but_stale() -> None:
     clock = _FakeClock()
     pm = _create_powermeter(max_measurement_age_seconds=30.0, clock=clock)
     pm._connected = True
@@ -280,7 +282,7 @@ async def test_stream_online_false_when_connected_but_stale():
     assert pm.stream_online() is False
 
 
-async def test_stream_online_does_not_flap_on_reconnect_replay():
+async def test_stream_online_does_not_flap_on_reconnect_replay() -> None:
     """Regression for the flapping "Online" sensor (#427): a broken P1 dongle
     keeps accepting the WebSocket and replays one cached value on every
     watchdog-triggered reconnect.  Each lone sample resets the freshness
@@ -312,7 +314,7 @@ async def test_stream_online_does_not_flap_on_reconnect_replay():
     assert pm.stream_online() is True
 
 
-async def test_stream_online_stays_online_across_brief_reconnect():
+async def test_stream_online_stays_online_across_brief_reconnect() -> None:
     """A short blip (reconnect well within the freshness window) keeps the
     stream healthy — only gaps longer than max age break continuity."""
     clock = _FakeClock()
@@ -327,7 +329,7 @@ async def test_stream_online_stays_online_across_brief_reconnect():
     assert pm.stream_online() is True
 
 
-async def test_stream_online_healthy_when_staleness_disabled():
+async def test_stream_online_healthy_when_staleness_disabled() -> None:
     """With max_age=0 the staleness check is disabled, so any sample on a
     connected stream counts as online."""
     clock = _FakeClock()
@@ -339,7 +341,7 @@ async def test_stream_online_healthy_when_staleness_disabled():
     assert pm.stream_online() is True
 
 
-def test_stream_online_false_when_disconnected_even_if_fresh():
+def test_stream_online_false_when_disconnected_even_if_fresh() -> None:
     clock = _FakeClock()
     pm = _create_powermeter(max_measurement_age_seconds=30.0, clock=clock)
     pm._connected = False
@@ -350,23 +352,23 @@ def test_stream_online_false_when_disconnected_even_if_fresh():
 # --- Category E: wait_for_message ---
 
 
-async def test_wait_for_message_returns_when_data_available():
+async def test_wait_for_message_returns_when_data_available() -> None:
     pm = _create_powermeter()
     pm._handle_measurement({"power_w": 100})
     await pm.wait_for_message(timeout=1)
 
 
-async def test_wait_for_message_timeout():
+async def test_wait_for_message_timeout() -> None:
     pm = _create_powermeter()
     with pytest.raises(TimeoutError):
         await pm.wait_for_message(timeout=0)
 
 
-async def test_wait_for_next_message_blocks_until_new():
+async def test_wait_for_next_message_blocks_until_new() -> None:
     pm = _create_powermeter()
     pm._handle_measurement({"power_w": 100})
 
-    async def _push_later():
+    async def _push_later() -> None:
         await asyncio.sleep(0.05)
         pm._handle_measurement({"power_w": 200})
 
@@ -376,7 +378,7 @@ async def test_wait_for_next_message_blocks_until_new():
     assert await pm.get_powermeter_watts() == [200]
 
 
-async def test_wait_for_next_message_timeout():
+async def test_wait_for_next_message_timeout() -> None:
     pm = _create_powermeter()
     pm._handle_measurement({"power_w": 100})
     with pytest.raises(TimeoutError):
@@ -386,7 +388,7 @@ async def test_wait_for_next_message_timeout():
 # --- Category F: Lifecycle ---
 
 
-async def test_start_creates_session_and_task():
+async def test_start_creates_session_and_task() -> None:
     pm = _create_powermeter()
     with patch.object(pm, "_ws_loop", new_callable=AsyncMock) as mock_loop:
         mock_loop.return_value = None
@@ -396,7 +398,7 @@ async def test_start_creates_session_and_task():
         await pm.stop()
 
 
-async def test_start_is_idempotent():
+async def test_start_is_idempotent() -> None:
     pm = _create_powermeter()
     with patch.object(pm, "_ws_loop", new_callable=AsyncMock) as mock_loop:
         mock_loop.return_value = None
@@ -407,7 +409,7 @@ async def test_start_is_idempotent():
         await pm.stop()
 
 
-async def test_stop_closes_session():
+async def test_stop_closes_session() -> None:
     pm = _create_powermeter()
     with patch.object(pm, "_ws_loop", new_callable=AsyncMock) as mock_loop:
         mock_loop.return_value = None
@@ -417,12 +419,12 @@ async def test_stop_closes_session():
         assert pm._ws_task is None
 
 
-async def test_stop_without_start():
+async def test_stop_without_start() -> None:
     pm = _create_powermeter()
     await pm.stop()
 
 
-async def test_start_resets_stale_state():
+async def test_start_resets_stale_state() -> None:
     pm = _create_powermeter()
     # Simulate leftover state from a previous session
     pm.values = [999.0]
@@ -442,16 +444,23 @@ async def test_start_resets_stale_state():
 class _FakeWs:
     """A fake ws that yields given messages and records send_json calls."""
 
-    def __init__(self, messages):
+    def __init__(self, messages: list[Any]) -> None:
         self._messages = messages
         self.send_json = AsyncMock()
+        self.closed = False
 
-    async def __aiter__(self):
+    async def close(self) -> bool:
+        # The read watchdog force-closes the socket; without this the fake
+        # would raise where the real connection just goes away.
+        self.closed = True
+        return True
+
+    async def __aiter__(self) -> AsyncIterator[Any]:
         for msg in self._messages:
             yield msg
 
 
-async def test_full_auth_subscribe_measurement_flow():
+async def test_full_auth_subscribe_measurement_flow() -> None:
     pm = _create_powermeter()
 
     messages = [
@@ -470,7 +479,7 @@ async def test_full_auth_subscribe_measurement_flow():
     assert await pm.get_powermeter_watts() == [500]
 
 
-async def test_close_message_exits_iteration():
+async def test_close_message_exits_iteration() -> None:
     """A CLOSE frame ends the read, so nothing after it is acted on."""
     pm = _create_powermeter()
     ws = _FakeWs(
@@ -489,7 +498,7 @@ async def test_close_message_exits_iteration():
 # --- Category H: Reconnection ---
 
 
-def _mock_ws_context(ws):
+def _mock_ws_context(ws: Any) -> MagicMock:
     """Create an async context manager that yields *ws*."""
     ctx = MagicMock()
     ctx.__aenter__ = AsyncMock(return_value=ws)
@@ -497,11 +506,11 @@ def _mock_ws_context(ws):
     return ctx
 
 
-def _empty_ws():
+def _empty_ws() -> MagicMock:
     """Create a mock ws whose async iteration ends immediately."""
     ws = AsyncMock()
 
-    async def empty_aiter():
+    async def empty_aiter() -> AsyncIterator[Any]:
         return
         yield  # pragma: no cover — makes this an async generator
 
@@ -509,13 +518,13 @@ def _empty_ws():
     return ws
 
 
-async def test_ws_loop_reconnects_after_disconnect():
+async def test_ws_loop_reconnects_after_disconnect() -> None:
     pm = _create_powermeter()
     pm._session = MagicMock(spec=aiohttp.ClientSession)
 
     call_count = 0
 
-    def fake_ws_connect(*args, **kwargs):
+    def fake_ws_connect(*args: Any, **kwargs: Any) -> Any:
         nonlocal call_count
         call_count += 1
         if call_count >= 2:
@@ -542,7 +551,7 @@ async def test_ws_loop_passes_heartbeat_to_ws_connect() -> None:
     captured_kwargs: dict = {}
     call_count = 0
 
-    def fake_ws_connect(*args, **kwargs):
+    def fake_ws_connect(*args: Any, **kwargs: Any) -> None:
         nonlocal call_count
         call_count += 1
         captured_kwargs.update(kwargs)
@@ -565,7 +574,7 @@ async def test_ws_loop_passes_heartbeat_to_ws_connect() -> None:
     )
 
 
-async def test_measurement_watchdog_closes_ws_on_timeout():
+async def test_measurement_watchdog_closes_ws_on_timeout() -> None:
     """Regression: when the WebSocket is alive (no transport error)
     but the measurement stream has stalled, the watchdog must force
     a close so ``ws_loop`` drops through to the reconnect branch.
@@ -586,7 +595,7 @@ async def test_measurement_watchdog_closes_ws_on_timeout():
     ws.close.assert_called_once()
 
 
-async def test_measurement_watchdog_re_arms_after_each_measurement():
+async def test_measurement_watchdog_re_arms_after_each_measurement() -> None:
     """The watchdog clears its event on every iteration so a single
     early measurement cannot appease it forever — the timer must
     restart from zero every time.  This test drives the real event
@@ -598,7 +607,7 @@ async def test_measurement_watchdog_re_arms_after_each_measurement():
 
     iterations = 0
 
-    async def set_event_twice_then_wait():
+    async def set_event_twice_then_wait() -> None:
         nonlocal iterations
         while True:
             await asyncio.sleep(0.001)
@@ -621,13 +630,13 @@ async def test_measurement_watchdog_re_arms_after_each_measurement():
     ws.close.assert_called_once()
 
 
-async def test_ws_loop_reconnects_on_client_error():
+async def test_ws_loop_reconnects_on_client_error() -> None:
     pm = _create_powermeter()
     pm._session = MagicMock(spec=aiohttp.ClientSession)
 
     call_count = 0
 
-    def fake_ws_connect(*args, **kwargs):
+    def fake_ws_connect(*args: Any, **kwargs: Any) -> None:
         nonlocal call_count
         call_count += 1
         if call_count == 1:

--- a/src/astrameter/powermeter/iobroker.py
+++ b/src/astrameter/powermeter/iobroker.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from .http_client import HttpPowermeter
 
 
@@ -10,7 +12,7 @@ class IoBroker(HttpPowermeter):
         power_calculate: bool,
         power_input_alias: str,
         power_output_alias: str,
-    ):
+    ) -> None:
         self.ip = ip
         self.port = port
         self.current_power_alias = current_power_alias
@@ -18,7 +20,7 @@ class IoBroker(HttpPowermeter):
         self.power_input_alias = power_input_alias
         self.power_output_alias = power_output_alias
 
-    async def _get_bulk(self, aliases: str):
+    async def _get_bulk(self, aliases: str) -> Any:
         return await self.get_json(f"http://{self.ip}:{self.port}/getBulk/{aliases}")
 
     async def get_powermeter_watts(self) -> list[float]:

--- a/src/astrameter/powermeter/iobroker_test.py
+++ b/src/astrameter/powermeter/iobroker_test.py
@@ -1,9 +1,11 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from astrameter.powermeter import IoBroker
 
 
-async def test_get_powermeter_watts_no_calculate(mock_aiohttp_session):
+async def test_get_powermeter_watts_no_calculate(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     mock_aiohttp_session.set_json([{"id": "alias1", "val": 100}])
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         iobroker = IoBroker(
@@ -19,7 +21,9 @@ async def test_get_powermeter_watts_no_calculate(mock_aiohttp_session):
         await iobroker.stop()
 
 
-async def test_get_powermeter_watts_with_calculate(mock_aiohttp_session):
+async def test_get_powermeter_watts_with_calculate(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     mock_aiohttp_session.set_json(
         [
             {"id": "input_alias", "val": 300},

--- a/src/astrameter/powermeter/json_http.py
+++ b/src/astrameter/powermeter/json_http.py
@@ -28,7 +28,7 @@ class JsonHttpPowermeter(HttpPowermeter):
         username: str | None = None,
         password: str | None = None,
         headers: dict[str, str] | None = None,
-    ):
+    ) -> None:
         self.url = url
         self.json_paths = as_list(json_path)
         self.auth = (

--- a/src/astrameter/powermeter/json_http.py
+++ b/src/astrameter/powermeter/json_http.py
@@ -47,9 +47,9 @@ class JsonHttpPowermeter(HttpPowermeter):
         try:
             data = await self.get_json(self.url)
         except json.JSONDecodeError as e:
-            logger.error(f"Failed to decode JSON: {e}")
+            logger.error("JSON HTTP: failed to decode response: %s", e)
             raise ValueError(f"Invalid JSON response: {e}") from e
         except aiohttp.ClientError as e:
-            logger.error(f"HTTP request error: {e}")
+            logger.error("JSON HTTP: request failed: %s", e)
             raise ValueError(f"HTTP request error: {e}") from e
         return [extract_json_value(data, path) for path in self.json_paths]

--- a/src/astrameter/powermeter/json_http_test.py
+++ b/src/astrameter/powermeter/json_http_test.py
@@ -1,11 +1,11 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from aiohttp import BasicAuth, ClientTimeout
 
 from astrameter.powermeter import JsonHttpPowermeter
 
 
-async def test_single_phase(mock_aiohttp_session):
+async def test_single_phase(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_json({"power": 100})
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         meter = JsonHttpPowermeter("http://localhost", "$.power")
@@ -14,7 +14,7 @@ async def test_single_phase(mock_aiohttp_session):
         await meter.stop()
 
 
-async def test_three_phase(mock_aiohttp_session):
+async def test_three_phase(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_json({"p1": 100, "p2": 200, "p3": 300})
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         meter = JsonHttpPowermeter("http://localhost", ["$.p1", "$.p2", "$.p3"])
@@ -23,7 +23,9 @@ async def test_three_phase(mock_aiohttp_session):
         await meter.stop()
 
 
-async def test_strips_unit_suffix_via_jsonpath_ext(mock_aiohttp_session):
+async def test_strips_unit_suffix_via_jsonpath_ext(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     mock_aiohttp_session.set_json({"state": "331.74 W"})
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         meter = JsonHttpPowermeter(
@@ -34,7 +36,7 @@ async def test_strips_unit_suffix_via_jsonpath_ext(mock_aiohttp_session):
         await meter.stop()
 
 
-async def test_headers_and_auth(mock_aiohttp_session):
+async def test_headers_and_auth(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_json({"power": 50})
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session) as mock_cls:
         meter = JsonHttpPowermeter(

--- a/src/astrameter/powermeter/modbus.py
+++ b/src/astrameter/powermeter/modbus.py
@@ -32,16 +32,16 @@ REGISTER_TYPES = {
 class ModbusPowermeter(Powermeter):
     def __init__(
         self,
-        host,
-        port,
-        unit_id,
-        address,
-        count,
-        data_type="UINT16",
-        byte_order="BIG",
-        word_order="BIG",
-        register_type="HOLDING",
-        transport="TCP",
+        host: str,
+        port: int,
+        unit_id: int,
+        address: int,
+        count: int,
+        data_type: str = "UINT16",
+        byte_order: str = "BIG",
+        word_order: str = "BIG",
+        register_type: str = "HOLDING",
+        transport: str = "TCP",
     ) -> None:
         self.host = host
         self.port = port

--- a/src/astrameter/powermeter/modbus_test.py
+++ b/src/astrameter/powermeter/modbus_test.py
@@ -1,4 +1,5 @@
 import struct
+from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -16,7 +17,7 @@ from astrameter.powermeter import ModbusPowermeter
 # ---------------------------------------------------------------------------
 
 
-async def test_get_powermeter_watts():
+async def test_get_powermeter_watts() -> None:
     with patch("astrameter.powermeter.modbus.AsyncModbusTcpClient") as MockClient:
         mock_client = MockClient.return_value
         mock_client.connect = AsyncMock(return_value=True)
@@ -35,7 +36,7 @@ async def test_get_powermeter_watts():
         await pm.stop()
 
 
-async def test_float32():
+async def test_float32() -> None:
     with patch("astrameter.powermeter.modbus.AsyncModbusTcpClient") as MockClient:
         mock_client = MockClient.return_value
         mock_client.connect = AsyncMock(return_value=True)
@@ -62,7 +63,7 @@ async def test_float32():
         await pm.stop()
 
 
-async def test_input_registers():
+async def test_input_registers() -> None:
     with patch("astrameter.powermeter.modbus.AsyncModbusTcpClient") as MockClient:
         mock_client = MockClient.return_value
         mock_client.connect = AsyncMock(return_value=True)
@@ -80,7 +81,7 @@ async def test_input_registers():
         await pm.stop()
 
 
-async def test_start_creates_client_and_connects():
+async def test_start_creates_client_and_connects() -> None:
     pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
     assert pm.client is None
     with patch("astrameter.powermeter.modbus.AsyncModbusTcpClient") as MockClient:
@@ -92,13 +93,13 @@ async def test_start_creates_client_and_connects():
         assert pm.client is mock_instance
 
 
-async def test_read_before_start_raises():
+async def test_read_before_start_raises() -> None:
     pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1)
     with pytest.raises(RuntimeError, match="Client not started"):
         await pm.get_powermeter_watts()
 
 
-async def test_udp_transport_creates_udp_client():
+async def test_udp_transport_creates_udp_client() -> None:
     pm = ModbusPowermeter("192.168.1.14", 502, 1, 0, 1, transport="UDP")
     with patch("astrameter.powermeter.modbus.AsyncModbusUdpClient") as MockClient:
         mock_instance = MockClient.return_value
@@ -108,7 +109,7 @@ async def test_udp_transport_creates_udp_client():
         assert pm.client is mock_instance
 
 
-async def test_invalid_transport_raises():
+async def test_invalid_transport_raises() -> None:
     with pytest.raises(ValueError, match="Unsupported transport"):
         ModbusPowermeter("192.168.1.14", 502, 1, 0, 1, transport="BOGUS")
 
@@ -118,7 +119,7 @@ async def test_invalid_transport_raises():
 # ---------------------------------------------------------------------------
 
 
-async def test_stop_closes_and_resets():
+async def test_stop_closes_and_resets() -> None:
     with patch("astrameter.powermeter.modbus.AsyncModbusTcpClient") as MockClient:
         mock_instance = MockClient.return_value
         mock_instance.connect = AsyncMock(return_value=True)
@@ -131,7 +132,7 @@ async def test_stop_closes_and_resets():
         assert pm.client is None
 
 
-async def test_start_is_idempotent():
+async def test_start_is_idempotent() -> None:
     with patch("astrameter.powermeter.modbus.AsyncModbusTcpClient") as MockClient:
         mock_instance = MockClient.return_value
         mock_instance.connect = AsyncMock(return_value=True)
@@ -143,7 +144,7 @@ async def test_start_is_idempotent():
         mock_instance.connect.assert_awaited_once()
 
 
-async def test_read_error_raises():
+async def test_read_error_raises() -> None:
     with patch("astrameter.powermeter.modbus.AsyncModbusTcpClient") as MockClient:
         mock_client = MockClient.return_value
         mock_client.connect = AsyncMock(return_value=True)
@@ -172,7 +173,7 @@ def _float32_to_registers(value: float) -> list[int]:
 
 
 @pytest.fixture
-async def modbus_server():
+async def modbus_server() -> AsyncIterator[int]:
     """Start a local Modbus TCP server on an ephemeral port."""
     # Holding registers: address 0+ with some known values
     hr_values = [0] * 100
@@ -194,12 +195,13 @@ async def modbus_server():
     context = ModbusServerContext(slaves=store, single=True)
     server = ModbusTcpServer(context, address=("127.0.0.1", 0))
     await server.listen()
-    port = server.transport.sockets[0].getsockname()[1]  # type: ignore[union-attr]
+    sockets = server.transport.sockets  # type: ignore[attr-defined]
+    port = sockets[0].getsockname()[1]
     yield port
     await server.shutdown()
 
 
-async def test_e2e_uint16_holding(modbus_server: int):
+async def test_e2e_uint16_holding(modbus_server: int) -> None:
     pm = ModbusPowermeter("127.0.0.1", modbus_server, 1, 0, 1)
     await pm.start()
     try:
@@ -209,7 +211,7 @@ async def test_e2e_uint16_holding(modbus_server: int):
         await pm.stop()
 
 
-async def test_e2e_float32(modbus_server: int):
+async def test_e2e_float32(modbus_server: int) -> None:
     pm = ModbusPowermeter(
         "127.0.0.1",
         modbus_server,
@@ -228,7 +230,7 @@ async def test_e2e_float32(modbus_server: int):
         await pm.stop()
 
 
-async def test_e2e_input_registers(modbus_server: int):
+async def test_e2e_input_registers(modbus_server: int) -> None:
     pm = ModbusPowermeter(
         "127.0.0.1",
         modbus_server,
@@ -246,7 +248,7 @@ async def test_e2e_input_registers(modbus_server: int):
 
 
 @pytest.fixture
-async def modbus_udp_server():
+async def modbus_udp_server() -> AsyncIterator[int]:
     """Start a local Modbus UDP server on an ephemeral port."""
     hr_values = [0] * 100
     hr_values[0] = 500
@@ -264,7 +266,7 @@ async def modbus_udp_server():
     await server.shutdown()
 
 
-async def test_e2e_udp_uint16_holding(modbus_udp_server: int):
+async def test_e2e_udp_uint16_holding(modbus_udp_server: int) -> None:
     pm = ModbusPowermeter("127.0.0.1", modbus_udp_server, 1, 0, 1, transport="UDP")
     await pm.start()
     try:

--- a/src/astrameter/powermeter/mqtt.py
+++ b/src/astrameter/powermeter/mqtt.py
@@ -27,7 +27,7 @@ class MqttPowermeter(PushPowermeter):
         username: str | None = None,
         password: str | None = None,
         tls: bool = False,
-    ):
+    ) -> None:
         super().__init__()
         self.broker = broker
         self.port = port

--- a/src/astrameter/powermeter/mqtt.py
+++ b/src/astrameter/powermeter/mqtt.py
@@ -88,59 +88,65 @@ class MqttPowermeter(PushPowermeter):
         self._run_task = asyncio.create_task(self._run())
 
     async def _run(self) -> None:
-        unique_topics = list(self._topic_indices.keys())
         tls_context = ssl.create_default_context() if self.tls else None
         while True:
             try:
-                async with aiomqtt.Client(
-                    hostname=self.broker,
-                    port=self.port,
-                    username=self.username,
-                    password=self.password,
-                    tls_context=tls_context,
-                    keepalive=60,
-                ) as client:
-                    logger.info(
-                        "Connected to MQTT broker %s:%s", self.broker, self.port
-                    )
-                    for topic_name in unique_topics:
-                        await client.subscribe(topic_name)
-                    self._connected_event.set()
-                    async for message in client.messages:
-                        raw = message.payload
-                        payload = raw.decode() if isinstance(raw, bytes) else str(raw)
-                        topic_str = str(message.topic)
-                        indices = self._topic_indices.get(topic_str, [])
-                        if not indices:
-                            continue
-                        # Parse JSON once if any subscription for this topic needs it
-                        parsed_json = None
-                        for index in indices:
-                            _, json_path = self._subscriptions[index]
-                            try:
-                                if json_path:
-                                    if parsed_json is None:
-                                        parsed_json = json.loads(payload)
-                                    self.values[index] = extract_json_value(
-                                        parsed_json, json_path
-                                    )
-                                else:
-                                    self.values[index] = float(payload)
-                                self._message_event.set()
-                            except (json.JSONDecodeError, ValueError) as e:
-                                logger.error(
-                                    f"Failed to parse MQTT payload for index {index}: {e}"
-                                )
-            except aiomqtt.MqttError as e:
+                await self._serve_connection(tls_context)
+            except aiomqtt.MqttError as exc:
                 self._connected_event.clear()
                 # Reconnect loop — traceback would be noisy, keep it terse.
                 logger.warning(
                     "MQTT connection error: %s. Reconnecting in %ss...",
-                    e,
+                    exc,
                     RECONNECT_DELAY,
                     exc_info=False,
                 )
                 await asyncio.sleep(RECONNECT_DELAY)
+
+    async def _serve_connection(self, tls_context: ssl.SSLContext | None) -> None:
+        """Subscribe and store every message, until the connection drops."""
+        async with aiomqtt.Client(
+            hostname=self.broker,
+            port=self.port,
+            username=self.username,
+            password=self.password,
+            tls_context=tls_context,
+            keepalive=60,
+        ) as client:
+            logger.info("Connected to MQTT broker %s:%s", self.broker, self.port)
+            for topic_name in self._topic_indices:
+                await client.subscribe(topic_name)
+            self._connected_event.set()
+            async for message in client.messages:
+                raw = message.payload
+                payload = raw.decode() if isinstance(raw, bytes) else str(raw)
+                self._store(str(message.topic), payload)
+
+    def _store(self, topic: str, payload: str) -> None:
+        """Fill every subscription slot *topic* feeds from one payload.
+
+        Several subscriptions can read different JSON paths out of the same
+        topic, so the document is parsed once for all of them.
+        """
+        document: object = None
+        for index in self._topic_indices.get(topic, ()):
+            _, json_path = self._subscriptions[index]
+            try:
+                if json_path:
+                    if document is None:
+                        document = json.loads(payload)
+                    self.values[index] = extract_json_value(document, json_path)
+                else:
+                    self.values[index] = float(payload)
+            except (json.JSONDecodeError, ValueError) as exc:
+                logger.error(
+                    "Failed to parse MQTT payload on %s for index %d: %s",
+                    topic,
+                    index,
+                    exc,
+                )
+                continue
+            self._message_event.set()
 
     async def stop(self) -> None:
         if self._run_task:

--- a/src/astrameter/powermeter/mqtt.py
+++ b/src/astrameter/powermeter/mqtt.py
@@ -100,7 +100,9 @@ class MqttPowermeter(PushPowermeter):
                     tls_context=tls_context,
                     keepalive=60,
                 ) as client:
-                    logger.info(f"Connected to MQTT broker {self.broker}:{self.port}")
+                    logger.info(
+                        "Connected to MQTT broker %s:%s", self.broker, self.port
+                    )
                     for topic_name in unique_topics:
                         await client.subscribe(topic_name)
                     self._connected_event.set()

--- a/src/astrameter/powermeter/mqtt_test.py
+++ b/src/astrameter/powermeter/mqtt_test.py
@@ -12,23 +12,23 @@ from .mqtt import MqttPowermeter, extract_json_value
 # ---------------------------------------------------------------------------
 
 
-def test_extract_curr_w():
+def test_extract_curr_w() -> None:
     data = {"SML": {"curr_w": 381}}
     assert extract_json_value(data, "$.SML.curr_w") == 381
 
 
-def test_extract_nonexistent_path():
+def test_extract_nonexistent_path() -> None:
     data = {"SML": {"curr_w": 381}}
     with pytest.raises(ValueError):
         extract_json_value(data, "$.SML.nonexistent")
 
 
-def test_extract_float_value():
+def test_extract_float_value() -> None:
     data = {"SML": {"curr_w": 381.75}}
     assert extract_json_value(data, "$.SML.curr_w") == 381.75
 
 
-def test_extract_from_array():
+def test_extract_from_array() -> None:
     data = {
         "SML": {
             "measurements": [{"curr_w": 100.5}, {"curr_w": 200.75}, {"curr_w": 300}]
@@ -62,34 +62,34 @@ def _make_pm(
     )
 
 
-async def test_get_powermeter_watts_returns_value():
+async def test_get_powermeter_watts_returns_value() -> None:
     pm = _make_pm()
     pm.value = 42.0
     assert await pm.get_powermeter_watts() == [42.0]
 
 
-async def test_get_powermeter_watts_raises_when_no_value():
+async def test_get_powermeter_watts_raises_when_no_value() -> None:
     pm = _make_pm()
     with pytest.raises(ValueError, match="No value received"):
         await pm.get_powermeter_watts()
 
 
-async def test_wait_for_message_returns_immediately():
+async def test_wait_for_message_returns_immediately() -> None:
     pm = _make_pm()
     pm.value = 1.0
     await pm.wait_for_message(timeout=0.1)
 
 
-async def test_wait_for_message_times_out():
+async def test_wait_for_message_times_out() -> None:
     pm = _make_pm()
     with pytest.raises(TimeoutError, match="Timeout waiting"):
         await pm.wait_for_message(timeout=0.1)
 
 
-async def test_wait_for_message_wakes_on_event():
+async def test_wait_for_message_wakes_on_event() -> None:
     pm = _make_pm()
 
-    async def _set_later():
+    async def _set_later() -> None:
         await asyncio.sleep(0.05)
         pm.value = 99.0
         pm._message_event.set()
@@ -100,12 +100,12 @@ async def test_wait_for_message_wakes_on_event():
     assert pm.value == 99.0
 
 
-async def test_wait_for_next_message_blocks_until_new():
+async def test_wait_for_next_message_blocks_until_new() -> None:
     pm = _make_pm()
     pm.value = 1.0
     pm._message_event.set()
 
-    async def _set_later():
+    async def _set_later() -> None:
         await asyncio.sleep(0.05)
         pm.value = 42.0
         pm._message_event.set()
@@ -118,7 +118,7 @@ async def test_wait_for_next_message_blocks_until_new():
     assert pm.value == 42.0
 
 
-async def test_wait_for_next_message_times_out():
+async def test_wait_for_next_message_times_out() -> None:
     pm = _make_pm()
     pm.value = 1.0
     pm._message_event.set()
@@ -126,7 +126,7 @@ async def test_wait_for_next_message_times_out():
         await pm.wait_for_next_message(timeout=0.1)
 
 
-async def test_wait_for_next_message_multi_topic_cold_start():
+async def test_wait_for_next_message_multi_topic_cold_start() -> None:
     pm = _make_pm(topic=["t1", "t2"])
     # Cold start: no values set, event not set. Only one of the two topics
     # publishes during the wait window — wait_for_next_message must return
@@ -134,7 +134,7 @@ async def test_wait_for_next_message_multi_topic_cold_start():
     # refreshed; the multi-phase consistency check belongs to
     # ``wait_for_message`` / ``get_powermeter_watts``).
 
-    async def _publish_one():
+    async def _publish_one() -> None:
         await asyncio.sleep(0.05)
         pm.values[0] = 100.0
         pm._message_event.set()
@@ -150,57 +150,57 @@ async def test_wait_for_next_message_multi_topic_cold_start():
 # ---------------------------------------------------------------------------
 
 
-def test_single_topic_backward_compat():
+def test_single_topic_backward_compat() -> None:
     pm = _make_pm(topic="t1")
     assert len(pm._subscriptions) == 1
     assert pm._subscriptions[0] == ("t1", None)
     assert len(pm.values) == 1
 
 
-def test_single_topic_with_json_path_backward_compat():
+def test_single_topic_with_json_path_backward_compat() -> None:
     pm = _make_pm(topic="t1", json_path="$.power")
     assert pm._subscriptions == [("t1", "$.power")]
 
 
-def test_multi_topic_constructor():
+def test_multi_topic_constructor() -> None:
     pm = _make_pm(topic=["t1", "t2", "t3"])
     assert len(pm._subscriptions) == 3
     assert len(pm.values) == 3
     assert pm._subscriptions == [("t1", None), ("t2", None), ("t3", None)]
 
 
-def test_single_topic_multi_json_paths():
+def test_single_topic_multi_json_paths() -> None:
     pm = _make_pm(topic="t", json_path=["$.a", "$.b", "$.c"])
     assert len(pm._subscriptions) == 3
     assert pm._subscriptions == [("t", "$.a"), ("t", "$.b"), ("t", "$.c")]
 
 
-def test_multi_topic_single_json_path():
+def test_multi_topic_single_json_path() -> None:
     pm = _make_pm(topic=["t1", "t2"], json_path="$.p")
     assert pm._subscriptions == [("t1", "$.p"), ("t2", "$.p")]
 
 
-def test_multi_topic_multi_json_path_matching():
+def test_multi_topic_multi_json_path_matching() -> None:
     pm = _make_pm(topic=["t1", "t2"], json_path=["$.a", "$.b"])
     assert pm._subscriptions == [("t1", "$.a"), ("t2", "$.b")]
 
 
-def test_empty_topic_list_raises():
+def test_empty_topic_list_raises() -> None:
     with pytest.raises(ValueError, match="At least one MQTT topic"):
         _make_pm(topic=[])
 
 
-def test_multi_topic_multi_json_path_length_mismatch():
+def test_multi_topic_multi_json_path_length_mismatch() -> None:
     with pytest.raises(ValueError, match="must match"):
         _make_pm(topic=["t1", "t2"], json_path=["$.a", "$.b", "$.c"])
 
 
-def test_topic_indices_mapping():
+def test_topic_indices_mapping() -> None:
     pm = _make_pm(topic="t", json_path=["$.a", "$.b"])
     assert pm._topic_indices == {"t": [0, 1]}
 
 
-def test_multi_topic_indices_mapping():
+def test_multi_topic_indices_mapping() -> None:
     pm = _make_pm(topic=["t1", "t2", "t3"])
     assert pm._topic_indices == {"t1": [0], "t2": [1], "t3": [2]}
 
@@ -210,14 +210,14 @@ def test_multi_topic_indices_mapping():
 # ---------------------------------------------------------------------------
 
 
-async def test_get_watts_raises_when_partial_values():
+async def test_get_watts_raises_when_partial_values() -> None:
     pm = _make_pm(topic=["t1", "t2"])
     pm.values[0] = 100.0
     with pytest.raises(ValueError, match="No value received"):
         await pm.get_powermeter_watts()
 
 
-async def test_get_watts_returns_all_phases():
+async def test_get_watts_returns_all_phases() -> None:
     pm = _make_pm(topic=["t1", "t2", "t3"])
     pm.values[0] = 100.0
     pm.values[1] = 200.0
@@ -225,10 +225,10 @@ async def test_get_watts_returns_all_phases():
     assert await pm.get_powermeter_watts() == [100.0, 200.0, 300.0]
 
 
-async def test_wait_for_message_returns_when_all_set():
+async def test_wait_for_message_returns_when_all_set() -> None:
     pm = _make_pm(topic=["t1", "t2"])
 
-    async def _set_later():
+    async def _set_later() -> None:
         await asyncio.sleep(0.05)
         pm.values[0] = 10.0
         pm._message_event.set()
@@ -242,7 +242,7 @@ async def test_wait_for_message_returns_when_all_set():
     assert await pm.get_powermeter_watts() == [10.0, 20.0]
 
 
-async def test_wait_for_message_times_out_with_partial():
+async def test_wait_for_message_times_out_with_partial() -> None:
     pm = _make_pm(topic=["t1", "t2"])
     pm.values[0] = 10.0
     # values[1] is still None
@@ -250,7 +250,7 @@ async def test_wait_for_message_times_out_with_partial():
         await pm.wait_for_message(timeout=0.2)
 
 
-async def test_value_property_backward_compat():
+async def test_value_property_backward_compat() -> None:
     pm = _make_pm()
     assert pm.value is None
     pm.value = 42.0
@@ -261,33 +261,33 @@ async def test_value_property_backward_compat():
 # --- stream_online health hook (no broker needed) ---
 
 
-def test_stream_online_false_before_connect():
+def test_stream_online_false_before_connect() -> None:
     pm = _make_pm()
     # Not connected and no value yet.
     assert pm.stream_online() is False
 
 
-def test_stream_online_false_when_connected_but_no_value():
+def test_stream_online_false_when_connected_but_no_value() -> None:
     pm = _make_pm()
     pm._connected_event.set()
     assert pm.stream_online() is False
 
 
-def test_stream_online_true_when_connected_and_value():
+def test_stream_online_true_when_connected_and_value() -> None:
     pm = _make_pm()
     pm._connected_event.set()
     pm.value = 42.0
     assert pm.stream_online() is True
 
 
-def test_stream_online_false_when_disconnected_even_with_value():
+def test_stream_online_false_when_disconnected_even_with_value() -> None:
     pm = _make_pm()
     pm.value = 42.0
     # _connected_event left cleared -> offline despite a cached value.
     assert pm.stream_online() is False
 
 
-def test_stream_online_multi_topic_stays_true_when_value_unchanged():
+def test_stream_online_multi_topic_stays_true_when_value_unchanged() -> None:
     pm = _make_pm(topic=["a", "b", "c"])
     pm._connected_event.set()
     pm.values[0] = 100.0
@@ -298,7 +298,7 @@ def test_stream_online_multi_topic_stays_true_when_value_unchanged():
     assert pm.stream_online() is True
 
 
-def test_stream_online_false_when_a_topic_never_received():
+def test_stream_online_false_when_a_topic_never_received() -> None:
     pm = _make_pm(topic=["a", "b", "c"])
     pm._connected_event.set()
     pm.values[0] = 100.0
@@ -313,7 +313,7 @@ def test_stream_online_false_when_a_topic_never_received():
 
 
 @needs_mosquitto
-async def test_receives_plain_value(mqtt_broker):
+async def test_receives_plain_value(mqtt_broker: int) -> None:
     import aiomqtt
 
     port = mqtt_broker
@@ -331,7 +331,7 @@ async def test_receives_plain_value(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_receives_json_value(mqtt_broker):
+async def test_receives_json_value(mqtt_broker: int) -> None:
     import aiomqtt
 
     port = mqtt_broker
@@ -349,7 +349,7 @@ async def test_receives_json_value(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_wait_for_message_timeout_with_no_publish(mqtt_broker):
+async def test_wait_for_message_timeout_with_no_publish(mqtt_broker: int) -> None:
     port = mqtt_broker
     topic = "test/timeout"
     pm = MqttPowermeter(broker="127.0.0.1", port=port, topic=topic)
@@ -363,7 +363,7 @@ async def test_wait_for_message_timeout_with_no_publish(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_receives_multiple_messages_returns_latest(mqtt_broker):
+async def test_receives_multiple_messages_returns_latest(mqtt_broker: int) -> None:
     import aiomqtt
 
     port = mqtt_broker
@@ -383,7 +383,7 @@ async def test_receives_multiple_messages_returns_latest(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_receives_multi_topic_values(mqtt_broker):
+async def test_receives_multi_topic_values(mqtt_broker: int) -> None:
     import aiomqtt
 
     port = mqtt_broker
@@ -403,7 +403,7 @@ async def test_receives_multi_topic_values(mqtt_broker):
 
 
 @needs_mosquitto
-async def test_receives_single_topic_multi_json_paths(mqtt_broker):
+async def test_receives_single_topic_multi_json_paths(mqtt_broker: int) -> None:
     import aiomqtt
 
     port = mqtt_broker

--- a/src/astrameter/powermeter/refoss.py
+++ b/src/astrameter/powermeter/refoss.py
@@ -49,7 +49,7 @@ class Refoss(HttpPowermeter):
     trusted local network; do not expose the meter API beyond that LAN.
     """
 
-    def __init__(self, ip: str, channels: list[int]):
+    def __init__(self, ip: str, channels: list[int]) -> None:
         """Create a meter for ``ip`` reading the given CT ``channels`` (1-based)."""
         ip = ip.strip()
         if not ip:

--- a/src/astrameter/powermeter/refoss_test.py
+++ b/src/astrameter/powermeter/refoss_test.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -6,7 +7,7 @@ from astrameter.powermeter import Refoss
 from astrameter.powermeter.refoss import parse_channels
 
 
-def _status_response(channels: dict[int, float]):
+def _status_response(channels: dict[int, float]) -> dict[str, Any]:
     """Build an Em.Status.Get-shaped payload for the given channel powers."""
     return {
         "status": [
@@ -22,7 +23,7 @@ def _status_response(channels: dict[int, float]):
     }
 
 
-def test_parse_channels():
+def test_parse_channels() -> None:
     """Accept positive ids and reject empty, non-integer, and zero values."""
     assert parse_channels("1") == [1]
     assert parse_channels("1,2,3") == [1, 2, 3]
@@ -48,7 +49,9 @@ def test_parse_channels():
 
 
 @pytest.mark.asyncio
-async def test_get_powermeter_watts_single_channel(mock_aiohttp_session):
+async def test_get_powermeter_watts_single_channel(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     """Return only the configured channel's signed power."""
     mock_aiohttp_session.set_json(_status_response({1: 421.5, 2: 10.0}))
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
@@ -59,7 +62,9 @@ async def test_get_powermeter_watts_single_channel(mock_aiohttp_session):
 
 
 @pytest.mark.asyncio
-async def test_get_powermeter_watts_three_phase(mock_aiohttp_session):
+async def test_get_powermeter_watts_three_phase(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     """Return watts in CHANNELS order even when the API lists channels out of order."""
     # Deliberately out of channel-id order so we catch implementations that
     # return response order instead of configured CHANNELS order.
@@ -74,7 +79,9 @@ async def test_get_powermeter_watts_three_phase(mock_aiohttp_session):
 
 
 @pytest.mark.asyncio
-async def test_get_powermeter_watts_missing_channel(mock_aiohttp_session):
+async def test_get_powermeter_watts_missing_channel(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     """Raise when a configured channel id is absent from the device response."""
     mock_aiohttp_session.set_json(_status_response({1: 10.0}))
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
@@ -86,7 +93,9 @@ async def test_get_powermeter_watts_missing_channel(mock_aiohttp_session):
 
 
 @pytest.mark.asyncio
-async def test_get_powermeter_watts_missing_power_field(mock_aiohttp_session):
+async def test_get_powermeter_watts_missing_power_field(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     """Raise when a status entry has an id but no power field."""
     mock_aiohttp_session.set_json(
         {"status": [{"id": 1, "current": 0.0, "voltage": 230.0}]}
@@ -100,7 +109,9 @@ async def test_get_powermeter_watts_missing_power_field(mock_aiohttp_session):
 
 
 @pytest.mark.asyncio
-async def test_get_powermeter_watts_rejects_non_object_json(mock_aiohttp_session):
+async def test_get_powermeter_watts_rejects_non_object_json(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     """Raise when the JSON root is not an object."""
     mock_aiohttp_session.set_json([{"id": 1, "power": 10.0}])
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
@@ -112,7 +123,7 @@ async def test_get_powermeter_watts_rejects_non_object_json(mock_aiohttp_session
 
 
 @pytest.mark.asyncio
-async def test_get_json_rejects_redirect(mock_aiohttp_session):
+async def test_get_json_rejects_redirect(mock_aiohttp_session: MagicMock) -> None:
     """Do not follow or accept HTTP redirects when polling the meter."""
     mock_resp = mock_aiohttp_session.get.return_value
     # __aenter__ returns the response mock used inside the async with block.
@@ -130,7 +141,9 @@ async def test_get_json_rejects_redirect(mock_aiohttp_session):
 
 
 @pytest.mark.asyncio
-async def test_get_powermeter_watts_rejects_non_finite_power(mock_aiohttp_session):
+async def test_get_powermeter_watts_rejects_non_finite_power(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     """Raise when power is NaN or ±infinity."""
     for bad in ("NaN", "inf", "-inf"):
         mock_aiohttp_session.set_json({"status": [{"id": 1, "power": bad}]})
@@ -142,7 +155,7 @@ async def test_get_powermeter_watts_rejects_non_finite_power(mock_aiohttp_sessio
             await meter.stop()
 
 
-def test_requires_ip():
+def test_requires_ip() -> None:
     """Reject blank IP values before opening a session."""
     with pytest.raises(ValueError, match="IP"):
         Refoss("", [1])
@@ -150,6 +163,6 @@ def test_requires_ip():
         Refoss("   ", [1])
 
 
-def test_strips_ip():
+def test_strips_ip() -> None:
     """Strip surrounding whitespace from the configured IP."""
     assert Refoss("  192.168.1.150  ", [1]).ip == "192.168.1.150"

--- a/src/astrameter/powermeter/script.py
+++ b/src/astrameter/powermeter/script.py
@@ -4,7 +4,7 @@ from .base import Powermeter
 
 
 class Script(Powermeter):
-    def __init__(self, command: str):
+    def __init__(self, command: str) -> None:
         self.script = command
 
     async def get_powermeter_watts(self) -> list[float]:

--- a/src/astrameter/powermeter/script_test.py
+++ b/src/astrameter/powermeter/script_test.py
@@ -1,11 +1,11 @@
 from .script import Script
 
 
-async def test_script_get_powermeter_watts_integer():
+async def test_script_get_powermeter_watts_integer() -> None:
     script = Script('echo "456"')
     assert await script.get_powermeter_watts() == [456]
 
 
-async def test_script_get_powermeter_watts_float():
+async def test_script_get_powermeter_watts_float() -> None:
     script = Script('echo "456.7"')
     assert await script.get_powermeter_watts() == [456.7]

--- a/src/astrameter/powermeter/shelly.py
+++ b/src/astrameter/powermeter/shelly.py
@@ -10,7 +10,7 @@ class Shelly(HttpPowermeter):
     # each subclass only ever talks to one of the two.
     _rpc = False
 
-    def __init__(self, ip: str, user: str, password: str, emeterindex: str):
+    def __init__(self, ip: str, user: str, password: str, emeterindex: str) -> None:
         self.ip = ip
         self.user = user
         self.password = password

--- a/src/astrameter/powermeter/shrdzm.py
+++ b/src/astrameter/powermeter/shrdzm.py
@@ -2,7 +2,7 @@ from .http_client import HttpPowermeter
 
 
 class Shrdzm(HttpPowermeter):
-    def __init__(self, ip: str, user: str, password: str):
+    def __init__(self, ip: str, user: str, password: str) -> None:
         self.ip = ip
         self.user = user
         self.password = password

--- a/src/astrameter/powermeter/shrdzm_test.py
+++ b/src/astrameter/powermeter/shrdzm_test.py
@@ -1,9 +1,9 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from astrameter.powermeter import Shrdzm
 
 
-async def test_shrdzm_get_powermeter_watts(mock_aiohttp_session):
+async def test_shrdzm_get_powermeter_watts(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_json({"1.7.0": 5000, "2.7.0": 2000})
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         shrdzm = Shrdzm("192.168.1.5", "user", "pass")

--- a/src/astrameter/powermeter/sma_energy_meter.py
+++ b/src/astrameter/powermeter/sma_energy_meter.py
@@ -66,14 +66,14 @@ class _SmaProtocol(asyncio.DatagramProtocol):
         try:
             self.meter._handle_packet(data)
         except Exception as e:
-            logger.debug(f"SMA Energy Meter: dropping invalid packet: {e}")
+            logger.debug("SMA Energy Meter: dropping invalid packet: %s", e)
 
     def error_received(self, exc: Exception) -> None:
-        logger.debug(f"SMA Energy Meter: OS error: {exc}")
+        logger.debug("SMA Energy Meter: OS error: %s", exc)
 
     def connection_lost(self, exc: Exception | None) -> None:
         if exc:
-            logger.warning(f"SMA Energy Meter: connection lost: {exc}")
+            logger.warning("SMA Energy Meter: connection lost: %s", exc)
 
 
 class SmaEnergyMeter(PushPowermeter):

--- a/src/astrameter/powermeter/sma_energy_meter.py
+++ b/src/astrameter/powermeter/sma_energy_meter.py
@@ -59,7 +59,7 @@ def _get_channel_data_length(identifier: int) -> int:
 
 
 class _SmaProtocol(asyncio.DatagramProtocol):
-    def __init__(self, meter: "SmaEnergyMeter"):
+    def __init__(self, meter: "SmaEnergyMeter") -> None:
         self.meter = meter
 
     def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
@@ -81,10 +81,10 @@ class SmaEnergyMeter(PushPowermeter):
 
     def __init__(
         self,
-        multicast_group=DEFAULT_MULTICAST_GROUP,
-        port=DEFAULT_PORT,
-        serial_number=0,
-        interface="",
+        multicast_group: str = DEFAULT_MULTICAST_GROUP,
+        port: int = DEFAULT_PORT,
+        serial_number: int = 0,
+        interface: str = "",
         *,
         max_telegram_age_seconds: float = DEFAULT_MAX_TELEGRAM_AGE_SECONDS,
         clock: Callable[[], float] | None = None,
@@ -137,7 +137,7 @@ class SmaEnergyMeter(PushPowermeter):
             self._transport.close()
             self._transport = None
 
-    def _handle_packet(self, data):
+    def _handle_packet(self, data: bytes) -> None:
         if len(data) < 28:
             return
 
@@ -178,7 +178,7 @@ class SmaEnergyMeter(PushPowermeter):
 
         self._parse_channels(data)
 
-    def _parse_channels(self, data):
+    def _parse_channels(self, data: bytes) -> None:
         raw = {}
         pos = 28
         data_len = len(data)

--- a/src/astrameter/powermeter/sma_energy_meter.py
+++ b/src/astrameter/powermeter/sma_energy_meter.py
@@ -129,7 +129,7 @@ class SmaEnergyMeter(PushPowermeter):
             raise
         self._transport = transport
         logger.info(
-            f"SMA Energy Meter: listening on {self.multicast_group}:{self.port}"
+            "SMA Energy Meter: listening on %s:%s", self.multicast_group, self.port
         )
 
     async def stop(self) -> None:
@@ -169,8 +169,9 @@ class SmaEnergyMeter(PushPowermeter):
                     return
                 self._detected_serial = serial
                 logger.info(
-                    f"SMA Energy Meter: auto-detected {device_name} "
-                    f"with serial {serial}"
+                    "SMA Energy Meter: auto-detected %s with serial %s",
+                    device_name,
+                    serial,
                 )
             elif serial != self._detected_serial:
                 return

--- a/src/astrameter/powermeter/sma_energy_meter_test.py
+++ b/src/astrameter/powermeter/sma_energy_meter_test.py
@@ -1,6 +1,7 @@
 import asyncio
 import struct
 import unittest
+from typing import Any
 
 import pytest
 
@@ -25,7 +26,9 @@ CHANNEL_TOTAL_ENERGY_PLUS = 0x00010800
 CHANNEL_L1_ENERGY_PLUS = 0x00150800
 
 
-def _build_header(susy_id=349, serial=3000012345, protocol_id=0x6069):
+def _build_header(
+    susy_id: int = 349, serial: int = 3000012345, protocol_id: int = 0x6069
+) -> bytes:
     """Build a valid SMA Speedwire header (28 bytes)."""
     header = bytearray(28)
     # Magic "SMA\0"
@@ -49,7 +52,7 @@ def _build_header(susy_id=349, serial=3000012345, protocol_id=0x6069):
     return bytes(header)
 
 
-def _build_channel(identifier, value, length=4):
+def _build_channel(identifier: int, value: int, length: int = 4) -> bytes:
     """Build an OBIS channel entry (4-byte identifier + value)."""
     data = struct.pack(">I", identifier)
     if length == 4:
@@ -59,11 +62,16 @@ def _build_channel(identifier, value, length=4):
     return data
 
 
-def _build_end_marker():
+def _build_end_marker() -> bytes:
     return struct.pack(">I", CHANNEL_END)
 
 
-def _build_packet(channels, susy_id=349, serial=3000012345, protocol_id=0x6069):
+def _build_packet(
+    channels: list[bytes],
+    susy_id: int = 349,
+    serial: int = 3000012345,
+    protocol_id: int = 0x6069,
+) -> bytes:
     """Build a complete SMA Speedwire packet."""
     header = _build_header(susy_id=susy_id, serial=serial, protocol_id=protocol_id)
     body = b""
@@ -73,27 +81,27 @@ def _build_packet(channels, susy_id=349, serial=3000012345, protocol_id=0x6069):
     return header + body
 
 
-def _create_meter(**kwargs):
+def _create_meter(**kwargs: Any) -> SmaEnergyMeter:
     """Create an SmaEnergyMeter without starting the listener."""
     return SmaEnergyMeter(**kwargs)
 
 
 class TestGetChannelDataLength(unittest.TestCase):
-    def test_type_04_returns_4(self):
+    def test_type_04_returns_4(self) -> None:
         self.assertEqual(_get_channel_data_length(0x00010400), 4)
 
-    def test_type_08_returns_8(self):
+    def test_type_08_returns_8(self) -> None:
         self.assertEqual(_get_channel_data_length(0x00010800), 8)
 
-    def test_end_marker_returns_0(self):
+    def test_end_marker_returns_0(self) -> None:
         self.assertEqual(_get_channel_data_length(CHANNEL_END), 0)
 
-    def test_software_version_returns_4(self):
+    def test_software_version_returns_4(self) -> None:
         self.assertEqual(_get_channel_data_length(CHANNEL_SOFTWARE_VERSION), 4)
 
 
 class TestHandlePacket(unittest.TestCase):
-    def test_three_phase_consumption(self):
+    def test_three_phase_consumption(self) -> None:
         meter = _create_meter()
         packet = _build_packet(
             [
@@ -108,7 +116,7 @@ class TestHandlePacket(unittest.TestCase):
         meter._handle_packet(packet)
         self.assertEqual(meter.values, [100.0, 200.0, 300.0])
 
-    def test_three_phase_net_power(self):
+    def test_three_phase_net_power(self) -> None:
         meter = _create_meter()
         packet = _build_packet(
             [
@@ -126,7 +134,7 @@ class TestHandlePacket(unittest.TestCase):
         self.assertAlmostEqual(meter.values[1], -200.0)
         self.assertAlmostEqual(meter.values[2], 0.0)
 
-    def test_total_only_fallback(self):
+    def test_total_only_fallback(self) -> None:
         meter = _create_meter()
         packet = _build_packet(
             [
@@ -137,7 +145,7 @@ class TestHandlePacket(unittest.TestCase):
         meter._handle_packet(packet)
         self.assertEqual(meter.values, [500.0])
 
-    def test_total_net_production(self):
+    def test_total_net_production(self) -> None:
         meter = _create_meter()
         packet = _build_packet(
             [
@@ -149,13 +157,13 @@ class TestHandlePacket(unittest.TestCase):
         assert meter.values is not None
         self.assertAlmostEqual(meter.values[0], -290.0)
 
-    def test_invalid_magic_ignored(self):
+    def test_invalid_magic_ignored(self) -> None:
         meter = _create_meter()
         packet = b"XYZ\x00" + b"\x00" * 24
         meter._handle_packet(packet)
         self.assertIsNone(meter.values)
 
-    def test_invalid_tag42_ignored(self):
+    def test_invalid_tag42_ignored(self) -> None:
         meter = _create_meter()
         packet = bytearray(_build_header())
         packet[5] = 0x00
@@ -164,7 +172,7 @@ class TestHandlePacket(unittest.TestCase):
         meter._handle_packet(bytes(packet))
         self.assertIsNone(meter.values)
 
-    def test_wrong_protocol_id_ignored(self):
+    def test_wrong_protocol_id_ignored(self) -> None:
         meter = _create_meter()
         packet = _build_packet(
             [_build_channel(CHANNEL_TOTAL_POWER_PLUS, 1000)],
@@ -173,12 +181,12 @@ class TestHandlePacket(unittest.TestCase):
         meter._handle_packet(packet)
         self.assertIsNone(meter.values)
 
-    def test_too_short_packet_ignored(self):
+    def test_too_short_packet_ignored(self) -> None:
         meter = _create_meter()
         meter._handle_packet(b"SMA\x00" + b"\x00" * 10)
         self.assertIsNone(meter.values)
 
-    def test_serial_filter_match(self):
+    def test_serial_filter_match(self) -> None:
         meter = _create_meter(serial_number=12345)
         packet = _build_packet(
             [_build_channel(CHANNEL_TOTAL_POWER_PLUS, 1000)],
@@ -187,7 +195,7 @@ class TestHandlePacket(unittest.TestCase):
         meter._handle_packet(packet)
         self.assertEqual(meter.values, [100.0])
 
-    def test_serial_filter_mismatch(self):
+    def test_serial_filter_mismatch(self) -> None:
         meter = _create_meter(serial_number=12345)
         packet = _build_packet(
             [_build_channel(CHANNEL_TOTAL_POWER_PLUS, 1000)],
@@ -196,7 +204,7 @@ class TestHandlePacket(unittest.TestCase):
         meter._handle_packet(packet)
         self.assertIsNone(meter.values)
 
-    def test_auto_detect_locks_serial(self):
+    def test_auto_detect_locks_serial(self) -> None:
         meter = _create_meter()
         # First packet from meter with serial 11111
         packet1 = _build_packet(
@@ -218,7 +226,7 @@ class TestHandlePacket(unittest.TestCase):
         # Should still have old value
         self.assertEqual(meter.values, [100.0])
 
-    def test_auto_detect_rejects_unknown_susy_id(self):
+    def test_auto_detect_rejects_unknown_susy_id(self) -> None:
         meter = _create_meter()
         packet = _build_packet(
             [_build_channel(CHANNEL_TOTAL_POWER_PLUS, 1000)],
@@ -229,7 +237,7 @@ class TestHandlePacket(unittest.TestCase):
         self.assertIsNone(meter._detected_serial)
         self.assertIsNone(meter.values)
 
-    def test_energy_channels_skipped_correctly(self):
+    def test_energy_channels_skipped_correctly(self) -> None:
         """8-byte energy channels should be skipped without breaking power parsing."""
         meter = _create_meter()
         packet = _build_packet(
@@ -248,7 +256,7 @@ class TestHandlePacket(unittest.TestCase):
         meter._handle_packet(packet)
         self.assertEqual(meter.values, [100.0, 200.0, 300.0])
 
-    def test_phase_data_preferred_over_total(self):
+    def test_phase_data_preferred_over_total(self) -> None:
         """When both phase and total data present, phase data is used."""
         meter = _create_meter()
         packet = _build_packet(
@@ -268,7 +276,7 @@ class TestHandlePacket(unittest.TestCase):
         self.assertEqual(len(meter.values), 3)
         self.assertEqual(meter.values, [100.0, 200.0, 300.0])
 
-    def test_software_version_channel_skipped(self):
+    def test_software_version_channel_skipped(self) -> None:
         meter = _create_meter()
         packet = _build_packet(
             [
@@ -282,12 +290,12 @@ class TestHandlePacket(unittest.TestCase):
 
 
 class TestGetPowermeterWattsAsync:
-    async def test_no_data_raises(self):
+    async def test_no_data_raises(self) -> None:
         meter = _create_meter()
         with pytest.raises(ValueError):
             await meter.get_powermeter_watts()
 
-    async def test_returns_copy(self):
+    async def test_returns_copy(self) -> None:
         meter = _create_meter()
         meter.values = [100.0, 200.0, 300.0]
         result = await meter.get_powermeter_watts()
@@ -296,12 +304,12 @@ class TestGetPowermeterWattsAsync:
 
 
 class TestWaitForMessageAsync:
-    async def test_timeout_raises(self):
+    async def test_timeout_raises(self) -> None:
         meter = _create_meter()
         with pytest.raises(TimeoutError):
             await meter.wait_for_message(timeout=0)
 
-    async def test_returns_when_data_available(self):
+    async def test_returns_when_data_available(self) -> None:
         meter = _create_meter()
         packet = _build_packet(
             [
@@ -316,7 +324,7 @@ class TestWaitForMessageAsync:
 
 
 class TestWaitForNextMessage:
-    async def test_blocks_until_new(self):
+    async def test_blocks_until_new(self) -> None:
         meter = _create_meter()
         packet = _build_packet(
             [
@@ -326,7 +334,7 @@ class TestWaitForNextMessage:
         )
         meter._handle_packet(packet)
 
-        async def _push_later():
+        async def _push_later() -> None:
             await asyncio.sleep(0.05)
             new_packet = _build_packet(
                 [
@@ -341,7 +349,7 @@ class TestWaitForNextMessage:
         await task
         assert await meter.get_powermeter_watts() == [200.0]
 
-    async def test_timeout(self):
+    async def test_timeout(self) -> None:
         meter = _create_meter()
         meter._message_event.set()
         with pytest.raises(TimeoutError):
@@ -349,15 +357,15 @@ class TestWaitForNextMessage:
 
 
 class TestLifecycle:
-    async def test_stop_closes_transport(self):
+    async def test_stop_closes_transport(self) -> None:
         meter = _create_meter()
         # Simulate a started meter with a mock transport
 
         class FakeTransport:
-            def __init__(self):
+            def __init__(self) -> None:
                 self.closed = False
 
-            def close(self):
+            def close(self) -> None:
                 self.closed = True
 
         transport = FakeTransport()
@@ -366,7 +374,7 @@ class TestLifecycle:
         assert transport.closed
         assert meter._transport is None
 
-    async def test_stop_when_not_started(self):
+    async def test_stop_when_not_started(self) -> None:
         meter = _create_meter()
         await meter.stop()  # should not raise
 
@@ -383,7 +391,7 @@ class _FakeClock:
 
 
 class TestStreamOnline(unittest.TestCase):
-    def _total_packet(self):
+    def _total_packet(self) -> bytes:
         return _build_packet(
             [
                 _build_channel(CHANNEL_TOTAL_POWER_PLUS, 1000),
@@ -391,11 +399,11 @@ class TestStreamOnline(unittest.TestCase):
             ]
         )
 
-    def test_false_before_any_telegram(self):
+    def test_false_before_any_telegram(self) -> None:
         meter = _create_meter()
         self.assertIs(meter.stream_online(), False)
 
-    def test_true_when_fresh(self):
+    def test_true_when_fresh(self) -> None:
         clock = _FakeClock()
         meter = _create_meter(max_telegram_age_seconds=30.0, clock=clock)
         meter._handle_packet(self._total_packet())
@@ -403,14 +411,14 @@ class TestStreamOnline(unittest.TestCase):
         clock.advance(29.0)
         self.assertIs(meter.stream_online(), True)
 
-    def test_false_when_stale(self):
+    def test_false_when_stale(self) -> None:
         clock = _FakeClock()
         meter = _create_meter(max_telegram_age_seconds=30.0, clock=clock)
         meter._handle_packet(self._total_packet())
         clock.advance(31.0)
         self.assertIs(meter.stream_online(), False)
 
-    def test_disabled_when_max_age_zero(self):
+    def test_disabled_when_max_age_zero(self) -> None:
         clock = _FakeClock()
         meter = _create_meter(max_telegram_age_seconds=0.0, clock=clock)
         meter._handle_packet(self._total_packet())
@@ -419,13 +427,13 @@ class TestStreamOnline(unittest.TestCase):
 
 
 class TestDeviceNames(unittest.TestCase):
-    def test_known_susy_ids(self):
+    def test_known_susy_ids(self) -> None:
         self.assertEqual(SMA_SUSY_IDS[270], "SMA Energy Meter 1.0")
         self.assertEqual(SMA_SUSY_IDS[349], "SMA Energy Meter 2.0")
         self.assertEqual(SMA_SUSY_IDS[372], "Sunny Home Manager 2.0")
         self.assertEqual(SMA_SUSY_IDS[501], "Sunny Home Manager 2.0")
 
-    def test_unknown_susy_id(self):
+    def test_unknown_susy_id(self) -> None:
         self.assertNotIn(999, SMA_SUSY_IDS)
 
 

--- a/src/astrameter/powermeter/sml.py
+++ b/src/astrameter/powermeter/sml.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 import re
 from dataclasses import dataclass, field
+from typing import Any
 
 import serial_asyncio_fast
 import smllib.errors
@@ -71,7 +72,7 @@ def _optional_w(by_obis: dict, obis_key: str, label: str) -> float | None:
     return _apply_scaler(ov)
 
 
-def _apply_scaler(ov) -> float:
+def _apply_scaler(ov: Any) -> float:
     """Scale an SML value by its ``10**scaler`` exponent.
 
     smllib exposes the meter's raw integer in ``ov.value`` and the decimal
@@ -88,7 +89,7 @@ def _apply_scaler(ov) -> float:
     return round(value * 10**scaler, abs(scaler) + 3)
 
 
-def _expect_unit(ov, expected: str, label: str) -> None:
+def _expect_unit(ov: Any, expected: str, label: str) -> None:
     actual = UNITS.get(ov.unit)
     if actual != expected:
         raise ValueError(
@@ -106,7 +107,7 @@ class Sml(Powermeter):
         obis_power_l1: str = _OBIS_POWER_L1,
         obis_power_l2: str = _OBIS_POWER_L2,
         obis_power_l3: str = _OBIS_POWER_L3,
-    ):
+    ) -> None:
         if not serial_device.strip():
             raise ValueError("serial_device must be non-empty (config: SERIAL)")
         self._serial_device = serial_device.strip()

--- a/src/astrameter/powermeter/sml_test.py
+++ b/src/astrameter/powermeter/sml_test.py
@@ -7,6 +7,7 @@ import threading
 import time
 import unittest
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -30,12 +31,12 @@ def _obis_value(
     return SimpleNamespace(obis=obis, value=value, unit=unit, scaler=scaler)
 
 
-def _defaults():
+def _defaults() -> tuple[str, str, str, str]:
     return (_OBIS_POWER_CURRENT, _OBIS_POWER_L1, _OBIS_POWER_L2, _OBIS_POWER_L3)
 
 
 class TestEnergyStatsFromSmlFrame(unittest.TestCase):
-    def test_aggregate_only(self):
+    def test_aggregate_only(self) -> None:
         frame = MagicMock()
         frame.get_obis.return_value = [
             _obis_value(_OBIS_POWER_CURRENT, 1500, 27),
@@ -43,7 +44,7 @@ class TestEnergyStatsFromSmlFrame(unittest.TestCase):
         stats = EnergyStats.from_sml_frame(frame, *_defaults())
         self.assertEqual(stats.powers, [1500])
 
-    def test_multiphase_when_all_phases_present(self):
+    def test_multiphase_when_all_phases_present(self) -> None:
         frame = MagicMock()
         frame.get_obis.return_value = [
             _obis_value(_OBIS_POWER_L1, 100, 27),
@@ -53,7 +54,7 @@ class TestEnergyStatsFromSmlFrame(unittest.TestCase):
         stats = EnergyStats.from_sml_frame(frame, *_defaults())
         self.assertEqual(stats.powers, [100, 200, 300])
 
-    def test_prefers_multiphase_when_aggregate_also_present(self):
+    def test_prefers_multiphase_when_aggregate_also_present(self) -> None:
         frame = MagicMock()
         frame.get_obis.return_value = [
             _obis_value(_OBIS_POWER_CURRENT, 9999, 27),
@@ -64,7 +65,7 @@ class TestEnergyStatsFromSmlFrame(unittest.TestCase):
         stats = EnergyStats.from_sml_frame(frame, *_defaults())
         self.assertEqual(stats.powers, [100, 200, 300])
 
-    def test_falls_back_to_aggregate_if_incomplete_phases(self):
+    def test_falls_back_to_aggregate_if_incomplete_phases(self) -> None:
         frame = MagicMock()
         frame.get_obis.return_value = [
             _obis_value(_OBIS_POWER_CURRENT, 1500, 27),
@@ -74,7 +75,7 @@ class TestEnergyStatsFromSmlFrame(unittest.TestCase):
         stats = EnergyStats.from_sml_frame(frame, *_defaults())
         self.assertEqual(stats.powers, [1500])
 
-    def test_applies_negative_scaler_aggregate(self):
+    def test_applies_negative_scaler_aggregate(self) -> None:
         # Meters like the Apator Picus eHZ send watts with scaler -3, so the
         # raw integer is 1000x too large; the scaler must be applied (#519).
         frame = MagicMock()
@@ -84,7 +85,7 @@ class TestEnergyStatsFromSmlFrame(unittest.TestCase):
         stats = EnergyStats.from_sml_frame(frame, *_defaults())
         self.assertEqual(stats.powers, [170.0])
 
-    def test_applies_scaler_per_phase(self):
+    def test_applies_scaler_per_phase(self) -> None:
         frame = MagicMock()
         frame.get_obis.return_value = [
             _obis_value(_OBIS_POWER_L1, 100000, 27, scaler=-3),
@@ -94,7 +95,7 @@ class TestEnergyStatsFromSmlFrame(unittest.TestCase):
         stats = EnergyStats.from_sml_frame(frame, *_defaults())
         self.assertEqual(stats.powers, [100.0, 200.0, -50.0])
 
-    def test_scaler_zero_or_absent_unchanged(self):
+    def test_scaler_zero_or_absent_unchanged(self) -> None:
         # scaler 0 and a missing scaler both mean "already in watts".
         frame = MagicMock()
         frame.get_obis.return_value = [
@@ -103,7 +104,7 @@ class TestEnergyStatsFromSmlFrame(unittest.TestCase):
         stats = EnergyStats.from_sml_frame(frame, *_defaults())
         self.assertEqual(stats.powers, [1500])
 
-    def test_wrong_unit_raises(self):
+    def test_wrong_unit_raises(self) -> None:
         frame = MagicMock()
         frame.get_obis.return_value = [_obis_value(_OBIS_POWER_CURRENT, 1500, 30)]
         with self.assertRaises(ValueError) as ctx:
@@ -113,20 +114,20 @@ class TestEnergyStatsFromSmlFrame(unittest.TestCase):
 
 
 class TestParseSmlObisConfig(unittest.TestCase):
-    def test_defaults_when_empty(self):
+    def test_defaults_when_empty(self) -> None:
         config = configparser.ConfigParser()
         config.read_string("[SML]\n")
         t = parse_sml_obis_config("SML", config)
         self.assertEqual(t, _defaults())
 
-    def test_override_normalized(self):
+    def test_override_normalized(self) -> None:
         config = configparser.ConfigParser()
         config.read_string("[SML]\nOBIS_POWER_CURRENT = 0100100700FF\n")
         oc, o1, _o2, _o3 = parse_sml_obis_config("SML", config)
         self.assertEqual(oc, "0100100700ff")
         self.assertEqual(o1, _OBIS_POWER_L1)
 
-    def test_invalid_length_raises(self):
+    def test_invalid_length_raises(self) -> None:
         config = configparser.ConfigParser()
         config.read_string("[SML]\nOBIS_POWER_CURRENT = deadbeef\n")
         with self.assertRaises(ValueError):
@@ -134,20 +135,21 @@ class TestParseSmlObisConfig(unittest.TestCase):
 
 
 class TestCreateSmlPowermeter(unittest.TestCase):
-    def test_missing_serial_raises(self):
+    def test_missing_serial_raises(self) -> None:
         config = configparser.ConfigParser()
         config.read_string("[SML]\n")
         with self.assertRaises(ValueError) as ctx:
             create_sml_powermeter("SML", config)
         self.assertIn("SERIAL", str(ctx.exception))
 
-    def test_serial_trimmed(self):
+    def test_serial_trimmed(self) -> None:
         config = configparser.ConfigParser()
         config.read_string("[SML]\nSERIAL = /dev/ttyAMA0\n")
         pm = create_sml_powermeter("SML", config)
+        assert isinstance(pm, Sml)
         self.assertEqual(pm._serial_device, "/dev/ttyAMA0")
 
-    def test_custom_obis_passed_to_sml(self):
+    def test_custom_obis_passed_to_sml(self) -> None:
         config = configparser.ConfigParser()
         config.read_string(
             "[SML]\n"
@@ -158,6 +160,7 @@ class TestCreateSmlPowermeter(unittest.TestCase):
             "OBIS_POWER_L3 = 01004c0700ff\n"
         )
         pm = create_sml_powermeter("SML", config)
+        assert isinstance(pm, Sml)
         self.assertEqual(pm._obis_current, "0100100700ff")
         self.assertEqual(pm._obis_l1, "0100240700ff")
 
@@ -165,10 +168,10 @@ class TestCreateSmlPowermeter(unittest.TestCase):
 # --- Async tests for the migrated Sml class ---
 
 
-async def test_async_read_returns_updated_powers():
+async def test_async_read_returns_updated_powers() -> None:
     sml = Sml("/dev/ttyUSB0")
 
-    async def fake_read():
+    async def fake_read() -> None:
         sml._current = EnergyStats(powers=[500])
 
     with patch.object(sml, "_read_serial", side_effect=fake_read):
@@ -176,13 +179,13 @@ async def test_async_read_returns_updated_powers():
     assert result == [500.0]
 
 
-async def test_async_skip_if_busy_returns_cached():
+async def test_async_skip_if_busy_returns_cached() -> None:
     sml = Sml("/dev/ttyUSB0")
     sml._current = EnergyStats(powers=[999])
 
     read_called = False
 
-    async def fake_read():
+    async def fake_read() -> None:
         nonlocal read_called
         read_called = True
 
@@ -198,14 +201,14 @@ async def test_async_skip_if_busy_returns_cached():
     assert not read_called
 
 
-async def test_async_lock_released_on_exception():
+async def test_async_lock_released_on_exception() -> None:
     sml = Sml("/dev/ttyUSB0")
     original_powers = sml._current.powers[:]
 
-    async def failing_read():
+    async def failing_read() -> None:
         raise OSError("serial port error")
 
-    async def successful_read():
+    async def successful_read() -> None:
         sml._current = EnergyStats(powers=[42])
 
     with (
@@ -224,7 +227,7 @@ async def test_async_lock_released_on_exception():
     assert result == [42.0]
 
 
-async def test_async_cold_start_skip_returns_zero():
+async def test_async_cold_start_skip_returns_zero() -> None:
     sml = Sml("/dev/ttyUSB0")
     await sml._lock.acquire()
     try:
@@ -234,13 +237,13 @@ async def test_async_cold_start_skip_returns_zero():
     assert result == [0.0]
 
 
-async def test_async_concurrent_callers():
+async def test_async_concurrent_callers() -> None:
     sml = Sml("/dev/ttyUSB0")
     sml._current = EnergyStats(powers=[100])
     read_count = 0
     read_started = asyncio.Event()
 
-    async def slow_read():
+    async def slow_read() -> None:
         nonlocal read_count
         read_count += 1
         read_started.set()
@@ -249,7 +252,7 @@ async def test_async_concurrent_callers():
 
     with patch.object(sml, "_read_serial", side_effect=slow_read):
         # Launch 3 concurrent callers
-        async def caller():
+        async def caller() -> list[float]:
             return await sml.get_powermeter_watts()
 
         task1 = asyncio.create_task(caller())
@@ -266,7 +269,7 @@ async def test_async_concurrent_callers():
     assert r3 == [100.0]  # Cached value (before read completed)
 
 
-async def test_read_serial_retries_on_crc_error():
+async def test_read_serial_retries_on_crc_error() -> None:
     sml = Sml("/dev/ttyUSB0")
 
     mock_reader = AsyncMock()
@@ -281,7 +284,7 @@ async def test_read_serial_retries_on_crc_error():
 
     import smllib.errors
 
-    def patched_get_frame(stream_self):
+    def patched_get_frame(stream_self: Any) -> Any:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -295,7 +298,7 @@ async def test_read_serial_retries_on_crc_error():
     assert call_count == 2
 
 
-async def test_read_serial_timeout():
+async def test_read_serial_timeout() -> None:
     sml = Sml("/dev/ttyUSB0")
 
     mock_reader = AsyncMock()
@@ -365,14 +368,14 @@ def _build_sml_frame(
     return frame_no_crc + struct.pack(">H", crc)
 
 
-def test_parse_sml_powers_decodes_full_telegram():
+def test_parse_sml_powers_decodes_full_telegram() -> None:
     """parse_sml_powers decodes a complete SML telegram (bytes) into watts."""
     frame = _build_sml_frame(power_agg=1234, power_l1=400, power_l2=500, power_l3=334)
     # All three phases present → per-phase preferred over the aggregate.
     assert parse_sml_powers(frame) == [400, 500, 334]
 
 
-def test_parse_sml_powers_applies_scaler():
+def test_parse_sml_powers_applies_scaler() -> None:
     """A meter sending watts with scaler -3 is decoded to true watts (#519)."""
     frame = _build_sml_frame(
         power_agg=170000, power_l1=170000, power_l2=0, power_l3=0, scaler=-3
@@ -381,12 +384,12 @@ def test_parse_sml_powers_applies_scaler():
     assert parse_sml_powers(frame) == [170.0, 0.0, 0.0]
 
 
-def test_parse_sml_powers_returns_none_on_garbage():
+def test_parse_sml_powers_returns_none_on_garbage() -> None:
     """parse_sml_powers returns None when no valid frame can be parsed."""
     assert parse_sml_powers(b"not an sml telegram") is None
 
 
-async def test_e2e_pty_serial_read():
+async def test_e2e_pty_serial_read() -> None:
     """Full E2E test: PTY pair → async serial read → SML parse → power values."""
     master_fd, slave_fd = os.openpty()
     slave_name = os.ttyname(slave_fd)
@@ -395,7 +398,7 @@ async def test_e2e_pty_serial_read():
         power_agg=1234, power_l1=400, power_l2=500, power_l3=334
     )
 
-    def writer():
+    def writer() -> None:
         time.sleep(0.2)
         os.write(master_fd, frame_data)
 
@@ -415,13 +418,16 @@ async def test_e2e_pty_serial_read():
 
 
 @pytest.mark.asyncio
-async def test_empty_first_read_reports_a_closed_connection(caplog):
+async def test_empty_first_read_reports_a_closed_connection(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """EOF on the first read is end-of-stream, not an unparseable frame."""
     sml = Sml("/dev/null")
-    sml._reader = SimpleNamespace(read=AsyncMock(return_value=b""))
+    reader = AsyncMock(return_value=b"")
+    sml._reader = cast("asyncio.StreamReader", SimpleNamespace(read=reader))
     with caplog.at_level(logging.ERROR):
         await sml._read_serial()
     assert "serial connection closed" in caplog.text
     assert "failed to read SML frame" not in caplog.text
     # One read, then stop -- no futile frame attempts against an empty stream.
-    assert sml._reader.read.await_count == 1
+    assert reader.await_count == 1

--- a/src/astrameter/powermeter/tasmota.py
+++ b/src/astrameter/powermeter/tasmota.py
@@ -16,7 +16,7 @@ class Tasmota(HttpPowermeter):
         json_power_input_mqtt_label: str | list[str],
         json_power_output_mqtt_label: str | list[str],
         json_power_calculate: bool,
-    ):
+    ) -> None:
         self.ip = ip
         self.user = user
         self.password = password

--- a/src/astrameter/powermeter/tasmota_test.py
+++ b/src/astrameter/powermeter/tasmota_test.py
@@ -1,11 +1,11 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from astrameter.powermeter import Tasmota
 
 
-async def test_tasmota_get_powermeter_watts(mock_aiohttp_session):
+async def test_tasmota_get_powermeter_watts(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_json({"StatusSNS": {"ENERGY": {"Power": 123}}})
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         tasmota = Tasmota(
@@ -27,7 +27,7 @@ async def test_tasmota_get_powermeter_watts(mock_aiohttp_session):
         await tasmota.stop()
 
 
-async def test_tasmota_unauthenticated(mock_aiohttp_session):
+async def test_tasmota_unauthenticated(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_json({"StatusSNS": {"ENERGY": {"Power": 123}}})
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         tasmota = Tasmota(
@@ -49,7 +49,7 @@ async def test_tasmota_unauthenticated(mock_aiohttp_session):
         await tasmota.stop()
 
 
-async def test_tasmota_three_phase(mock_aiohttp_session):
+async def test_tasmota_three_phase(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_json(
         {"StatusSNS": {"eBZ": {"Power_L1": 100, "Power_L2": 200, "Power_L3": 300}}}
     )
@@ -70,7 +70,7 @@ async def test_tasmota_three_phase(mock_aiohttp_session):
         await tasmota.stop()
 
 
-async def test_tasmota_three_phase_calculate(mock_aiohttp_session):
+async def test_tasmota_three_phase_calculate(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_json(
         {
             "StatusSNS": {
@@ -102,7 +102,7 @@ async def test_tasmota_three_phase_calculate(mock_aiohttp_session):
         await tasmota.stop()
 
 
-def test_tasmota_mismatched_calculate_labels():
+def test_tasmota_mismatched_calculate_labels() -> None:
     with pytest.raises(ValueError, match="same number of entries"):
         Tasmota(
             "192.168.1.1",
@@ -117,7 +117,7 @@ def test_tasmota_mismatched_calculate_labels():
         )
 
 
-def test_tasmota_empty_calculate_labels():
+def test_tasmota_empty_calculate_labels() -> None:
     with pytest.raises(ValueError, match="cannot be empty"):
         Tasmota(
             "192.168.1.1",

--- a/src/astrameter/powermeter/tibber_pulse.py
+++ b/src/astrameter/powermeter/tibber_pulse.py
@@ -56,7 +56,7 @@ class TibberPulse(HttpPowermeter):
         obis_power_l3: str = _OBIS_POWER_L3,
         timeout: float = DEFAULT_TIMEOUT_S,
         clock: Callable[[], float] | None = None,
-    ):
+    ) -> None:
         super().__init__(timeout=timeout)
         self.ip = ip
         self.password = password

--- a/src/astrameter/powermeter/tibber_pulse_test.py
+++ b/src/astrameter/powermeter/tibber_pulse_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -6,7 +6,9 @@ from astrameter.powermeter import TibberPulse
 from astrameter.powermeter.sml_test import _build_sml_frame
 
 
-async def test_get_powermeter_watts_decodes_multiphase(mock_aiohttp_session):
+async def test_get_powermeter_watts_decodes_multiphase(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     frame = _build_sml_frame(power_agg=1234, power_l1=400, power_l2=500, power_l3=334)
     mock_aiohttp_session.set_read(frame)
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
@@ -17,7 +19,9 @@ async def test_get_powermeter_watts_decodes_multiphase(mock_aiohttp_session):
         await pm.stop()
 
 
-async def test_get_powermeter_watts_builds_authenticated_url(mock_aiohttp_session):
+async def test_get_powermeter_watts_builds_authenticated_url(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     frame = _build_sml_frame(power_l1=100, power_l2=200, power_l3=300)
     mock_aiohttp_session.set_read(frame)
     with patch(
@@ -42,7 +46,7 @@ async def test_get_powermeter_watts_builds_authenticated_url(mock_aiohttp_sessio
     assert url == "http://10.0.0.5/data.json?node_id=2"
 
 
-async def test_timeout_is_configurable(mock_aiohttp_session):
+async def test_timeout_is_configurable(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_read(_build_sml_frame(power_agg=100))
     with patch(
         "aiohttp.ClientSession", return_value=mock_aiohttp_session
@@ -55,8 +59,8 @@ async def test_timeout_is_configurable(mock_aiohttp_session):
 
 
 async def test_get_powermeter_watts_raises_on_undecodable_telegram(
-    mock_aiohttp_session,
-):
+    mock_aiohttp_session: MagicMock,
+) -> None:
     mock_aiohttp_session.set_read(b"not a valid sml frame")
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         pm = TibberPulse("127.0.0.1", "pw")
@@ -66,7 +70,9 @@ async def test_get_powermeter_watts_raises_on_undecodable_telegram(
         await pm.stop()
 
 
-async def test_transient_undecodable_reuses_last_good(mock_aiohttp_session):
+async def test_transient_undecodable_reuses_last_good(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     # A bridge serving a push source occasionally returns an undecodable
     # telegram; within the staleness window the last good reading is reused
     # instead of raising (#518).
@@ -85,7 +91,9 @@ async def test_transient_undecodable_reuses_last_good(mock_aiohttp_session):
         await pm.stop()
 
 
-async def test_stale_undecodable_raises_after_window(mock_aiohttp_session):
+async def test_stale_undecodable_raises_after_window(
+    mock_aiohttp_session: MagicMock,
+) -> None:
     now = [1000.0]
     frame = _build_sml_frame(power_l1=100, power_l2=200, power_l3=300)
     mock_aiohttp_session.set_read(frame)
@@ -103,8 +111,8 @@ async def test_stale_undecodable_raises_after_window(mock_aiohttp_session):
 
 
 async def test_get_powermeter_watts_raises_when_decoder_returns_no_powers(
-    mock_aiohttp_session,
-):
+    mock_aiohttp_session: MagicMock,
+) -> None:
     # Defensive: an empty decode result is treated as a failed read, not 0 W.
     mock_aiohttp_session.set_read(b"frame-bytes-ignored-by-mock")
     with (

--- a/src/astrameter/powermeter/tq_em_test.py
+++ b/src/astrameter/powermeter/tq_em_test.py
@@ -1,9 +1,10 @@
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from astrameter.powermeter.tq_em import TQEnergyManager
 
 
-def _make_resp(data, status=200):
+def _make_resp(data: Any, status: int = 200) -> MagicMock:
     """Create a mock aiohttp response with async context manager support."""
     resp = MagicMock()
     resp.json = AsyncMock(return_value=data)
@@ -14,7 +15,9 @@ def _make_resp(data, status=200):
     return resp
 
 
-def _make_session(get_responses, post_responses=None):
+def _make_session(
+    get_responses: list[Any], post_responses: list[Any] | None = None
+) -> MagicMock:
     """Create a mock aiohttp session with sequenced GET/POST responses."""
     session = MagicMock()
     session.get = MagicMock(side_effect=[_make_resp(d) for d in get_responses])
@@ -26,7 +29,7 @@ def _make_session(get_responses, post_responses=None):
     return session
 
 
-async def test_three_phase():
+async def test_three_phase() -> None:
     session = _make_session(
         get_responses=[
             {"serial": "123", "authentication": False},
@@ -48,7 +51,7 @@ async def test_three_phase():
         await meter.stop()
 
 
-async def test_total_only():
+async def test_total_only() -> None:
     session = _make_session(
         get_responses=[
             {"serial": "321", "authentication": False},
@@ -63,7 +66,7 @@ async def test_total_only():
         await meter.stop()
 
 
-async def test_relogin_on_expired_session():
+async def test_relogin_on_expired_session() -> None:
     session = _make_session(
         get_responses=[
             {"serial": "123", "authentication": False},
@@ -83,7 +86,7 @@ async def test_relogin_on_expired_session():
         await meter.stop()
 
 
-async def test_missing_export():
+async def test_missing_export() -> None:
     session = _make_session(
         get_responses=[
             {"serial": "111", "authentication": False},
@@ -98,7 +101,7 @@ async def test_missing_export():
         await meter.stop()
 
 
-async def test_three_phase_missing_export():
+async def test_three_phase_missing_export() -> None:
     session = _make_session(
         get_responses=[
             {"serial": "777", "authentication": False},

--- a/src/astrameter/powermeter/vzlogger.py
+++ b/src/astrameter/powermeter/vzlogger.py
@@ -5,7 +5,7 @@ from .http_client import HttpPowermeter
 
 
 class VZLogger(HttpPowermeter):
-    def __init__(self, ip: str, port: str, uuid: str | list[str]):
+    def __init__(self, ip: str, port: str, uuid: str | list[str]) -> None:
         self.ip = ip
         self.port = port
         self.uuids = as_list(uuid)

--- a/src/astrameter/powermeter/vzlogger_test.py
+++ b/src/astrameter/powermeter/vzlogger_test.py
@@ -1,9 +1,9 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from astrameter.powermeter import VZLogger
 
 
-async def test_vzlogger_get_powermeter_watts(mock_aiohttp_session):
+async def test_vzlogger_get_powermeter_watts(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_json({"data": [{"tuples": [[None, 900]]}]})
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         vzlogger = VZLogger("192.168.1.9", "8088", "uuid")
@@ -12,7 +12,7 @@ async def test_vzlogger_get_powermeter_watts(mock_aiohttp_session):
         await vzlogger.stop()
 
 
-async def test_vzlogger_three_phase(mock_aiohttp_session):
+async def test_vzlogger_three_phase(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.set_json({"data": [{"tuples": [[None, 900]]}]})
     with patch("aiohttp.ClientSession", return_value=mock_aiohttp_session):
         vzlogger = VZLogger("192.168.1.9", "8088", ["uuid-l1", "uuid-l2", "uuid-l3"])

--- a/src/astrameter/powermeter/wrappers/conftest.py
+++ b/src/astrameter/powermeter/wrappers/conftest.py
@@ -1,0 +1,41 @@
+"""Fixtures shared by the wrapper tests."""
+
+from __future__ import annotations
+
+from ..base import Powermeter
+
+
+class FakePowermeter(Powermeter):
+    """A source the wrapper tests drive directly, one reading at a time.
+
+    Subclasses :class:`Powermeter` so a wrapper that starts expecting more of
+    its inner source fails here rather than at the call site of whichever test
+    happened to notice.
+    """
+
+    def __init__(self, values: list[float] | None = None) -> None:
+        self._values: list[float] = [0.0] if values is None else values
+        self.started = False
+        self.stopped = False
+        self.reset_count = 0
+
+    def set(self, values: list[float]) -> None:
+        self._values = values
+
+    async def get_powermeter_watts(self) -> list[float]:
+        return list(self._values)
+
+    async def get_powermeter_watts_raw(self) -> list[float]:
+        return list(self._values)
+
+    async def wait_for_message(self, timeout: float = 5) -> None:
+        pass
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    def reset(self) -> None:
+        self.reset_count += 1

--- a/src/astrameter/powermeter/wrappers/hampel_test.py
+++ b/src/astrameter/powermeter/wrappers/hampel_test.py
@@ -2,48 +2,20 @@
 
 import pytest
 
+from .conftest import FakePowermeter
 from .hampel import HampelPowermeter
 
 
-class FakePowermeter:
-    """Minimal powermeter stub for testing wrappers."""
-
-    def __init__(self, values: list[float] | None = None):
-        self._values: list[float] = values if values is not None else [0.0]
-        self.started = False
-        self.stopped = False
-        self.reset_count = 0
-
-    def set(self, values: list[float]) -> None:
-        self._values = values
-
-    async def get_powermeter_watts(self) -> list[float]:
-        return list(self._values)
-
-    async def get_powermeter_watts_raw(self) -> list[float]:
-        return list(self._values)
-
-    async def wait_for_message(self, timeout=5):
-        pass
-
-    async def start(self):
-        self.started = True
-
-    async def stop(self):
-        self.stopped = True
-
-    def reset(self):
-        self.reset_count += 1
-
-
-async def _push(hp: HampelPowermeter, fake: FakePowermeter, values: list[float]):
+async def _push(
+    hp: HampelPowermeter, fake: FakePowermeter, values: list[float]
+) -> list[float]:
     fake.set(values)
     return await hp.get_powermeter_watts()
 
 
 class TestHampelPowermeter:
     @pytest.mark.asyncio
-    async def test_warmup_passes_through(self):
+    async def test_warmup_passes_through(self) -> None:
         fake = FakePowermeter([100.0])
         hp = HampelPowermeter(fake, window=5, n_sigma=3.0)
         for _ in range(4):
@@ -51,7 +23,7 @@ class TestHampelPowermeter:
             assert result == [100.0]
 
     @pytest.mark.asyncio
-    async def test_clean_signal_not_modified(self):
+    async def test_clean_signal_not_modified(self) -> None:
         fake = FakePowermeter()
         hp = HampelPowermeter(fake, window=5, n_sigma=3.0)
         # Fill window with clean samples
@@ -62,7 +34,7 @@ class TestHampelPowermeter:
         assert result == [100.5]
 
     @pytest.mark.asyncio
-    async def test_single_spike_replaced_by_median(self):
+    async def test_single_spike_replaced_by_median(self) -> None:
         fake = FakePowermeter()
         hp = HampelPowermeter(fake, window=5, n_sigma=3.0)
         for v in [100.0, 102.0, 98.0, 101.0, 99.0]:
@@ -74,7 +46,7 @@ class TestHampelPowermeter:
         assert result[0] != 10000.0
 
     @pytest.mark.asyncio
-    async def test_spike_in_window_does_not_stop_later_detection(self):
+    async def test_spike_in_window_does_not_stop_later_detection(self) -> None:
         """A rejected sample stays in the window, and that is fine: the median
         is what the filter reads, and one outlier in five cannot move it.
         """
@@ -90,7 +62,7 @@ class TestHampelPowermeter:
         assert await _push(hp, fake, [9000.0]) != [9000.0]
 
     @pytest.mark.asyncio
-    async def test_sustained_change_is_followed_not_latched(self):
+    async def test_sustained_change_is_followed_not_latched(self) -> None:
         """The regression this filter was rewritten for.
 
         Rejecting a *spike* is the job; rejecting the new normal is not. When
@@ -114,7 +86,7 @@ class TestHampelPowermeter:
         )
 
     @pytest.mark.asyncio
-    async def test_near_zero_total_does_not_amplify_phases(self):
+    async def test_near_zero_total_does_not_amplify_phases(self) -> None:
         """Scaling phases so their sum matches the median must stay bounded.
 
         With only an exact-zero guard, a dropout whose phases nearly cancel
@@ -132,7 +104,7 @@ class TestHampelPowermeter:
         assert max(abs(v) for v in result) <= 1100.0
 
     @pytest.mark.asyncio
-    async def test_constant_signal_mad_zero_no_floor(self):
+    async def test_constant_signal_mad_zero_no_floor(self) -> None:
         """MAD=0 with min_threshold=0 → threshold is 0 → documented
         limitation: spikes pass through."""
         fake = FakePowermeter()
@@ -143,7 +115,7 @@ class TestHampelPowermeter:
         assert result == [500.0]
 
     @pytest.mark.asyncio
-    async def test_min_threshold_floor_catches_spike_on_constant(self):
+    async def test_min_threshold_floor_catches_spike_on_constant(self) -> None:
         fake = FakePowermeter()
         hp = HampelPowermeter(fake, window=5, n_sigma=3.0, min_threshold=50.0)
         for _ in range(5):
@@ -153,7 +125,7 @@ class TestHampelPowermeter:
         assert result == [0.0]
 
     @pytest.mark.asyncio
-    async def test_min_threshold_floor_lets_small_changes_pass(self):
+    async def test_min_threshold_floor_lets_small_changes_pass(self) -> None:
         fake = FakePowermeter()
         hp = HampelPowermeter(fake, window=5, n_sigma=3.0, min_threshold=50.0)
         for _ in range(5):
@@ -163,7 +135,7 @@ class TestHampelPowermeter:
         assert result == [30.0]
 
     @pytest.mark.asyncio
-    async def test_negative_outlier_symmetric(self):
+    async def test_negative_outlier_symmetric(self) -> None:
         fake = FakePowermeter()
         hp = HampelPowermeter(fake, window=5, n_sigma=3.0)
         for v in [100.0, 102.0, 98.0, 101.0, 99.0]:
@@ -173,7 +145,7 @@ class TestHampelPowermeter:
         assert result[0] != -10000.0
 
     @pytest.mark.asyncio
-    async def test_phase_ratio_preserved_on_replacement(self):
+    async def test_phase_ratio_preserved_on_replacement(self) -> None:
         # Constant total → MAD=0; use min_threshold to gate detection.
         fake = FakePowermeter()
         hp = HampelPowermeter(fake, window=5, n_sigma=3.0, min_threshold=50.0)
@@ -192,7 +164,7 @@ class TestHampelPowermeter:
         assert result == pytest.approx([60.0, 30.0, 10.0])
 
     @pytest.mark.asyncio
-    async def test_raw_total_near_zero_equal_split(self):
+    async def test_raw_total_near_zero_equal_split(self) -> None:
         fake = FakePowermeter()
         hp = HampelPowermeter(fake, window=5, n_sigma=3.0, min_threshold=50.0)
         # Fill window with a nonzero stable total so median is nonzero
@@ -205,14 +177,14 @@ class TestHampelPowermeter:
         assert result == pytest.approx([100.0 / 3] * 3)
 
     @pytest.mark.asyncio
-    async def test_empty_raw_values_returns_empty(self):
+    async def test_empty_raw_values_returns_empty(self) -> None:
         fake = FakePowermeter([])
         hp = HampelPowermeter(fake, window=5, n_sigma=3.0)
         result = await hp.get_powermeter_watts()
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_window_one_always_passthrough(self):
+    async def test_window_one_always_passthrough(self) -> None:
         """window=1 is degenerate: median == sample, MAD always 0 → passthrough
         (when min_threshold=0)."""
         fake = FakePowermeter()
@@ -222,7 +194,7 @@ class TestHampelPowermeter:
             assert result == [v]
 
     @pytest.mark.asyncio
-    async def test_even_window_works(self):
+    async def test_even_window_works(self) -> None:
         """With an even window, statistics.median returns the mean of the two
         middle values. Confirm no crash and sane behavior."""
         fake = FakePowermeter()
@@ -237,7 +209,7 @@ class TestHampelPowermeter:
         assert result[0] != 10000.0
 
     @pytest.mark.asyncio
-    async def test_n_sigma_zero_relies_on_min_threshold(self):
+    async def test_n_sigma_zero_relies_on_min_threshold(self) -> None:
         fake = FakePowermeter()
         hp = HampelPowermeter(fake, window=5, n_sigma=0.0, min_threshold=50.0)
         for v in [100.0, 100.0, 100.0, 100.0, 100.0]:
@@ -252,7 +224,7 @@ class TestHampelPowermeter:
         assert result[0] == pytest.approx(100.0, abs=1.0)
 
     @pytest.mark.asyncio
-    async def test_warmup_poisoning_recovers(self):
+    async def test_warmup_poisoning_recovers(self) -> None:
         """A spike within the warmup window passes through, but subsequent
         outliers after warmup still get detected once the window re-fills
         with clean samples. Uses min_threshold so MAD=0 doesn't block."""
@@ -268,7 +240,7 @@ class TestHampelPowermeter:
         assert result[0] != 10000.0
 
     @pytest.mark.asyncio
-    async def test_reset_clears_window(self):
+    async def test_reset_clears_window(self) -> None:
         fake = FakePowermeter()
         hp = HampelPowermeter(fake, window=3, n_sigma=3.0)
         for _ in range(3):
@@ -280,25 +252,25 @@ class TestHampelPowermeter:
         assert result == [10000.0]
 
     @pytest.mark.asyncio
-    async def test_invalid_window_rejected(self):
+    async def test_invalid_window_rejected(self) -> None:
         fake = FakePowermeter()
         with pytest.raises(ValueError):
             HampelPowermeter(fake, window=0)
 
     @pytest.mark.asyncio
-    async def test_invalid_n_sigma_rejected(self):
+    async def test_invalid_n_sigma_rejected(self) -> None:
         fake = FakePowermeter()
         with pytest.raises(ValueError):
             HampelPowermeter(fake, window=5, n_sigma=-1.0)
 
     @pytest.mark.asyncio
-    async def test_invalid_min_threshold_rejected(self):
+    async def test_invalid_min_threshold_rejected(self) -> None:
         fake = FakePowermeter()
         with pytest.raises(ValueError):
             HampelPowermeter(fake, window=5, min_threshold=-1.0)
 
     @pytest.mark.asyncio
-    async def test_lifecycle_delegation(self):
+    async def test_lifecycle_delegation(self) -> None:
         fake = FakePowermeter([100.0])
         hp = HampelPowermeter(fake, window=5, n_sigma=3.0)
         await hp.start()

--- a/src/astrameter/powermeter/wrappers/health_test.py
+++ b/src/astrameter/powermeter/wrappers/health_test.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -18,11 +19,11 @@ class _FakeClock:
         self.now += seconds
 
 
-def _make(wrapped: Powermeter, **kwargs) -> HealthTrackingPowermeter:
+def _make(wrapped: Powermeter, **kwargs: Any) -> HealthTrackingPowermeter:
     return HealthTrackingPowermeter(wrapped, **kwargs)
 
 
-async def test_passes_values_through_and_records_success():
+async def test_passes_values_through_and_records_success() -> None:
     clock = _FakeClock()
     inner = Mock(spec=Powermeter)
     inner.get_powermeter_watts = AsyncMock(return_value=[100.0, 200.0])
@@ -41,7 +42,7 @@ async def test_passes_values_through_and_records_success():
     assert pm.name == "MQTT_1"
 
 
-async def test_last_values_none_until_first_success():
+async def test_last_values_none_until_first_success() -> None:
     inner = Mock(spec=Powermeter)
     inner.get_powermeter_watts = AsyncMock(side_effect=ValueError("stale"))
     pm = _make(inner)
@@ -53,7 +54,7 @@ async def test_last_values_none_until_first_success():
     assert pm.last_values is None
 
 
-async def test_records_failure_and_reraises():
+async def test_records_failure_and_reraises() -> None:
     inner = Mock(spec=Powermeter)
     inner.get_powermeter_watts = AsyncMock(side_effect=ValueError("stale"))
     pm = _make(inner)
@@ -65,7 +66,7 @@ async def test_records_failure_and_reraises():
     assert pm.last_outcome_ok is False
 
 
-async def test_empty_result_counts_as_not_ok():
+async def test_empty_result_counts_as_not_ok() -> None:
     inner = Mock(spec=Powermeter)
     inner.get_powermeter_watts = AsyncMock(return_value=[])
     pm = _make(inner)
@@ -74,7 +75,7 @@ async def test_empty_result_counts_as_not_ok():
     assert pm.last_outcome_ok is False
 
 
-async def test_raw_read_also_tracked():
+async def test_raw_read_also_tracked() -> None:
     inner = Mock(spec=Powermeter)
     inner.get_powermeter_watts_raw = AsyncMock(return_value=[7.0])
     pm = _make(inner)
@@ -83,7 +84,7 @@ async def test_raw_read_also_tracked():
     assert pm.last_outcome_ok is True
 
 
-def test_stream_online_is_passed_through():
+def test_stream_online_is_passed_through() -> None:
     inner = Mock(spec=Powermeter)
     inner.stream_online = Mock(return_value=True)
     pm = _make(inner)
@@ -93,7 +94,7 @@ def test_stream_online_is_passed_through():
     assert pm.stream_online() is None
 
 
-async def test_lifecycle_delegates_to_inner():
+async def test_lifecycle_delegates_to_inner() -> None:
     inner = Mock(spec=Powermeter)
     inner.start = AsyncMock()
     inner.stop = AsyncMock()

--- a/src/astrameter/powermeter/wrappers/pid.py
+++ b/src/astrameter/powermeter/wrappers/pid.py
@@ -30,7 +30,7 @@ class PidPowermeter(PowermeterWrapper):
         kd: float = 0.0,
         output_max: float = 800.0,
         mode: str = "bias",
-    ):
+    ) -> None:
         if output_max <= 0:
             raise ValueError(f"PID output_max must be positive, got {output_max}")
         mode = mode.lower()

--- a/src/astrameter/powermeter/wrappers/pid_test.py
+++ b/src/astrameter/powermeter/wrappers/pid_test.py
@@ -6,7 +6,7 @@ from .pid import PidPowermeter
 
 
 @pytest.fixture
-def mock_powermeter():
+def mock_powermeter() -> Mock:
     """Return a mock powermeter with async stubs for all interface methods."""
     pm = Mock()
     pm.get_powermeter_watts = AsyncMock()
@@ -23,7 +23,7 @@ def mock_powermeter():
 # ------------------------------------------------------------------
 
 
-def test_invalid_output_max_raises(mock_powermeter):
+def test_invalid_output_max_raises(mock_powermeter: Mock) -> None:
     """output_max must be positive."""
     with pytest.raises(ValueError):
         PidPowermeter(mock_powermeter, output_max=0.0)
@@ -31,13 +31,13 @@ def test_invalid_output_max_raises(mock_powermeter):
         PidPowermeter(mock_powermeter, output_max=-100.0)
 
 
-def test_invalid_mode_raises(mock_powermeter):
+def test_invalid_mode_raises(mock_powermeter: Mock) -> None:
     """Only 'bias' and 'replace' are accepted."""
     with pytest.raises(ValueError):
         PidPowermeter(mock_powermeter, mode="invalid")
 
 
-def test_mode_case_insensitive(mock_powermeter):
+def test_mode_case_insensitive(mock_powermeter: Mock) -> None:
     """Mode string should be case-insensitive."""
     pm = PidPowermeter(mock_powermeter, mode="BIAS")
     assert pm.mode == "bias"
@@ -50,7 +50,7 @@ def test_mode_case_insensitive(mock_powermeter):
 # ------------------------------------------------------------------
 
 
-async def test_p_only_positive_error(mock_powermeter):
+async def test_p_only_positive_error(mock_powermeter: Mock) -> None:
     """With P-only control, a large import (actual=200W) produces
     a negative adjustment to tell the storage device to cover that import."""
     mock_powermeter.get_powermeter_watts.return_value = [200.0]
@@ -61,7 +61,7 @@ async def test_p_only_positive_error(mock_powermeter):
     assert result[0] == pytest.approx(0.0)
 
 
-async def test_p_only_negative_error(mock_powermeter):
+async def test_p_only_negative_error(mock_powermeter: Mock) -> None:
     """Export reading (actual=-100W) produces a positive adjustment."""
     mock_powermeter.get_powermeter_watts.return_value = [-100.0]
     pm = PidPowermeter(mock_powermeter, kp=1.0, output_max=800.0)
@@ -76,7 +76,7 @@ async def test_p_only_negative_error(mock_powermeter):
 # ------------------------------------------------------------------
 
 
-async def test_output_clamped_positive(mock_powermeter):
+async def test_output_clamped_positive(mock_powermeter: Mock) -> None:
     """PID output should not exceed +output_max."""
     mock_powermeter.get_powermeter_watts.return_value = [-1000.0]
     pm = PidPowermeter(mock_powermeter, kp=1.0, output_max=500.0)
@@ -85,7 +85,7 @@ async def test_output_clamped_positive(mock_powermeter):
     assert result[0] == pytest.approx(-500.0)  # -1000 + 500
 
 
-async def test_output_clamped_negative(mock_powermeter):
+async def test_output_clamped_negative(mock_powermeter: Mock) -> None:
     """PID output should not go below -output_max."""
     mock_powermeter.get_powermeter_watts.return_value = [2000.0]
     pm = PidPowermeter(mock_powermeter, kp=1.0, output_max=500.0)
@@ -99,7 +99,7 @@ async def test_output_clamped_negative(mock_powermeter):
 # ------------------------------------------------------------------
 
 
-async def test_integral_accumulates_over_time(mock_powermeter):
+async def test_integral_accumulates_over_time(mock_powermeter: Mock) -> None:
     """The integral term should grow over successive calls."""
     mock_powermeter.get_powermeter_watts.return_value = [100.0]
     pm = PidPowermeter(mock_powermeter, kp=0.0, ki=1.0, output_max=800.0)
@@ -118,7 +118,7 @@ async def test_integral_accumulates_over_time(mock_powermeter):
     assert r2[0] == pytest.approx(0.0)  # 100 + (-100) in bias mode
 
 
-async def test_anti_windup_stops_integration(mock_powermeter):
+async def test_anti_windup_stops_integration(mock_powermeter: Mock) -> None:
     """The integral should not grow beyond what output_max allows."""
     mock_powermeter.get_powermeter_watts.return_value = [500.0]
     pm = PidPowermeter(mock_powermeter, kp=0.0, ki=1.0, output_max=200.0)
@@ -142,7 +142,7 @@ async def test_anti_windup_stops_integration(mock_powermeter):
 # ------------------------------------------------------------------
 
 
-async def test_derivative_reacts_to_change(mock_powermeter):
+async def test_derivative_reacts_to_change(mock_powermeter: Mock) -> None:
     """The D term should respond to changes in error."""
     pm = PidPowermeter(mock_powermeter, kp=0.0, kd=1.0, output_max=800.0)
 
@@ -168,7 +168,7 @@ async def test_derivative_reacts_to_change(mock_powermeter):
 # ------------------------------------------------------------------
 
 
-async def test_multiphase_bias(mock_powermeter):
+async def test_multiphase_bias(mock_powermeter: Mock) -> None:
     """PID output should be distributed equally across phases in bias mode."""
     mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
     pm = PidPowermeter(mock_powermeter, kp=1.0, output_max=800.0)
@@ -180,7 +180,7 @@ async def test_multiphase_bias(mock_powermeter):
     assert result[2] == pytest.approx(100.0)  # 300 + (-200)
 
 
-async def test_multiphase_replace(mock_powermeter):
+async def test_multiphase_replace(mock_powermeter: Mock) -> None:
     """In replace mode, all phases should get equal share of PID output."""
     mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
     pm = PidPowermeter(
@@ -203,7 +203,7 @@ async def test_multiphase_replace(mock_powermeter):
 # ------------------------------------------------------------------
 
 
-async def test_replace_mode(mock_powermeter):
+async def test_replace_mode(mock_powermeter: Mock) -> None:
     """In replace mode the raw value should be discarded."""
     mock_powermeter.get_powermeter_watts.return_value = [500.0]
     pm = PidPowermeter(
@@ -222,7 +222,7 @@ async def test_replace_mode(mock_powermeter):
 # ------------------------------------------------------------------
 
 
-async def test_all_gains_zero_passthrough(mock_powermeter):
+async def test_all_gains_zero_passthrough(mock_powermeter: Mock) -> None:
     """With all gains at zero, the PID should have no effect."""
     mock_powermeter.get_powermeter_watts.return_value = [123.4]
     pm = PidPowermeter(mock_powermeter, kp=0.0, ki=0.0, kd=0.0)
@@ -235,14 +235,14 @@ async def test_all_gains_zero_passthrough(mock_powermeter):
 # ------------------------------------------------------------------
 
 
-async def test_wait_for_message_passthrough(mock_powermeter):
+async def test_wait_for_message_passthrough(mock_powermeter: Mock) -> None:
     """wait_for_message should be delegated to the wrapped powermeter."""
     pm = PidPowermeter(mock_powermeter, kp=1.0)
     await pm.wait_for_message(timeout=7)
     mock_powermeter.wait_for_message.assert_called_once_with(7)
 
 
-async def test_wait_for_next_message_passthrough(mock_powermeter):
+async def test_wait_for_next_message_passthrough(mock_powermeter: Mock) -> None:
     pm = PidPowermeter(mock_powermeter, kp=1.0)
     await pm.wait_for_next_message(timeout=3)
     mock_powermeter.wait_for_next_message.assert_called_once_with(3)
@@ -253,7 +253,7 @@ async def test_wait_for_next_message_passthrough(mock_powermeter):
 # ------------------------------------------------------------------
 
 
-async def test_does_not_mutate_wrapped_list(mock_powermeter):
+async def test_does_not_mutate_wrapped_list(mock_powermeter: Mock) -> None:
     """The wrapper must not mutate the list from the inner powermeter."""
     raw = [100.0, 200.0]
     mock_powermeter.get_powermeter_watts.return_value = raw
@@ -268,7 +268,7 @@ async def test_does_not_mutate_wrapped_list(mock_powermeter):
 # ------------------------------------------------------------------
 
 
-async def test_first_call_no_derivative_spike(mock_powermeter):
+async def test_first_call_no_derivative_spike(mock_powermeter: Mock) -> None:
     """The first call should not produce a derivative spike."""
     mock_powermeter.get_powermeter_watts.return_value = [500.0]
     pm = PidPowermeter(mock_powermeter, kp=0.0, kd=100.0, output_max=800.0)

--- a/src/astrameter/powermeter/wrappers/smoothing_test.py
+++ b/src/astrameter/powermeter/wrappers/smoothing_test.py
@@ -2,39 +2,8 @@
 
 import pytest
 
+from .conftest import FakePowermeter
 from .smoothing import DeadbandPowermeter, SmoothedPowermeter
-
-
-class FakePowermeter:
-    """Minimal powermeter stub for testing wrappers."""
-
-    def __init__(self, values: list[float] | None = None):
-        self._values: list[float] = values or [0.0]
-        self.started = False
-        self.stopped = False
-        self.reset_count = 0
-
-    def set(self, values: list[float]) -> None:
-        self._values = values
-
-    async def get_powermeter_watts(self) -> list[float]:
-        return list(self._values)
-
-    async def get_powermeter_watts_raw(self) -> list[float]:
-        return list(self._values)
-
-    async def wait_for_message(self, timeout=5):
-        pass
-
-    async def start(self):
-        self.started = True
-
-    async def stop(self):
-        self.stopped = True
-
-    def reset(self):
-        self.reset_count += 1
-
 
 # ---------------------------------------------------------------------------
 # SmoothedPowermeter
@@ -43,7 +12,7 @@ class FakePowermeter:
 
 class TestSmoothedPowermeter:
     @pytest.mark.asyncio
-    async def test_first_call_seeds_value(self):
+    async def test_first_call_seeds_value(self) -> None:
         fake = FakePowermeter([100.0, 50.0, -30.0])
         sm = SmoothedPowermeter(fake, alpha=0.5)
         result = await sm.get_powermeter_watts()
@@ -51,7 +20,7 @@ class TestSmoothedPowermeter:
         assert sm.smoothed_value == 120.0
 
     @pytest.mark.asyncio
-    async def test_ema_converges_toward_raw(self):
+    async def test_ema_converges_toward_raw(self) -> None:
         fake = FakePowermeter([100.0])
         sm = SmoothedPowermeter(fake, alpha=0.5)
 
@@ -72,7 +41,7 @@ class TestSmoothedPowermeter:
         assert sm.smoothed_value == 175.0
 
     @pytest.mark.asyncio
-    async def test_sign_change_catchup(self):
+    async def test_sign_change_catchup(self) -> None:
         fake = FakePowermeter([100.0])
         sm = SmoothedPowermeter(fake, alpha=0.1)
 
@@ -87,7 +56,7 @@ class TestSmoothedPowermeter:
         assert sm.smoothed_value == pytest.approx(20.0)
 
     @pytest.mark.asyncio
-    async def test_sign_change_does_not_slow_high_alpha(self):
+    async def test_sign_change_does_not_slow_high_alpha(self) -> None:
         fake = FakePowermeter([1.0])
         sm = SmoothedPowermeter(fake, alpha=1.0)
 
@@ -104,7 +73,7 @@ class TestSmoothedPowermeter:
         assert sm.smoothed_value == pytest.approx(-99.0)
 
     @pytest.mark.asyncio
-    async def test_max_step_limits_delta(self):
+    async def test_max_step_limits_delta(self) -> None:
         fake = FakePowermeter([100.0])
         sm = SmoothedPowermeter(fake, alpha=0.9, max_step=10)
 
@@ -117,7 +86,7 @@ class TestSmoothedPowermeter:
         assert sm.smoothed_value == 110.0
 
     @pytest.mark.asyncio
-    async def test_dedup_identical_values(self):
+    async def test_dedup_identical_values(self) -> None:
         fake = FakePowermeter([100.0])
         sm = SmoothedPowermeter(fake, alpha=0.5)
 
@@ -130,7 +99,7 @@ class TestSmoothedPowermeter:
         assert result == [100.0]
 
     @pytest.mark.asyncio
-    async def test_dedup_same_sample_different_total_advances_ema(self):
+    async def test_dedup_same_sample_different_total_advances_ema(self) -> None:
         """When sample_id matches but raw_total differs, EMA should advance."""
         fake = FakePowermeter([100.0, 50.0])
         sm = SmoothedPowermeter(fake, alpha=0.5)
@@ -145,7 +114,7 @@ class TestSmoothedPowermeter:
         assert sm.smoothed_value == 165.0
 
     @pytest.mark.asyncio
-    async def test_reset_clears_state(self):
+    async def test_reset_clears_state(self) -> None:
         fake = FakePowermeter([100.0])
         sm = SmoothedPowermeter(fake, alpha=0.5)
 
@@ -161,7 +130,7 @@ class TestSmoothedPowermeter:
         assert sm.smoothed_value == 200.0
 
     @pytest.mark.asyncio
-    async def test_proportional_phase_distribution(self):
+    async def test_proportional_phase_distribution(self) -> None:
         fake = FakePowermeter([60.0, 30.0, 10.0])  # total=100
         sm = SmoothedPowermeter(fake, alpha=0.5)
 
@@ -176,7 +145,7 @@ class TestSmoothedPowermeter:
         assert result == pytest.approx([60.0, 30.0, 60.0])
 
     @pytest.mark.asyncio
-    async def test_all_zero_returns_raw(self):
+    async def test_all_zero_returns_raw(self) -> None:
         fake = FakePowermeter([0.0, 0.0, 0.0])
         sm = SmoothedPowermeter(fake, alpha=0.5)
 
@@ -184,7 +153,7 @@ class TestSmoothedPowermeter:
         assert result == [0.0, 0.0, 0.0]
 
     @pytest.mark.asyncio
-    async def test_lifecycle_delegation(self):
+    async def test_lifecycle_delegation(self) -> None:
         fake = FakePowermeter([100.0])
         sm = SmoothedPowermeter(fake, alpha=0.5)
 
@@ -207,7 +176,7 @@ class TestSmoothedPowermeter:
 
 class TestDeadbandPowermeter:
     @pytest.mark.asyncio
-    async def test_values_within_deadband_return_zeros(self):
+    async def test_values_within_deadband_return_zeros(self) -> None:
         fake = FakePowermeter([5.0, -3.0, 2.0])  # total=4
         db = DeadbandPowermeter(fake, deadband=20.0)
 
@@ -215,7 +184,7 @@ class TestDeadbandPowermeter:
         assert result == [0.0, 0.0, 0.0]
 
     @pytest.mark.asyncio
-    async def test_values_outside_deadband_pass_through(self):
+    async def test_values_outside_deadband_pass_through(self) -> None:
         fake = FakePowermeter([50.0, 30.0, -10.0])  # total=70
         db = DeadbandPowermeter(fake, deadband=20.0)
 
@@ -223,7 +192,7 @@ class TestDeadbandPowermeter:
         assert result == [50.0, 30.0, -10.0]
 
     @pytest.mark.asyncio
-    async def test_zero_deadband_disables_gating(self):
+    async def test_zero_deadband_disables_gating(self) -> None:
         fake = FakePowermeter([1.0, -1.0, 0.5])  # total=0.5
         db = DeadbandPowermeter(fake, deadband=0.0)
 
@@ -231,7 +200,7 @@ class TestDeadbandPowermeter:
         assert result == [1.0, -1.0, 0.5]
 
     @pytest.mark.asyncio
-    async def test_negative_total_within_deadband(self):
+    async def test_negative_total_within_deadband(self) -> None:
         fake = FakePowermeter([-5.0, -3.0, 2.0])  # total=-6
         db = DeadbandPowermeter(fake, deadband=20.0)
 
@@ -239,7 +208,7 @@ class TestDeadbandPowermeter:
         assert result == [0.0, 0.0, 0.0]
 
     @pytest.mark.asyncio
-    async def test_exactly_at_threshold_returns_zeros(self):
+    async def test_exactly_at_threshold_returns_zeros(self) -> None:
         fake = FakePowermeter([19.9])
         db = DeadbandPowermeter(fake, deadband=20.0)
 
@@ -247,7 +216,7 @@ class TestDeadbandPowermeter:
         assert result == [0.0]
 
     @pytest.mark.asyncio
-    async def test_lifecycle_delegation(self):
+    async def test_lifecycle_delegation(self) -> None:
         fake = FakePowermeter([100.0])
         db = DeadbandPowermeter(fake, deadband=20.0)
 

--- a/src/astrameter/powermeter/wrappers/throttling.py
+++ b/src/astrameter/powermeter/wrappers/throttling.py
@@ -21,7 +21,9 @@ class ThrottledPowermeter(PowermeterWrapper):
     a controlled rate.
     """
 
-    def __init__(self, wrapped_powermeter: Powermeter, throttle_interval: float = 0.0):
+    def __init__(
+        self, wrapped_powermeter: Powermeter, throttle_interval: float = 0.0
+    ) -> None:
         super().__init__(wrapped_powermeter)
         self.throttle_interval = throttle_interval
 

--- a/src/astrameter/powermeter/wrappers/throttling_test.py
+++ b/src/astrameter/powermeter/wrappers/throttling_test.py
@@ -6,7 +6,7 @@ import pytest
 from .throttling import ThrottledPowermeter
 
 
-async def test_no_throttling_always_fetches_fresh_values():
+async def test_no_throttling_always_fetches_fresh_values() -> None:
     """Test that when throttling is disabled, fresh values are always fetched."""
     mock_pm = Mock()
     mock_pm.get_powermeter_watts = AsyncMock(return_value=[100.0, 200.0, 300.0])
@@ -21,7 +21,7 @@ async def test_no_throttling_always_fetches_fresh_values():
     assert mock_pm.get_powermeter_watts.call_count == 2
 
 
-async def test_throttling_waits_for_interval():
+async def test_throttling_waits_for_interval() -> None:
     """Test that throttling waits for remaining time before fetching new values."""
     mock_pm = Mock()
     mock_pm.get_powermeter_watts = AsyncMock(return_value=[100.0, 200.0, 300.0])
@@ -44,7 +44,7 @@ async def test_throttling_waits_for_interval():
     assert elapsed >= 0.2
 
 
-async def test_throttling_fetches_fresh_after_interval():
+async def test_throttling_fetches_fresh_after_interval() -> None:
     """Test that fresh values are fetched after throttling interval passes."""
     mock_pm = Mock()
     mock_pm.get_powermeter_watts = AsyncMock(return_value=[100.0, 200.0, 300.0])
@@ -64,7 +64,7 @@ async def test_throttling_fetches_fresh_after_interval():
     assert mock_pm.get_powermeter_watts.call_count == 2
 
 
-async def test_wait_for_message_passthrough():
+async def test_wait_for_message_passthrough() -> None:
     """Test that wait_for_message is passed through to wrapped powermeter."""
     mock_pm = Mock()
     mock_pm.wait_for_message = AsyncMock()
@@ -74,7 +74,7 @@ async def test_wait_for_message_passthrough():
     mock_pm.wait_for_message.assert_called_once_with(30)
 
 
-async def test_wait_for_next_message_passthrough():
+async def test_wait_for_next_message_passthrough() -> None:
     mock_pm = Mock()
     mock_pm.wait_for_next_message = AsyncMock()
     throttled = ThrottledPowermeter(mock_pm, throttle_interval=1.0)
@@ -83,7 +83,7 @@ async def test_wait_for_next_message_passthrough():
     mock_pm.wait_for_next_message.assert_called_once_with(15)
 
 
-async def test_exception_handling_with_cache():
+async def test_exception_handling_with_cache() -> None:
     """Test that cached values are returned on error after a successful fetch."""
     mock_pm = Mock()
     mock_pm.start = AsyncMock()
@@ -102,7 +102,7 @@ async def test_exception_handling_with_cache():
     assert result2 == [100.0, 200.0]
 
 
-async def test_exception_raises_without_cache():
+async def test_exception_raises_without_cache() -> None:
     """Test that exceptions propagate if no cached values exist."""
     mock_pm = Mock()
     mock_pm.start = AsyncMock()
@@ -116,7 +116,7 @@ async def test_exception_raises_without_cache():
         await throttled.get_powermeter_watts()
 
 
-async def test_throttled_raw_bypasses_get_and_throttle_coalescing():
+async def test_throttled_raw_bypasses_get_and_throttle_coalescing() -> None:
     mock_pm = Mock()
     get_m = AsyncMock(return_value=[1.0])
     raw_m = AsyncMock(return_value=[2.0, 3.0, 4.0])

--- a/src/astrameter/powermeter/wrappers/transform_test.py
+++ b/src/astrameter/powermeter/wrappers/transform_test.py
@@ -6,7 +6,7 @@ from .transform import TransformedPowermeter
 
 
 @pytest.fixture
-def mock_powermeter():
+def mock_powermeter() -> Mock:
     pm = Mock()
     pm.get_powermeter_watts = AsyncMock()
     pm.get_powermeter_watts_raw = AsyncMock()
@@ -15,7 +15,9 @@ def mock_powermeter():
     return pm
 
 
-async def test_transformed_raw_matches_wrapped_without_offset(mock_powermeter):
+async def test_transformed_raw_matches_wrapped_without_offset(
+    mock_powermeter: Mock,
+) -> None:
     mock_powermeter.get_powermeter_watts.return_value = [110.0, 210.0, 310.0]
     mock_powermeter.get_powermeter_watts_raw.return_value = [100.0, 200.0, 300.0]
     t = TransformedPowermeter(mock_powermeter, [10.0], [1.0])
@@ -24,37 +26,37 @@ async def test_transformed_raw_matches_wrapped_without_offset(mock_powermeter):
     mock_powermeter.get_powermeter_watts_raw.assert_awaited_once()
 
 
-async def test_identity_single_phase(mock_powermeter):
+async def test_identity_single_phase(mock_powermeter: Mock) -> None:
     mock_powermeter.get_powermeter_watts.return_value = [500.0]
     t = TransformedPowermeter(mock_powermeter, [0.0], [1.0])
     assert await t.get_powermeter_watts() == [500.0]
 
 
-async def test_identity_three_phase(mock_powermeter):
+async def test_identity_three_phase(mock_powermeter: Mock) -> None:
     mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
     t = TransformedPowermeter(mock_powermeter, [0.0], [1.0])
     assert await t.get_powermeter_watts() == [100.0, 200.0, 300.0]
 
 
-async def test_offset_only_broadcast(mock_powermeter):
+async def test_offset_only_broadcast(mock_powermeter: Mock) -> None:
     mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
     t = TransformedPowermeter(mock_powermeter, [10.0], [1.0])
     assert await t.get_powermeter_watts() == [110.0, 210.0, 310.0]
 
 
-async def test_negative_offset(mock_powermeter):
+async def test_negative_offset(mock_powermeter: Mock) -> None:
     mock_powermeter.get_powermeter_watts.return_value = [1050.0]
     t = TransformedPowermeter(mock_powermeter, [-50.0], [1.0])
     assert await t.get_powermeter_watts() == [1000.0]
 
 
-async def test_multiplier_only_broadcast(mock_powermeter):
+async def test_multiplier_only_broadcast(mock_powermeter: Mock) -> None:
     mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
     t = TransformedPowermeter(mock_powermeter, [0.0], [2.0])
     assert await t.get_powermeter_watts() == [200.0, 400.0, 600.0]
 
 
-async def test_both_offset_and_multiplier(mock_powermeter):
+async def test_both_offset_and_multiplier(mock_powermeter: Mock) -> None:
     # 1050 * 0.95 + (-50) = 947.5
     mock_powermeter.get_powermeter_watts.return_value = [1050.0]
     t = TransformedPowermeter(mock_powermeter, [-50.0], [0.95])
@@ -62,19 +64,19 @@ async def test_both_offset_and_multiplier(mock_powermeter):
     assert result[0] == pytest.approx(947.5)
 
 
-async def test_negative_meter_values_with_multiplier(mock_powermeter):
+async def test_negative_meter_values_with_multiplier(mock_powermeter: Mock) -> None:
     mock_powermeter.get_powermeter_watts.return_value = [-100.0]
     t = TransformedPowermeter(mock_powermeter, [0.0], [2.0])
     assert await t.get_powermeter_watts() == [-200.0]
 
 
-async def test_per_phase_offsets(mock_powermeter):
+async def test_per_phase_offsets(mock_powermeter: Mock) -> None:
     mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
     t = TransformedPowermeter(mock_powermeter, [-10.0, -20.0, -30.0], [1.0])
     assert await t.get_powermeter_watts() == [90.0, 180.0, 270.0]
 
 
-async def test_per_phase_multipliers(mock_powermeter):
+async def test_per_phase_multipliers(mock_powermeter: Mock) -> None:
     mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
     t = TransformedPowermeter(mock_powermeter, [0.0], [1.05, 1.02, 1.03])
     result = await t.get_powermeter_watts()
@@ -83,13 +85,13 @@ async def test_per_phase_multipliers(mock_powermeter):
     assert result[2] == pytest.approx(309.0)
 
 
-async def test_mixed_single_offset_per_phase_multipliers(mock_powermeter):
+async def test_mixed_single_offset_per_phase_multipliers(mock_powermeter: Mock) -> None:
     mock_powermeter.get_powermeter_watts.return_value = [100.0, 200.0, 300.0]
     t = TransformedPowermeter(mock_powermeter, [10.0], [1.0, 2.0, 3.0])
     assert await t.get_powermeter_watts() == [110.0, 410.0, 910.0]
 
 
-async def test_phase_count_mismatch_does_not_crash(mock_powermeter):
+async def test_phase_count_mismatch_does_not_crash(mock_powermeter: Mock) -> None:
     """Per-phase count != returned value count should warn, not raise."""
     mock_powermeter.get_powermeter_watts.return_value = [100.0]
     t = TransformedPowermeter(mock_powermeter, [10.0, 20.0, 30.0], [1.0])
@@ -98,36 +100,36 @@ async def test_phase_count_mismatch_does_not_crash(mock_powermeter):
     assert result == [110.0]
 
 
-async def test_int_values_from_powermeter(mock_powermeter):
+async def test_int_values_from_powermeter(mock_powermeter: Mock) -> None:
     """Many powermeters return int values; transform should handle them."""
     mock_powermeter.get_powermeter_watts.return_value = [100, 200]
     t = TransformedPowermeter(mock_powermeter, [0.5], [1.0])
     assert await t.get_powermeter_watts() == [100.5, 200.5]
 
 
-async def test_wait_for_message_passthrough(mock_powermeter):
+async def test_wait_for_message_passthrough(mock_powermeter: Mock) -> None:
     t = TransformedPowermeter(mock_powermeter, [0.0], [1.0])
     await t.wait_for_message(timeout=30)
     mock_powermeter.wait_for_message.assert_called_once_with(30)
 
 
-async def test_wait_for_message_default_timeout(mock_powermeter):
+async def test_wait_for_message_default_timeout(mock_powermeter: Mock) -> None:
     t = TransformedPowermeter(mock_powermeter, [0.0], [1.0])
     await t.wait_for_message()
     mock_powermeter.wait_for_message.assert_called_once_with(5)
 
 
-async def test_wait_for_next_message_passthrough(mock_powermeter):
+async def test_wait_for_next_message_passthrough(mock_powermeter: Mock) -> None:
     t = TransformedPowermeter(mock_powermeter, [0.0], [1.0])
     await t.wait_for_next_message(timeout=10)
     mock_powermeter.wait_for_next_message.assert_called_once_with(10)
 
 
-def test_empty_offsets_raises(mock_powermeter):
+def test_empty_offsets_raises(mock_powermeter: Mock) -> None:
     with pytest.raises(ValueError, match="offsets must be a non-empty list"):
         TransformedPowermeter(mock_powermeter, [], [1.0])
 
 
-def test_empty_multipliers_raises(mock_powermeter):
+def test_empty_multipliers_raises(mock_powermeter: Mock) -> None:
     with pytest.raises(ValueError, match="multipliers must be a non-empty list"):
         TransformedPowermeter(mock_powermeter, [0.0], [])

--- a/src/astrameter/powermeter/ws_client.py
+++ b/src/astrameter/powermeter/ws_client.py
@@ -1,0 +1,130 @@
+"""The connect/read/reconnect loop the WebSocket-fed power sources share.
+
+Home Assistant and the HomeWizard P1 dongle both push measurements over a
+WebSocket that has to be reconnected for the life of the process. Everything
+that is the same either way — owning the session and the reader task, closing
+one message type on another, logging the drop and backing off — lives here, so
+a fix to one source cannot leave the other behind.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from contextlib import AbstractAsyncContextManager
+
+import aiohttp
+
+from .base import PushPowermeter
+
+logger = logging.getLogger("astrameter")
+
+#: How long to wait before dialling again after the connection drops.
+RECONNECT_DELAY_SECONDS = 5.0
+
+#: WebSocket heartbeat (seconds).  With this set, aiohttp sends ping frames at
+#: this interval and forcibly closes the connection if no pong is received
+#: within 2x the heartbeat — catching half-open TCP sockets that would
+#: otherwise freeze ``async for msg in ws`` forever.
+WS_HEARTBEAT_SECONDS = 30.0
+
+#: Frame types that mean this connection is over.
+_CLOSING = (
+    aiohttp.WSMsgType.ERROR,
+    aiohttp.WSMsgType.CLOSE,
+    aiohttp.WSMsgType.CLOSING,
+    aiohttp.WSMsgType.CLOSED,
+)
+
+WebSocket = aiohttp.ClientWebSocketResponse[bool]
+
+
+async def cancel(task: asyncio.Task | None) -> None:
+    """Cancel *task* and wait for it to finish unwinding."""
+    if task is None:
+        return
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+class WebSocketPowermeter(PushPowermeter):
+    """A push source fed by a WebSocket this class keeps re-dialling.
+
+    A subclass says where to connect (:meth:`_connect`), what a text frame
+    means (:meth:`_on_text`), and what to forget when the connection goes
+    (:meth:`_on_disconnect`); the loop around all three is inherited.
+    """
+
+    #: Host this source talks to, named in the connection log lines.
+    ip: str
+
+    #: What the log lines call this source.
+    _LOG_NAME = "WebSocket"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._session: aiohttp.ClientSession | None = None
+        self._ws_task: asyncio.Task[None] | None = None
+        # Read-only health flag for stream_online(): set by the subclass once
+        # the connection is up and subscribed, cleared whenever it drops.
+        self._connected = False
+
+    # -- what a subclass fills in --------------------------------------
+
+    def _connect(
+        self, session: aiohttp.ClientSession
+    ) -> AbstractAsyncContextManager[WebSocket]:
+        """Open the WebSocket — ``session.ws_connect(...)``, unawaited."""
+        raise NotImplementedError
+
+    async def _on_text(self, ws: WebSocket, raw: str) -> None:
+        """Handle one text frame."""
+        raise NotImplementedError
+
+    def _on_disconnect(self) -> None:
+        """Drop whatever the closed connection made true. Called after every drop."""
+
+    # -- lifecycle -----------------------------------------------------
+
+    async def start(self) -> None:
+        if self._session:
+            return
+        self._connected = False
+        self._session = aiohttp.ClientSession()
+        self._ws_task = asyncio.create_task(self._ws_loop())
+
+    async def stop(self) -> None:
+        # Cleared before cancelling: cancellation leaves the loop before its
+        # own reset runs, so stream_online() would otherwise stay True.
+        self._connected = False
+        await cancel(self._ws_task)
+        self._ws_task = None
+        if self._session:
+            await self._session.close()
+            self._session = None
+
+    async def _ws_loop(self) -> None:
+        while True:
+            try:
+                assert self._session is not None
+                async with self._connect(self._session) as ws:
+                    logger.info("%s WebSocket connected to %s", self._LOG_NAME, self.ip)
+                    await self._read(ws)
+                    logger.info("%s WebSocket closed", self._LOG_NAME)
+            except Exception as exc:
+                logger.error(
+                    "%s WebSocket error: %s", self._LOG_NAME, exc, exc_info=True
+                )
+            self._connected = False
+            self._on_disconnect()
+            await asyncio.sleep(RECONNECT_DELAY_SECONDS)
+
+    async def _read(self, ws: WebSocket) -> None:
+        """Feed text frames to :meth:`_on_text` until the peer closes."""
+        async for msg in ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                await self._on_text(ws, msg.data)
+            elif msg.type in _CLOSING:
+                break

--- a/src/astrameter/powermeter/ws_client.py
+++ b/src/astrameter/powermeter/ws_client.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager
+from typing import Any, Protocol
 
 import aiohttp
 
@@ -37,7 +39,25 @@ _CLOSING = (
     aiohttp.WSMsgType.CLOSED,
 )
 
-WebSocket = aiohttp.ClientWebSocketResponse[bool]
+
+class WebSocket(Protocol):
+    """What a connection has to offer the read loop and the message handlers.
+
+    Stated structurally rather than as ``aiohttp.ClientWebSocketResponse`` so
+    a test can drive the same handlers with a few canned frames.
+    """
+
+    def __aiter__(self) -> AsyncIterator[Any]: ...
+
+    async def send_json(self, data: Any) -> None: ...
+
+    async def close(self) -> bool: ...
+
+
+#: What ``session.ws_connect(...)`` hands back, unawaited. A concrete aiohttp
+#: type rather than the protocol above: only the handlers need to accept a
+#: stand-in, and the connection itself is always the real thing.
+WebSocketConnect = AbstractAsyncContextManager[aiohttp.ClientWebSocketResponse[bool]]
 
 
 async def cancel(task: asyncio.Task | None) -> None:
@@ -73,9 +93,7 @@ class WebSocketPowermeter(PushPowermeter):
 
     # -- what a subclass fills in --------------------------------------
 
-    def _connect(
-        self, session: aiohttp.ClientSession
-    ) -> AbstractAsyncContextManager[WebSocket]:
+    def _connect(self, session: aiohttp.ClientSession) -> WebSocketConnect:
         """Open the WebSocket — ``session.ws_connect(...)``, unawaited."""
         raise NotImplementedError
 

--- a/src/astrameter/shelly/shelly.py
+++ b/src/astrameter/shelly/shelly.py
@@ -13,7 +13,7 @@ from astrameter.config.logger import debug_traceback, logger
 from astrameter.config.settings import ConfiguredPowermeter
 from astrameter.meter_pool import powermeter_for, powermeter_name, read_fresh
 from astrameter.request_dedupe import RequestDeduplicator
-from astrameter.udp_server import UdpServer
+from astrameter.udp_server import DatagramSink, UdpServer
 
 BATTERY_INACTIVE_TIMEOUT_SECONDS = 120
 POLL_INTERVAL_EMA_ALPHA = 0.3
@@ -252,7 +252,7 @@ class Shelly:
             )
 
     async def _safe_handle_request(
-        self, data: bytes, addr: tuple[str, int], transport: asyncio.DatagramTransport
+        self, data: bytes, addr: tuple[str, int], transport: DatagramSink
     ) -> None:
         try:
             await self._handle_request(data, addr, transport)
@@ -260,7 +260,7 @@ class Shelly:
             logger.exception("Error handling Shelly request from %s", addr)
 
     async def _handle_request(
-        self, data: bytes, addr: tuple[str, int], transport: asyncio.DatagramTransport
+        self, data: bytes, addr: tuple[str, int], transport: DatagramSink
     ) -> None:
         battery_ip = addr[0]
         poll_interval = self._track_battery_seen(addr)

--- a/src/astrameter/shelly/shelly.py
+++ b/src/astrameter/shelly/shelly.py
@@ -9,14 +9,45 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
 
-from astrameter.config import ClientFilter
 from astrameter.config.logger import debug_traceback, logger
-from astrameter.powermeter import Powermeter
+from astrameter.config.settings import ConfiguredPowermeter
+from astrameter.meter_pool import powermeter_for, powermeter_name, read_fresh
 from astrameter.request_dedupe import RequestDeduplicator
 from astrameter.udp_server import UdpServer
 
 BATTERY_INACTIVE_TIMEOUT_SECONDS = 120
 POLL_INTERVAL_EMA_ALPHA = 0.3
+
+
+def _decode_request(data: bytes, addr: tuple[str, int]) -> dict[str, Any] | None:
+    """The Shelly RPC call in *data*, or ``None`` when it is not one.
+
+    A poll carries a channel index at ``params.id``; a datagram without it is
+    something else on the port and gets no reply.
+    """
+    try:
+        request = json.loads(data.decode())
+    except UnicodeDecodeError:
+        logger.debug("Ignoring non-UTF-8 datagram from %s:%s", addr[0], addr[1])
+        return None
+    except json.JSONDecodeError:
+        logger.debug("Ignoring non-JSON datagram from %s:%s", addr[0], addr[1])
+        return None
+    if not isinstance(request, dict) or not isinstance(
+        request.get("params", {}).get("id"), int
+    ):
+        return None
+    logger.debug("Parsed request from %s: %s", addr[0], request)
+    return request
+
+
+def _three_phases(powers: list[float]) -> tuple[float, float, float]:
+    """*powers* as three floats: a single reading is phase A, anything else zero."""
+    if len(powers) == 1:
+        return float(powers[0]), 0.0, 0.0
+    if len(powers) >= 3:
+        return float(powers[0]), float(powers[1]), float(powers[2])
+    return 0.0, 0.0, 0.0
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -52,12 +83,12 @@ class ShellySnapshot:
 class Shelly:
     def __init__(
         self,
-        powermeters: list[tuple[Powermeter, ClientFilter, bool]],
+        powermeters: list[ConfiguredPowermeter],
         udp_port: int,
-        device_id,
+        device_id: str,
         dedupe_time_window: float = 0.0,
         device_type: str = "",
-    ):
+    ) -> None:
         self._udp_port = udp_port
         self._device_id = device_id
         self._device_type = device_type
@@ -79,7 +110,7 @@ class Shelly:
         # in-flight handler per battery answers per reading; duplicates drop.
         self._inflight_batteries: set[str] = set()
         self._stopped = asyncio.Event()
-        self._inactive_check_task = None
+        self._inactive_check_task: asyncio.Task[None] | None = None
         self._dedupe_time_window = max(0.0, dedupe_time_window)
         self._dedup: RequestDeduplicator[str] = RequestDeduplicator(
             self._dedupe_time_window
@@ -89,7 +120,7 @@ class Shelly:
         self._started_at: float = 0.0
         self._running: bool = False
 
-    def _calculate_derived_values(self, power):
+    def _calculate_derived_values(self, power: float) -> float:
         decimal_point_enforcer = 0.001
         if abs(power) < 0.1:
             return decimal_point_enforcer
@@ -100,7 +131,9 @@ class Shelly:
             1,
         )
 
-    def _create_em_response(self, request_id, powers):
+    def _create_em_response(
+        self, request_id: Any, powers: list[float]
+    ) -> dict[str, Any]:
         if len(powers) == 1:
             powers = [powers[0], 0, 0]
         elif len(powers) != 3:
@@ -129,7 +162,9 @@ class Shelly:
             },
         }
 
-    def _create_em1_response(self, request_id, powers):
+    def _create_em1_response(
+        self, request_id: Any, powers: list[float]
+    ) -> dict[str, Any]:
         total_power = round(sum(powers), 3)
         total_power = total_power + (
             0.001 if total_power == round(total_power) or total_power == 0 else 0
@@ -144,7 +179,7 @@ class Shelly:
             },
         }
 
-    def _track_battery_seen(self, addr) -> float | None:
+    def _track_battery_seen(self, addr: tuple[str, int]) -> float | None:
         battery_ip = addr[0]
         now = time.time()
 
@@ -185,7 +220,7 @@ class Shelly:
 
         return poll_interval
 
-    def _log_inactive_batteries(self):
+    def _log_inactive_batteries(self) -> None:
         now = time.time()
         newly_inactive_batteries = []
 
@@ -216,133 +251,107 @@ class Shelly:
                 "event_listener failed for %s: %s", battery_ip, exc, exc_info=True
             )
 
-    async def _safe_handle_request(self, data, addr, transport):
+    async def _safe_handle_request(
+        self, data: bytes, addr: tuple[str, int], transport: asyncio.DatagramTransport
+    ) -> None:
         try:
-            await self._handle_request(transport, data, addr)
+            await self._handle_request(data, addr, transport)
         except Exception:
             logger.exception("Error handling Shelly request from %s", addr)
 
-    async def _handle_request(self, transport, data, addr):
+    async def _handle_request(
+        self, data: bytes, addr: tuple[str, int], transport: asyncio.DatagramTransport
+    ) -> None:
+        battery_ip = addr[0]
         poll_interval = self._track_battery_seen(addr)
 
-        if not self._dedup.should_process(addr[0]):
+        if not self._dedup.should_process(battery_ip):
             logger.debug("Ignoring request from %s due to dedupe window", addr)
             return
 
-        try:
-            request_str = data.decode()
-        except UnicodeDecodeError:
-            logger.debug("Ignoring non-UTF-8 datagram from %s:%s", addr[0], addr[1])
+        request = _decode_request(data, addr)
+        if request is None:
             return
 
-        logger.debug(f"Received UDP message: {request_str}")
-        logger.debug(f"From: {addr[0]}:{addr[1]}")
+        configured = powermeter_for(self._powermeters, battery_ip)
+        if configured is None:
+            logger.warning("No powermeter found for client %s", battery_ip)
+            return
 
+        # Coalesce concurrent polls from the same battery.  If a handler for
+        # this battery is already parked awaiting the next meter reading, the
+        # reading has not been answered yet — letting this duplicate poll wait
+        # and respond too would feed the battery's zero-export loop the same
+        # stale error several times the moment the meter updates and wakes
+        # every parked handler, overshooting target.  Drop it;
+        # _track_battery_seen above already refreshed the liveness and
+        # poll-interval state, and the in-flight handler sends the one response
+        # for the next reading.
+        if battery_ip in self._inflight_batteries:
+            logger.debug(
+                "Coalescing Shelly poll from %s: a handler is already awaiting "
+                "the next meter reading; dropping this duplicate to avoid a "
+                "burst of readings",
+                addr,
+            )
+            return
+
+        self._inflight_batteries.add(battery_ip)
         try:
-            request = json.loads(request_str)
-            logger.debug(f"Parsed request: {json.dumps(request, indent=2)}")
-            if isinstance(request.get("params", {}).get("id"), int):
-                powermeter = None
-                wait_for_next_message = False
-                for pm, client_filter, wait_flag in self._powermeters:
-                    if client_filter.matches(addr[0]):
-                        powermeter = pm
-                        wait_for_next_message = wait_flag
-                        break
-                if powermeter is None:
-                    logger.warning(f"No powermeter found for client {addr[0]}")
-                    return
+            try:
+                powers = await read_fresh(configured)
+            except Exception as exc:
+                # Reading the meter can fail transiently (e.g. an HTTP source
+                # timing out). Log a one-liner at the normal level and reserve
+                # the full traceback for DEBUG so an outage doesn't flood the
+                # log with stack traces on every poll.
+                logger.warning(
+                    "Could not read meter values from %s (%s): %s",
+                    powermeter_name(configured.powermeter),
+                    battery_ip,
+                    exc,
+                    exc_info=debug_traceback(),
+                )
+                return
 
-                # Coalesce concurrent polls from the same battery.  If a handler
-                # for this battery is already parked awaiting the next meter
-                # reading, the reading has not been answered yet — letting this
-                # duplicate poll wait and respond too would feed the battery's
-                # zero-export loop the same stale error several times the moment
-                # the meter updates and wakes every parked handler, overshooting
-                # target.  Drop it; _track_battery_seen above already refreshed
-                # the liveness/poll-interval state, and the in-flight handler
-                # sends the one response for the next reading.
-                if addr[0] in self._inflight_batteries:
-                    logger.debug(
-                        "Coalescing Shelly poll from %s: a handler is already "
-                        "awaiting the next meter reading; dropping this "
-                        "duplicate to avoid a burst of readings",
-                        addr,
-                    )
-                    return
-                self._inflight_batteries.add(addr[0])
-                try:
-                    if wait_for_next_message:
-                        try:
-                            await powermeter.wait_for_next_message(timeout=2)
-                        except TimeoutError:
-                            logger.debug(
-                                "Powermeter %s produced no fresh message within "
-                                "2s; serving last known value",
-                                type(powermeter).__name__,
-                            )
-                    try:
-                        powers = await powermeter.get_powermeter_watts()
-                    except Exception as exc:
-                        # Reading the meter can fail transiently (e.g. an HTTP
-                        # source timing out). Log a one-liner at the normal level
-                        # and reserve the full traceback for DEBUG so an outage
-                        # doesn't flood the log with stack traces on every poll.
-                        logger.warning(
-                            "Could not read meter values from %s (%s): %s",
-                            type(powermeter).__name__,
-                            addr[0],
-                            exc,
-                            exc_info=debug_traceback(),
-                        )
-                        return
+            response = self._response_for(request, powers)
+            if response is None:
+                return
+            response_json = json.dumps(response, separators=(",", ":"))
+            logger.debug("Sending response: %s", response_json)
+            transport.sendto(response_json.encode(), addr)
 
-                    if request.get("method") == "EM.GetStatus":
-                        response = self._create_em_response(request["id"], powers)
-                    elif request.get("method") == "EM1.GetStatus":
-                        response = self._create_em1_response(request["id"], powers)
-                    else:
-                        return
+            l1, l2, l3 = _three_phases(powers)
+            self._call_event_listener(
+                battery_ip,
+                {
+                    "grid_power": {
+                        "l1": l1,
+                        "l2": l2,
+                        "l3": l3,
+                        "total": l1 + l2 + l3,
+                    },
+                    "active": battery_ip not in self._inactive_batteries,
+                    "poll_interval": poll_interval,
+                    "last_seen": datetime.now(timezone.utc).isoformat(),
+                    "battery_count": len(self._battery_last_seen),
+                },
+            )
+        finally:
+            self._inflight_batteries.discard(battery_ip)
 
-                    response_json = json.dumps(response, separators=(",", ":"))
-                    logger.debug(f"Sending response: {response_json}")
-                    response_data = response_json.encode()
-                    transport.sendto(response_data, addr)
+    def _response_for(
+        self, request: dict[str, Any], powers: list[float]
+    ) -> dict[str, Any] | None:
+        """The reply *request* asks for, or ``None`` for a method we do not serve."""
+        method = request.get("method")
+        if method == "EM.GetStatus":
+            return self._create_em_response(request["id"], powers)
+        if method == "EM1.GetStatus":
+            return self._create_em1_response(request["id"], powers)
+        return None
 
-                    battery_ip = addr[0]
-                    if len(powers) == 1:
-                        grid_l1, grid_l2, grid_l3 = powers[0], 0.0, 0.0
-                    elif len(powers) >= 3:
-                        grid_l1, grid_l2, grid_l3 = (
-                            float(powers[0]),
-                            float(powers[1]),
-                            float(powers[2]),
-                        )
-                    else:
-                        grid_l1, grid_l2, grid_l3 = 0.0, 0.0, 0.0
-                    self._call_event_listener(
-                        battery_ip,
-                        {
-                            "grid_power": {
-                                "l1": grid_l1,
-                                "l2": grid_l2,
-                                "l3": grid_l3,
-                                "total": grid_l1 + grid_l2 + grid_l3,
-                            },
-                            "active": battery_ip not in self._inactive_batteries,
-                            "poll_interval": poll_interval,
-                            "last_seen": datetime.now(timezone.utc).isoformat(),
-                            "battery_count": len(self._battery_last_seen),
-                        },
-                    )
-                finally:
-                    self._inflight_batteries.discard(addr[0])
-        except json.JSONDecodeError:
-            logger.error("Error: Invalid JSON")
-        except Exception:
-            logger.exception("Error processing message")
-
-    async def _inactive_check_loop(self):
+    async def _inactive_check_loop(self) -> None:
         try:
             while True:
                 await asyncio.sleep(1.0)
@@ -356,14 +365,14 @@ class Shelly:
         except asyncio.CancelledError:
             pass
 
-    async def start(self):
+    async def start(self) -> None:
         self._server = await UdpServer.serve(self._udp_port, self._safe_handle_request)
         self._stopped.clear()
         self._inactive_check_task = asyncio.create_task(self._inactive_check_loop())
         self._udp_port = self._server.port or self._udp_port
         self._started_at = time.time()
         self._running = True
-        logger.info(f"Shelly emulator listening on UDP port {self._udp_port}...")
+        logger.info("Shelly emulator listening on UDP port %s", self._udp_port)
 
     @property
     def udp_port(self) -> int:
@@ -399,10 +408,10 @@ class Shelly:
             ),
         )
 
-    async def wait(self):
+    async def wait(self) -> None:
         await self._stopped.wait()
 
-    async def stop(self):
+    async def stop(self) -> None:
         if self._inactive_check_task:
             self._inactive_check_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/src/astrameter/shelly/shelly_test.py
+++ b/src/astrameter/shelly/shelly_test.py
@@ -12,7 +12,7 @@ from astrameter.shelly.shelly import BATTERY_INACTIVE_TIMEOUT_SECONDS, Shelly
 
 
 class DummyPowermeter(Powermeter):
-    async def get_powermeter_watts(self):
+    async def get_powermeter_watts(self) -> list[float]:
         return [1.0]
 
 
@@ -39,13 +39,13 @@ def _shelly() -> Shelly:
     )
 
 
-def test_status_snapshot_is_not_a_coroutine_function():
+def test_status_snapshot_is_not_a_coroutine_function() -> None:
     """The builder shares the loop with the UDP handlers; an ``await`` in it
     would tear the snapshot across two polls."""
     assert not inspect.iscoroutinefunction(Shelly.status_snapshot)
 
 
-async def test_status_snapshot_reports_registered_battery():
+async def test_status_snapshot_reports_registered_battery() -> None:
     shelly = _shelly()
     transport = _FakeTransport()
     await shelly._handle_request(REQUEST, ("127.0.0.1", 54321), transport)
@@ -73,7 +73,7 @@ async def test_status_snapshot_reports_registered_battery():
     assert battery.in_flight is True
 
 
-async def test_status_snapshot_batteries_sorted_and_marked_inactive():
+async def test_status_snapshot_batteries_sorted_and_marked_inactive() -> None:
     shelly = _shelly()
     transport = _FakeTransport()
     for ip in ("127.0.0.2", "127.0.0.1"):
@@ -88,7 +88,7 @@ async def test_status_snapshot_batteries_sorted_and_marked_inactive():
     assert snap.batteries[1].last_seen_age > BATTERY_INACTIVE_TIMEOUT_SECONDS
 
 
-async def test_status_snapshot_is_detached_from_the_device():
+async def test_status_snapshot_is_detached_from_the_device() -> None:
     shelly = _shelly()
     transport = _FakeTransport()
     await shelly._handle_request(REQUEST, ("127.0.0.1", 54321), transport)
@@ -107,7 +107,7 @@ async def test_status_snapshot_is_detached_from_the_device():
     assert snap.batteries[0].active is True
 
 
-async def test_running_tracks_start_and_stop():
+async def test_running_tracks_start_and_stop() -> None:
     shelly = Shelly([], udp_port=0, device_id="test")
     assert shelly.status_snapshot().started_at is None
 

--- a/src/astrameter/shelly/shelly_test.py
+++ b/src/astrameter/shelly/shelly_test.py
@@ -6,6 +6,7 @@ from ipaddress import IPv4Network
 import pytest
 
 from astrameter.config import ClientFilter
+from astrameter.config.settings import ConfiguredPowermeter
 from astrameter.powermeter import Powermeter
 from astrameter.shelly.shelly import BATTERY_INACTIVE_TIMEOUT_SECONDS, Shelly
 
@@ -31,7 +32,7 @@ REQUEST = json.dumps(
 def _shelly() -> Shelly:
     cf = ClientFilter([IPv4Network("127.0.0.0/8")])
     return Shelly(
-        [(DummyPowermeter(), cf, False)],
+        [ConfiguredPowermeter(DummyPowermeter(), cf, False)],
         udp_port=1010,
         device_id="test",
         device_type="shellypro3em_old",
@@ -47,7 +48,7 @@ def test_status_snapshot_is_not_a_coroutine_function():
 async def test_status_snapshot_reports_registered_battery():
     shelly = _shelly()
     transport = _FakeTransport()
-    await shelly._handle_request(transport, REQUEST, ("127.0.0.1", 54321))
+    await shelly._handle_request(REQUEST, ("127.0.0.1", 54321), transport)
 
     snap = shelly.status_snapshot()
     assert snap.device_id == "test"
@@ -65,7 +66,7 @@ async def test_status_snapshot_reports_registered_battery():
     assert battery.in_flight is False
 
     # A second poll establishes the cadence and the parked-handler flag shows.
-    await shelly._handle_request(transport, REQUEST, ("127.0.0.1", 54322))
+    await shelly._handle_request(REQUEST, ("127.0.0.1", 54322), transport)
     shelly._inflight_batteries.add("127.0.0.1")
     (battery,) = shelly.status_snapshot().batteries
     assert battery.poll_interval is not None
@@ -76,7 +77,7 @@ async def test_status_snapshot_batteries_sorted_and_marked_inactive():
     shelly = _shelly()
     transport = _FakeTransport()
     for ip in ("127.0.0.2", "127.0.0.1"):
-        await shelly._handle_request(transport, REQUEST, (ip, 54321))
+        await shelly._handle_request(REQUEST, (ip, 54321), transport)
 
     shelly._battery_last_seen["127.0.0.2"] -= BATTERY_INACTIVE_TIMEOUT_SECONDS + 1
     shelly._log_inactive_batteries()
@@ -90,7 +91,7 @@ async def test_status_snapshot_batteries_sorted_and_marked_inactive():
 async def test_status_snapshot_is_detached_from_the_device():
     shelly = _shelly()
     transport = _FakeTransport()
-    await shelly._handle_request(transport, REQUEST, ("127.0.0.1", 54321))
+    await shelly._handle_request(REQUEST, ("127.0.0.1", 54321), transport)
     snap = shelly.status_snapshot()
 
     with pytest.raises(dataclasses.FrozenInstanceError):
@@ -100,7 +101,7 @@ async def test_status_snapshot_is_detached_from_the_device():
 
     # The containers are copies: later device state cannot leak into a
     # snapshot already handed to a request handler, and vice versa.
-    await shelly._handle_request(transport, REQUEST, ("127.0.0.2", 54321))
+    await shelly._handle_request(REQUEST, ("127.0.0.2", 54321), transport)
     shelly._inactive_batteries.add("127.0.0.1")
     assert [b.ip for b in snap.batteries] == ["127.0.0.1"]
     assert snap.batteries[0].active is True

--- a/src/astrameter/shelly/shelly_udp_test.py
+++ b/src/astrameter/shelly/shelly_udp_test.py
@@ -5,6 +5,7 @@ import socket
 from ipaddress import IPv4Network
 
 from astrameter.config import ClientFilter
+from astrameter.config.settings import ConfiguredPowermeter
 from astrameter.powermeter import Powermeter, ThrottledPowermeter
 from astrameter.request_dedupe import RequestDeduplicator
 from astrameter.shelly.shelly import Shelly
@@ -66,7 +67,7 @@ async def test_dedupe_window_drops_rapid_duplicates():
     dummy = DummyPowermeter()
     cf = ClientFilter([IPv4Network("127.0.0.1/32")])
     shelly = Shelly(
-        [(dummy, cf, False)],
+        [ConfiguredPowermeter(dummy, cf, False)],
         udp_port=0,
         device_id="test",
         dedupe_time_window=10.0,
@@ -81,20 +82,20 @@ async def test_dedupe_window_drops_rapid_duplicates():
     addr = ("127.0.0.1", 54321)
 
     # First request: accepted and a response is sent.
-    await shelly._handle_request(transport, req, addr)
+    await shelly._handle_request(req, addr, transport)
     assert len(transport.sent) == 1
     assert dummy.call_count == 1
 
     # Second request within the window: dropped. Same source IP, different
     # port (mirroring real Shelly batteries which use ephemeral ports).
     clock.now = 1.0
-    await shelly._handle_request(transport, req, ("127.0.0.1", 54322))
+    await shelly._handle_request(req, ("127.0.0.1", 54322), transport)
     assert len(transport.sent) == 1
     assert dummy.call_count == 1
 
     # After the window elapses, requests are answered again.
     clock.now = 11.5
-    await shelly._handle_request(transport, req, ("127.0.0.1", 54323))
+    await shelly._handle_request(req, ("127.0.0.1", 54323), transport)
     assert len(transport.sent) == 2
     assert dummy.call_count == 2
 
@@ -108,7 +109,7 @@ async def test_concurrent_polls_from_one_battery_coalesce_over_udp():
     pm = ThrottledPowermeter(dummy, throttle_interval=0.3)
     cf = ClientFilter([IPv4Network("127.0.0.1/32")])
 
-    shelly = Shelly([(pm, cf, True)], udp_port=0, device_id="test")
+    shelly = Shelly([ConfiguredPowermeter(pm, cf, True)], udp_port=0, device_id="test")
     await shelly.start()
     port = shelly.udp_port
     assert port != 0, "Shelly should have bound to an actual port"
@@ -147,7 +148,7 @@ async def test_concurrent_polls_coalesce_to_a_single_response():
     goes out when the reading lands — not a four-deep burst."""
     pm = GatedPowermeter()
     cf = ClientFilter([IPv4Network("127.0.0.1/32")])
-    shelly = Shelly([(pm, cf, False)], udp_port=0, device_id="test")
+    shelly = Shelly([ConfiguredPowermeter(pm, cf, False)], udp_port=0, device_id="test")
     transport = _FakeTransport()
     req = json.dumps(
         {"id": 1, "src": "cli", "method": "EM.GetStatus", "params": {"id": 0}}
@@ -155,7 +156,7 @@ async def test_concurrent_polls_coalesce_to_a_single_response():
     addr = ("127.0.0.1", 54321)
 
     handlers = [
-        asyncio.create_task(shelly._handle_request(transport, req, addr))
+        asyncio.create_task(shelly._handle_request(req, addr, transport))
         for _ in range(4)
     ]
     await asyncio.sleep(0.05)
@@ -174,7 +175,7 @@ async def test_coalescing_is_per_battery():
     get their own response; one does not suppress the other."""
     pm = GatedPowermeter()
     cf = ClientFilter([IPv4Network("127.0.0.0/8")])
-    shelly = Shelly([(pm, cf, False)], udp_port=0, device_id="test")
+    shelly = Shelly([ConfiguredPowermeter(pm, cf, False)], udp_port=0, device_id="test")
     transport = _FakeTransport()
     req = json.dumps(
         {"id": 1, "src": "cli", "method": "EM.GetStatus", "params": {"id": 0}}
@@ -184,7 +185,7 @@ async def test_coalescing_is_per_battery():
     for ip in ("127.0.0.1", "127.0.0.2"):
         for _ in range(2):  # two concurrent polls per battery
             handlers.append(
-                asyncio.create_task(shelly._handle_request(transport, req, (ip, 5000)))
+                asyncio.create_task(shelly._handle_request(req, (ip, 5000), transport))
             )
 
     await asyncio.sleep(0.05)
@@ -201,18 +202,18 @@ async def test_poll_answered_again_after_burst_coalesced():
     pm = GatedPowermeter()
     pm.gate.set()  # reads resolve immediately
     cf = ClientFilter([IPv4Network("127.0.0.1/32")])
-    shelly = Shelly([(pm, cf, False)], udp_port=0, device_id="test")
+    shelly = Shelly([ConfiguredPowermeter(pm, cf, False)], udp_port=0, device_id="test")
     transport = _FakeTransport()
     req = json.dumps(
         {"id": 1, "src": "cli", "method": "EM.GetStatus", "params": {"id": 0}}
     ).encode()
     addr = ("127.0.0.1", 54321)
 
-    await shelly._handle_request(transport, req, addr)
+    await shelly._handle_request(req, addr, transport)
     assert len(transport.sent) == 1
     assert shelly._inflight_batteries == set()
 
-    await shelly._handle_request(transport, req, addr)
+    await shelly._handle_request(req, addr, transport)
     assert len(transport.sent) == 2
 
 
@@ -220,14 +221,18 @@ async def test_inflight_flag_cleared_when_meter_read_fails():
     """A failing meter read must still clear the in-flight flag, or the battery
     would be locked out of every future response."""
     cf = ClientFilter([IPv4Network("127.0.0.1/32")])
-    shelly = Shelly([(FailingPowermeter(), cf, False)], udp_port=0, device_id="test")
+    shelly = Shelly(
+        [ConfiguredPowermeter(FailingPowermeter(), cf, False)],
+        udp_port=0,
+        device_id="test",
+    )
     transport = _FakeTransport()
     req = json.dumps(
         {"id": 1, "src": "cli", "method": "EM.GetStatus", "params": {"id": 0}}
     ).encode()
     addr = ("127.0.0.1", 54321)
 
-    await shelly._handle_request(transport, req, addr)
+    await shelly._handle_request(req, addr, transport)
     assert transport.sent == []  # read failed, no response
     assert shelly._inflight_batteries == set()  # but the flag is cleared
 
@@ -236,14 +241,18 @@ async def _drive_failing_read(caplog, level):
     """Send one request to a Shelly backed by a failing meter and return the
     single captured log record (and the fake transport, to assert no reply)."""
     cf = ClientFilter([IPv4Network("127.0.0.1/32")])
-    shelly = Shelly([(FailingPowermeter(), cf, False)], udp_port=0, device_id="test")
+    shelly = Shelly(
+        [ConfiguredPowermeter(FailingPowermeter(), cf, False)],
+        udp_port=0,
+        device_id="test",
+    )
     transport = _FakeTransport()
     req = json.dumps(
         {"id": 1, "src": "cli", "method": "EM.GetStatus", "params": {"id": 0}}
     ).encode()
 
     with caplog.at_level(level, logger="astrameter"):
-        await shelly._handle_request(transport, req, ("127.0.0.1", 54321))
+        await shelly._handle_request(req, ("127.0.0.1", 54321), transport)
 
     records = [
         r for r in caplog.records if "Could not read meter values" in r.getMessage()

--- a/src/astrameter/shelly/shelly_udp_test.py
+++ b/src/astrameter/shelly/shelly_udp_test.py
@@ -4,6 +4,8 @@ import logging
 import socket
 from ipaddress import IPv4Network
 
+import pytest
+
 from astrameter.config import ClientFilter
 from astrameter.config.settings import ConfiguredPowermeter
 from astrameter.powermeter import Powermeter, ThrottledPowermeter
@@ -12,21 +14,21 @@ from astrameter.shelly.shelly import Shelly
 
 
 class DummyPowermeter(Powermeter):
-    def __init__(self):
+    def __init__(self) -> None:
         self.call_count = 0
 
-    async def get_powermeter_watts(self):
+    async def get_powermeter_watts(self) -> list[float]:
         self.call_count += 1
         return [1.0]
 
-    async def get_powermeter_watts_raw(self):
+    async def get_powermeter_watts_raw(self) -> list[float]:
         # Same physical reading as get_powermeter_watts; do not bump call_count so
         # throttling/dedupe tests that only observe get_powermeter_watts stay stable.
         return [1.0]
 
 
 class FailingPowermeter(Powermeter):
-    async def get_powermeter_watts(self):
+    async def get_powermeter_watts(self) -> list[float]:
         raise TimeoutError("Connection timeout to host http://192.168.2.17/")
 
 
@@ -35,11 +37,11 @@ class GatedPowermeter(Powermeter):
     read or WAIT_FOR_NEXT_MESSAGE holding the handler so concurrent polls pile
     up behind it."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.gate = asyncio.Event()
         self.call_count = 0
 
-    async def get_powermeter_watts(self):
+    async def get_powermeter_watts(self) -> list[float]:
         self.call_count += 1
         await self.gate.wait()
         return [42.0]
@@ -61,7 +63,7 @@ class _FakeTransport:
         self.sent.append((data, addr))
 
 
-async def test_dedupe_window_drops_rapid_duplicates():
+async def test_dedupe_window_drops_rapid_duplicates() -> None:
     # Drive the handler directly with a fake transport and a fake clock so
     # the test is independent of wall-clock time and real UDP delivery.
     dummy = DummyPowermeter()
@@ -100,7 +102,7 @@ async def test_dedupe_window_drops_rapid_duplicates():
     assert dummy.call_count == 2
 
 
-async def test_concurrent_polls_from_one_battery_coalesce_over_udp():
+async def test_concurrent_polls_from_one_battery_coalesce_over_udp() -> None:
     """End-to-end burst prevention over real UDP: a battery firing several
     polls while a throttled read is in flight gets exactly ONE response, not one
     per poll — repeating the same reading would feed its zero-export loop the
@@ -122,7 +124,7 @@ async def test_concurrent_polls_from_one_battery_coalesce_over_udp():
         responses = []
         timeouts = []
 
-        async def send_req(i):
+        async def send_req(i: int) -> None:
             try:
                 responses.append(await _send_req(port, i, timeout=1.0))
             except (TimeoutError, asyncio.TimeoutError):
@@ -143,7 +145,7 @@ async def test_concurrent_polls_from_one_battery_coalesce_over_udp():
         await shelly.stop()
 
 
-async def test_concurrent_polls_coalesce_to_a_single_response():
+async def test_concurrent_polls_coalesce_to_a_single_response() -> None:
     """Four polls from one battery pile up in a parked read; only ONE response
     goes out when the reading lands — not a four-deep burst."""
     pm = GatedPowermeter()
@@ -170,7 +172,7 @@ async def test_concurrent_polls_coalesce_to_a_single_response():
     assert shelly._inflight_batteries == set()  # flag cleared for the next read
 
 
-async def test_coalescing_is_per_battery():
+async def test_coalescing_is_per_battery() -> None:
     """Coalescing is keyed per battery IP: two batteries polling at once each
     get their own response; one does not suppress the other."""
     pm = GatedPowermeter()
@@ -196,7 +198,7 @@ async def test_coalescing_is_per_battery():
     assert shelly._inflight_batteries == set()
 
 
-async def test_poll_answered_again_after_burst_coalesced():
+async def test_poll_answered_again_after_burst_coalesced() -> None:
     """Dropping duplicates is not a lock-out: once the in-flight handler
     responds, the next poll is served normally."""
     pm = GatedPowermeter()
@@ -217,7 +219,7 @@ async def test_poll_answered_again_after_burst_coalesced():
     assert len(transport.sent) == 2
 
 
-async def test_inflight_flag_cleared_when_meter_read_fails():
+async def test_inflight_flag_cleared_when_meter_read_fails() -> None:
     """A failing meter read must still clear the in-flight flag, or the battery
     would be locked out of every future response."""
     cf = ClientFilter([IPv4Network("127.0.0.1/32")])
@@ -237,7 +239,9 @@ async def test_inflight_flag_cleared_when_meter_read_fails():
     assert shelly._inflight_batteries == set()  # but the flag is cleared
 
 
-async def _drive_failing_read(caplog, level):
+async def _drive_failing_read(
+    caplog: pytest.LogCaptureFixture, level: int
+) -> tuple[logging.LogRecord, _FakeTransport]:
     """Send one request to a Shelly backed by a failing meter and return the
     single captured log record (and the fake transport, to assert no reply)."""
     cf = ClientFilter([IPv4Network("127.0.0.1/32")])
@@ -261,7 +265,9 @@ async def _drive_failing_read(caplog, level):
     return records[0], transport
 
 
-async def test_meter_read_failure_logs_one_liner_without_traceback(caplog):
+async def test_meter_read_failure_logs_one_liner_without_traceback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     record, transport = await _drive_failing_read(caplog, logging.WARNING)
     # No response is sent to the battery when the meter read fails.
     assert transport.sent == []
@@ -271,14 +277,16 @@ async def test_meter_read_failure_logs_one_liner_without_traceback(caplog):
     assert "Connection timeout" in record.getMessage()
 
 
-async def test_meter_read_failure_includes_traceback_at_debug(caplog):
+async def test_meter_read_failure_includes_traceback_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     record, _ = await _drive_failing_read(caplog, logging.DEBUG)
     # At DEBUG the full traceback is attached.
     assert record.exc_info is not None
     assert record.exc_info[0] is TimeoutError
 
 
-async def _send_req(port, request_id, timeout=2.0):
+async def _send_req(port: int, request_id: int, timeout: float = 2.0) -> int:
     loop = asyncio.get_running_loop()
     transport, protocol = await loop.create_datagram_endpoint(
         lambda: _ClientProtocol(),
@@ -303,10 +311,10 @@ class _ClientProtocol(asyncio.DatagramProtocol):
     def __init__(self) -> None:
         self.received: asyncio.Future = asyncio.get_running_loop().create_future()
 
-    def datagram_received(self, data, addr):
+    def datagram_received(self, data: bytes, addr: tuple) -> None:
         if not self.received.done():
             self.received.set_result(data)
 
-    def error_received(self, exc):
+    def error_received(self, exc: Exception) -> None:
         if not self.received.done():
             self.received.set_exception(exc)

--- a/src/astrameter/simulator/b2500_steering_test.py
+++ b/src/astrameter/simulator/b2500_steering_test.py
@@ -10,6 +10,8 @@ here — see the module docstring.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 
 from astrameter.simulator.b2500_steering import (
@@ -24,10 +26,15 @@ from astrameter.simulator.b2500_steering import (
 ENV = 2500
 
 
-def _run(ctl: B2500SteeringController, grid_of, cycles: int, dt: float = 1.0):
+def _run(
+    ctl: B2500SteeringController,
+    grid_of: Callable[[int], int],
+    cycles: int,
+    dt: float = 1.0,
+) -> list[int]:
     """Drive *ctl* closed-loop; return the output after each cycle."""
     out = 0
-    trace = []
+    trace: list[int] = []
     for _ in range(cycles):
         out = ctl.step(grid_of(out), out, dt, max_power=ENV)
         trace.append(out)

--- a/src/astrameter/simulator/battery.py
+++ b/src/astrameter/simulator/battery.py
@@ -353,7 +353,7 @@ class BatterySimulator:
                 transport.close()
 
         response_fields, err = protocol.parse_request(data)
-        if err:
+        if response_fields is None:
             logger.debug("Battery %s: bad response: %s", self.mac, err)
             return None
 

--- a/src/astrameter/simulator/battery_test.py
+++ b/src/astrameter/simulator/battery_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -15,7 +16,7 @@ from astrameter.simulator.venus_integer_steering import (
 )
 
 
-def _battery(delay: int = 0, **kwargs) -> BatterySimulator:
+def _battery(delay: int = 0, **kwargs: Any) -> BatterySimulator:
     defaults: dict = {
         "mac": "02B250000001",
         "phase": "A",

--- a/src/astrameter/simulator/cli.py
+++ b/src/astrameter/simulator/cli.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .runner import SimulationRunner
+    from .runner import SimulationConfig, SimulationRunner
     from .tui import SimulatorApp
 
 PID_FILE = Path.home() / ".astra-sim.pid"
@@ -55,7 +55,9 @@ def _http_post(port: int, path: str, body: dict | None = None) -> dict:
 # -- subcommands -----------------------------------------------------------
 
 
-def _apply_power_update_delay_override(cfg, ticks: int | None) -> None:
+def _apply_power_update_delay_override(
+    cfg: SimulationConfig, ticks: int | None
+) -> None:
     """If *ticks* is set, apply the same delay to every battery."""
     if ticks is None:
         return

--- a/src/astrameter/simulator/cli.py
+++ b/src/astrameter/simulator/cli.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .runner import SimulationRunner
+    from .tui import SimulatorApp
 
 PID_FILE = Path.home() / ".astra-sim.pid"
 LOG_FILE = Path.home() / ".astra-sim.log"
@@ -261,8 +262,8 @@ JSON_PATHS = {json_paths}""")
 # -- TUI -------------------------------------------------------------------
 
 
-def _run_with_tui(runner: SimulationRunner) -> None:
-    """Start daemon in-process, then attach TUI in the same event loop."""
+def _simulator_app() -> type[SimulatorApp] | None:
+    """The TUI app class, or ``None`` when the optional extra is not installed."""
     try:
         from .tui import SimulatorApp
     except ImportError:
@@ -271,27 +272,25 @@ def _run_with_tui(runner: SimulationRunner) -> None:
             "Install with: pip install 'astrameter[sim]'",
             file=sys.stderr,
         )
+        return None
+    return SimulatorApp
+
+
+def _run_with_tui(runner: SimulationRunner) -> None:
+    """Start daemon in-process, then attach TUI in the same event loop."""
+    app = _simulator_app()
+    if app is None:
         print("Falling back to headless mode.")
         asyncio.run(runner.run_headless())
         return
-
-    app = SimulatorApp(runner)
-    app.run()
+    app(runner).run()
 
 
 def _attach_tui(port: int) -> None:
-    try:
-        from .tui import SimulatorApp
-    except ImportError:
-        print(
-            "Textual is required for TUI mode. "
-            "Install with: pip install 'astrameter[sim]'",
-            file=sys.stderr,
-        )
+    app = _simulator_app()
+    if app is None:
         sys.exit(1)
-
-    app = SimulatorApp.attach_to_daemon(port)
-    app.run()
+    app.attach_to_daemon(port).run()
 
 
 # -- logging ---------------------------------------------------------------

--- a/src/astrameter/simulator/eval_compare.py
+++ b/src/astrameter/simulator/eval_compare.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 from .eval_metrics import (
     EVENT_WINDOW_S,
@@ -180,7 +181,7 @@ def _metric_ndp(key: str) -> int:
     return 2 if key.endswith("_ct") else 1
 
 
-def _mean_value(values: list, ndp: int = 1):
+def _mean_value(values: list, ndp: int = 1) -> Any:
     """Average a homogeneous list of result values across seeds.
 
     Recurses into nested lists (a battery's trace, the list of per-battery

--- a/src/astrameter/simulator/eval_harness.py
+++ b/src/astrameter/simulator/eval_harness.py
@@ -150,7 +150,11 @@ async def run_scenario(
     meter_read_at = [-math.inf]
     grid_history: list[tuple[float, dict[str, float]]] = []
 
-    async def before_send(_addr, _request=None, _consumer_id=None):
+    async def before_send(
+        _addr: tuple[str, int],
+        _request: object = None,
+        _consumer_id: str | None = None,
+    ) -> list[float]:
         now = clock() - _EPOCH
         # Draw the house load once; derive both the true grid and the raw
         # consumption from that same sample (get_grid_contribution re-draws

--- a/src/astrameter/simulator/evaluation_test.py
+++ b/src/astrameter/simulator/evaluation_test.py
@@ -19,7 +19,7 @@ class TestReserveUdpPort:
     with the change under evaluation.
     """
 
-    def test_port_is_held_against_other_binders(self):
+    def test_port_is_held_against_other_binders(self) -> None:
         reservation = _reserve_udp_port()
         port = reservation.getsockname()[1]
         try:
@@ -33,7 +33,7 @@ class TestReserveUdpPort:
         finally:
             reservation.close()
 
-    def test_port_is_bindable_once_released(self):
+    def test_port_is_bindable_once_released(self) -> None:
         reservation = _reserve_udp_port()
         port = reservation.getsockname()[1]
         reservation.close()
@@ -41,7 +41,7 @@ class TestReserveUdpPort:
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as listener:
             listener.bind(("0.0.0.0", port))
 
-    def test_live_reservations_are_distinct(self):
+    def test_live_reservations_are_distinct(self) -> None:
         """Two live reservations cannot name the same port — the property the
         parallel workers actually depend on."""
         reservations = [_reserve_udp_port() for _ in range(16)]
@@ -52,7 +52,7 @@ class TestReserveUdpPort:
             for r in reservations:
                 r.close()
 
-    def test_simultaneous_reservations_are_distinct(self):
+    def test_simultaneous_reservations_are_distinct(self) -> None:
         """The same property when the calls genuinely overlap in time.
 
         The workers are separate processes rather than threads, but a barrier
@@ -62,7 +62,7 @@ class TestReserveUdpPort:
         workers = 16
         barrier = threading.Barrier(workers)
 
-        def reserve():
+        def reserve() -> socket.socket:
             barrier.wait()
             return _reserve_udp_port()
 

--- a/src/astrameter/simulator/load_model_test.py
+++ b/src/astrameter/simulator/load_model_test.py
@@ -13,7 +13,7 @@ _TRACE = Path(__file__).parent / "traces" / "rae_household.csv"
 _NET_TRACE = Path(__file__).parent / "traces" / "cyprus_netload.csv"
 
 
-def test_load_power_trace_skips_comments_and_header(tmp_path):
+def test_load_power_trace_skips_comments_and_header(tmp_path: Path) -> None:
     p = tmp_path / "t.csv"
     p.write_text(
         "# a comment\n"
@@ -27,13 +27,13 @@ def test_load_power_trace_skips_comments_and_header(tmp_path):
     assert load_power_trace(p) == [(0.0, 100.0), (60.0, 250.5), (120.0, 90.0)]
 
 
-def test_load_power_trace_sorts_by_time(tmp_path):
+def test_load_power_trace_sorts_by_time(tmp_path: Path) -> None:
     p = tmp_path / "t.csv"
     p.write_text("120,3\n0,1\n60,2\n")
     assert load_power_trace(p) == [(0.0, 1.0), (60.0, 2.0), (120.0, 3.0)]
 
 
-def test_vendored_household_trace_loads():
+def test_vendored_household_trace_loads() -> None:
     trace = load_power_trace(_TRACE)
     # The fixture is a multi-hour 1-second window: thousands of samples, evenly
     # spaced at 1 s, all non-negative watts.
@@ -56,14 +56,16 @@ def test_vendored_household_trace_loads():
         "t_s,watts\nnope,nope\nfoo,bar\n",  # header + invalid-only rows
     ],
 )
-def test_load_power_trace_raises_without_valid_rows(tmp_path, content):
+def test_load_power_trace_raises_without_valid_rows(
+    tmp_path: Path, content: str
+) -> None:
     p = tmp_path / "bad.csv"
     p.write_text(content)
     with pytest.raises(ValueError):
         load_power_trace(p)
 
 
-def test_load_net_trace_reads_three_columns(tmp_path):
+def test_load_net_trace_reads_three_columns(tmp_path: Path) -> None:
     p = tmp_path / "n.csv"
     p.write_text("# c\nt_s,load_w,pv_w\n0,300,0\n30,250.5,1200\n60,400,900\n")
     assert load_net_trace(p) == [
@@ -73,7 +75,7 @@ def test_load_net_trace_reads_three_columns(tmp_path):
     ]
 
 
-def test_vendored_net_trace_loads():
+def test_vendored_net_trace_loads() -> None:
     trace = load_net_trace(_NET_TRACE)
     assert len(trace) > 600  # multi-hour 30 s window
     assert trace[0][0] == 0.0
@@ -92,7 +94,7 @@ def test_vendored_net_trace_loads():
         "t_s,load_w,pv_w\nx,y,z\n1,2\n",  # header, invalid + too-few-column rows
     ],
 )
-def test_load_net_trace_raises_without_valid_rows(tmp_path, content):
+def test_load_net_trace_raises_without_valid_rows(tmp_path: Path, content: str) -> None:
     p = tmp_path / "bad.csv"
     p.write_text(content)
     with pytest.raises(ValueError):

--- a/src/astrameter/simulator/tui.py
+++ b/src/astrameter/simulator/tui.py
@@ -12,8 +12,10 @@ import contextlib
 import json
 import logging
 from collections import deque
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, ClassVar
 
+import aiohttp
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
@@ -30,6 +32,25 @@ _COL = 12
 
 # Number of data points kept for the sparkline graph
 _GRAPH_HISTORY = 120
+
+
+_SSE_DATA_PREFIX = "data: "
+
+
+async def _sse_payloads(chunks: AsyncIterator[bytes]) -> AsyncIterator[str]:
+    """The ``data:`` payload of every complete event in an SSE byte stream.
+
+    Events are delimited by a blank line, so a chunk can hold several of them
+    or half of one; the tail stays buffered until its delimiter arrives.
+    """
+    buffered = ""
+    async for chunk in chunks:
+        buffered += chunk.decode("utf-8", errors="replace")
+        while "\n\n" in buffered:
+            event, buffered = buffered.split("\n\n", 1)
+            for line in event.split("\n"):
+                if line.startswith(_SSE_DATA_PREFIX):
+                    yield line[len(_SSE_DATA_PREFIX) :]
 
 
 class SimulatorApp(App):
@@ -148,8 +169,6 @@ class SimulatorApp(App):
 
     async def _sse_listener(self) -> None:
         """Connect to daemon SSE endpoint and update status."""
-        import aiohttp
-
         url = f"http://localhost:{self._daemon_port}/events"
         try:
             async with (
@@ -158,15 +177,9 @@ class SimulatorApp(App):
                     url, timeout=aiohttp.ClientTimeout(total=None, sock_read=60)
                 ) as resp,
             ):
-                buffer = ""
-                async for chunk_bytes in resp.content.iter_any():
-                    buffer += chunk_bytes.decode("utf-8", errors="replace")
-                    while "\n\n" in buffer:
-                        event, buffer = buffer.split("\n\n", 1)
-                        for line in event.split("\n"):
-                            if line.startswith("data: "):
-                                with contextlib.suppress(json.JSONDecodeError):
-                                    self._status = json.loads(line[6:])
+                async for payload in _sse_payloads(resp.content.iter_any()):
+                    with contextlib.suppress(json.JSONDecodeError):
+                        self._status = json.loads(payload)
         except Exception as exc:
             logger.error("SSE connection lost: %s", exc)
 

--- a/src/astrameter/simulator/venus_integer_steering_test.py
+++ b/src/astrameter/simulator/venus_integer_steering_test.py
@@ -7,13 +7,15 @@ law (:meth:`step_raw`); the gate tests drive :meth:`step`.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from .steering_common import SMALL_IMPORT_HOLD_W
 from .venus_integer_steering import DEADBAND_W, VenusIntegerSteeringController
 
 
-def _run(steps, **kwargs):
+def _run(steps: list[tuple[float, float]], **kwargs: Any) -> list[int]:
     """Feed ``(g, out)`` pairs to a fresh controller; return the setpoints."""
     c = VenusIntegerSteeringController(**kwargs)
     return [c.step(g, 2500.0, -2500.0, out=out) for g, out in steps]

--- a/src/astrameter/status/secrets.py
+++ b/src/astrameter/status/secrets.py
@@ -13,6 +13,7 @@ add-on log, so the two agree on what counts as a secret.
 from __future__ import annotations
 
 import re
+from typing import Any
 
 # Eight bullets.  Deliberately not a plausible password, and identical in
 # every field so its length leaks nothing about the real value.
@@ -35,7 +36,7 @@ def is_secret_key(key: str) -> bool:
     return bool(_SECRET_KEY.search(key))
 
 
-def redact_value(key: str, value):
+def redact_value(key: str, value: Any) -> Any:
     """Replace a secret value, or the userinfo inside a URI, with the sentinel."""
     if not isinstance(value, str):
         return value
@@ -52,7 +53,7 @@ def redact_sections(sections: dict) -> dict:
     }
 
 
-def _restore_value(key: str, value: str, stored):
+def _restore_value(key: str, value: str, stored: Any) -> Any:
     """Put the stored secret back into an echoed value.
 
     For a plain secret the whole value is the secret, so the stored one

--- a/src/astrameter/status/serialize.py
+++ b/src/astrameter/status/serialize.py
@@ -18,8 +18,19 @@ Two rules the dashboard depends on:
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Sequence
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from astrameter.ct002.balancer import (
+        BalancerConsumerSnapshot,
+        BalancerSnapshot,
+        ControlQualitySnapshot,
+    )
+    from astrameter.ct002.ct002 import ConsumerSnapshot, CT002Snapshot
+    from astrameter.powermeter.wrappers.health import PowermeterHealth
+    from astrameter.shelly.shelly import ShellySnapshot
 
 
 def compact(mapping: dict[str, Any]) -> dict[str, Any]:
@@ -45,7 +56,9 @@ def round_or_none(value: float | None, digits: int = 1) -> float | None:
     return round(float(value), digits)
 
 
-def _phase_triple(values, suffix: str = "_w") -> dict[str, Any] | None:
+def _phase_triple(
+    values: Sequence[float] | None, suffix: str = "_w"
+) -> dict[str, Any] | None:
     """Three per-phase numbers as ``l1``/``l2``/``l3``.
 
     The wire keeps ``l1/l2/l3`` because that is exactly what the existing
@@ -57,7 +70,7 @@ def _phase_triple(values, suffix: str = "_w") -> dict[str, Any] | None:
     return {f"l{i + 1}{suffix}": round_or_none(float(v)) for i, v in enumerate(padded)}
 
 
-def powermeter_to_wire(health) -> dict[str, Any]:
+def powermeter_to_wire(health: PowermeterHealth) -> dict[str, Any]:
     """A :class:`PowermeterHealth` as its wire object."""
     return compact(
         {
@@ -77,7 +90,9 @@ def powermeter_to_wire(health) -> dict[str, Any]:
     )
 
 
-def _balancer_consumer_to_wire(state) -> dict[str, Any] | None:
+def _balancer_consumer_to_wire(
+    state: BalancerConsumerSnapshot | None,
+) -> dict[str, Any] | None:
     if state is None:
         return None
     return compact(
@@ -109,7 +124,7 @@ def _balancer_consumer_to_wire(state) -> dict[str, Any] | None:
     )
 
 
-def consumer_to_wire(consumer) -> dict[str, Any]:
+def consumer_to_wire(consumer: ConsumerSnapshot) -> dict[str, Any]:
     """A :class:`ConsumerSnapshot` as its wire object."""
     return compact(
         {
@@ -164,7 +179,7 @@ def consumer_to_wire(consumer) -> dict[str, Any]:
     )
 
 
-def _control_quality_to_wire(quality) -> dict[str, Any]:
+def _control_quality_to_wire(quality: ControlQualitySnapshot) -> dict[str, Any]:
     """A :class:`ControlQualitySnapshot` as its wire object.
 
     The three measurements are omitted until the window holds a sample: the
@@ -198,7 +213,7 @@ def _control_quality_to_wire(quality) -> dict[str, Any]:
     )
 
 
-def _balancer_to_wire(balancer) -> dict[str, Any]:
+def _balancer_to_wire(balancer: BalancerSnapshot) -> dict[str, Any]:
     probe = balancer.probe
     return compact(
         {
@@ -278,7 +293,7 @@ _UNIT_SUFFIX = {
 }
 
 
-def ct002_to_wire(device) -> dict[str, Any]:
+def ct002_to_wire(device: CT002Snapshot) -> dict[str, Any]:
     """A :class:`CT002Snapshot` as its wire object."""
     grid = _phase_triple(device.grid)
     if grid is not None:
@@ -347,7 +362,7 @@ def ct002_to_wire(device) -> dict[str, Any]:
     )
 
 
-def shelly_to_wire(device) -> dict[str, Any]:
+def shelly_to_wire(device: ShellySnapshot) -> dict[str, Any]:
     """A :class:`ShellySnapshot` as its wire object.
 
     A Shelly emulator has no balancer and no per-battery targets — batteries

--- a/src/astrameter/status/status_test.py
+++ b/src/astrameter/status/status_test.py
@@ -2,7 +2,9 @@
 
 import dataclasses
 import inspect
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -17,7 +19,7 @@ from astrameter.status.secrets import SENTINEL, redact_sections, restore_section
 from astrameter.status.serialize import compact, iso, round_or_none
 
 
-def _registry(**kwargs) -> StatusRegistry:
+def _registry(**kwargs: Any) -> StatusRegistry:
     kwargs.setdefault("config_path", "config.ini")
     kwargs.setdefault("log_level", "info")
     kwargs.setdefault("version", "9.9.9")
@@ -48,7 +50,9 @@ def _ct(device_id: str = "ct-1") -> CT002:
         StatusRegistry.snapshot,
     ],
 )
-def test_snapshot_methods_are_synchronous_and_await_free(func):
+def test_snapshot_methods_are_synchronous_and_await_free(
+    func: Callable[..., Any],
+) -> None:
     """A snapshot must be atomic against every in-flight UDP handler.
 
     They all share one asyncio loop, so an await-free builder cannot be
@@ -60,7 +64,7 @@ def test_snapshot_methods_are_synchronous_and_await_free(func):
     assert "await " not in source, f"{func.__qualname__} contains an await"
 
 
-def test_snapshot_hands_out_copies_not_live_containers():
+def test_snapshot_hands_out_copies_not_live_containers() -> None:
     registry = _registry()
     device = _ct()
     registry.register_device("ct-1", "ct002", device)
@@ -77,7 +81,7 @@ def test_snapshot_hands_out_copies_not_live_containers():
     assert len(registry.snapshot(ingress=False)["devices"][0]["consumers"]) == 2
 
 
-def test_relay_mode_reports_the_grid_it_served_not_zero():
+def test_relay_mode_reports_the_grid_it_served_not_zero() -> None:
     """`_last_smooth_target` is only written by the active-control path, so
     deriving the headline figure from it alone showed every relay-mode user a
     grid total of 0 W beside three non-zero phases."""
@@ -94,7 +98,7 @@ def test_relay_mode_reports_the_grid_it_served_not_zero():
     assert device.status_snapshot().grid_total == pytest.approx(-11.0)
 
 
-def test_control_quality_reaches_the_wire_with_its_evidence():
+def test_control_quality_reaches_the_wire_with_its_evidence() -> None:
     """The verdict is the one balancer figure aimed at a user, so it has to
     survive the wire layer intact — with the numbers behind it, since "this
     loop is off target" is worth little without how far off and how often."""
@@ -135,7 +139,7 @@ def test_control_quality_reaches_the_wire_with_its_evidence():
     assert quality["in_band_fraction"] == 0.0
 
 
-def test_a_consumer_created_by_a_retained_command_is_marked_as_such():
+def test_a_consumer_created_by_a_retained_command_is_marked_as_such() -> None:
     """Every consumer setter materializes the consumer, because a retained MQTT
     command has to hold its setting until the battery turns up.  That
     placeholder carries Consumer's defaults — phase "A", 0 W, no timestamp —
@@ -163,7 +167,7 @@ def test_a_consumer_created_by_a_retained_command_is_marked_as_such():
     assert placeholder["expired"] is False
 
 
-def test_a_shelly_device_reaches_the_wire_with_its_batteries():
+def test_a_shelly_device_reaches_the_wire_with_its_batteries() -> None:
     """The Shelly emulator is the default device type, so the document has to
     carry it as a first-class device — not as an unrecognised shape the UI
     quietly drops."""
@@ -196,19 +200,20 @@ def test_a_shelly_device_reaches_the_wire_with_its_batteries():
 # -- absence is not zero ----------------------------------------------
 
 
-def test_compact_drops_none_but_keeps_zero():
+def test_compact_drops_none_but_keeps_zero() -> None:
     assert compact({"a": None, "b": 0, "c": False}) == {"b": 0, "c": False}
 
 
-def test_round_and_iso_preserve_absence():
+def test_round_and_iso_preserve_absence() -> None:
     assert round_or_none(None) is None
     assert round_or_none(1.23456) == 1.2
     assert iso(None) is None
     assert iso(0) is None
-    assert iso(1_770_000_000.0).startswith("2026-")
+    stamp = iso(1_770_000_000.0)
+    assert stamp is not None and stamp.startswith("2026-")
 
 
-def test_absent_fields_are_omitted_not_zeroed():
+def test_absent_fields_are_omitted_not_zeroed() -> None:
     """A field the backend cannot produce must be missing, so the UI can omit
     the card instead of rendering a convincing zero."""
     snapshot = _registry(git_commit="").snapshot(ingress=False)
@@ -221,7 +226,7 @@ def test_absent_fields_are_omitted_not_zeroed():
     assert snapshot["capabilities"]
 
 
-def test_snapshot_carries_no_credentials():
+def test_snapshot_carries_no_credentials() -> None:
     registry = _registry()
     registry.register_device("ct-1", "ct002", _ct())
     text = repr(registry.snapshot(ingress=False)).lower()
@@ -232,7 +237,7 @@ def test_snapshot_carries_no_credentials():
 # -- capabilities gate the UI -----------------------------------------
 
 
-def test_capabilities_are_fail_closed_without_ingress():
+def test_capabilities_are_fail_closed_without_ingress() -> None:
     registry = _registry(
         allow_write=True, direct_access=False, config_mode="ha_advanced"
     )
@@ -240,7 +245,7 @@ def test_capabilities_are_fail_closed_without_ingress():
     assert registry.capabilities(ingress=True)["controls"] is True
 
 
-def test_standalone_needs_no_direct_access_opt_in():
+def test_standalone_needs_no_direct_access_opt_in() -> None:
     """There is no ingress outside the add-on, so the flag would be one the
     user could never usefully leave off."""
     registry = _registry(
@@ -249,7 +254,7 @@ def test_standalone_needs_no_direct_access_opt_in():
     assert registry.capabilities(ingress=False)["controls"] is True
 
 
-def test_simple_mode_is_never_config_writable():
+def test_simple_mode_is_never_config_writable() -> None:
     """The add-on regenerates config.ini on every start, so offering to edit
     it there would silently lose the user's work."""
     registry = _registry(config_mode="ha_simple", allow_write=True)
@@ -258,7 +263,7 @@ def test_simple_mode_is_never_config_writable():
     assert caps["ha_options"] is True
 
 
-def test_etag_changes_with_state_and_over_time(monkeypatch):
+def test_etag_changes_with_state_and_over_time(monkeypatch: pytest.MonkeyPatch) -> None:
     # The ETag mixes in a coarse time bucket, so two real calls either side of
     # a bucket boundary differ for a reason this test is not about. Freeze the
     # clock and the assertion is purely about state.
@@ -270,7 +275,7 @@ def test_etag_changes_with_state_and_over_time(monkeypatch):
     assert registry.etag() != first
 
 
-def test_revision_folds_in_device_local_mutations():
+def test_revision_folds_in_device_local_mutations() -> None:
     """Serving a battery bumps only the device's own ``_rev`` (ct002.py), not
     any registry field — so the registry has to fold each device's revision
     into its own, or a polling client would sit on a 304 through every
@@ -284,7 +289,7 @@ def test_revision_folds_in_device_local_mutations():
     assert registry.etag() != f'W/"{before}-0"'
 
 
-def test_register_and_unregister_device():
+def test_register_and_unregister_device() -> None:
     registry = _registry()
     registry.register_device("ct-1", "ct002", _ct())
     assert "ct-1" in registry.devices
@@ -292,7 +297,7 @@ def test_register_and_unregister_device():
     assert registry.devices == {}
 
 
-def test_reset_cycle_clears_per_run_state():
+def test_reset_cycle_clears_per_run_state() -> None:
     registry = _registry()
     registry.register_device("ct-1", "ct002", _ct())
     registry.powermeters = [object()]
@@ -306,7 +311,7 @@ def test_reset_cycle_clears_per_run_state():
 # -- config mode ------------------------------------------------------
 
 
-def test_mode_comes_from_the_loaded_backend_never_from_the_filesystem():
+def test_mode_comes_from_the_loaded_backend_never_from_the_filesystem() -> None:
     # Outside the add-on it makes no difference whether a file backs the
     # config — a Docker install is standalone either way.
     assert detect_config_mode(addon=False, config_path=None) == "standalone"
@@ -316,7 +321,7 @@ def test_mode_comes_from_the_loaded_backend_never_from_the_filesystem():
     assert detect_config_mode(addon=True, config_path="/config/x.ini") == "ha_advanced"
 
 
-def test_target_path_rejects_traversal(tmp_path):
+def test_target_path_rejects_traversal(tmp_path: Path) -> None:
     assert target_path("astrameter.ini", str(tmp_path)).endswith("/astrameter.ini")
     assert target_path("../../etc/passwd", str(tmp_path)) == str(tmp_path / "passwd")
     with pytest.raises(ValueError):
@@ -325,7 +330,7 @@ def test_target_path_rejects_traversal(tmp_path):
         target_path(".hidden", str(tmp_path))
 
 
-def test_materialize_copies_a_config_that_already_has_a_file(tmp_path):
+def test_materialize_copies_a_config_that_already_has_a_file(tmp_path: Path) -> None:
     """Verbatim, comments and all — there is nothing to gain by re-rendering."""
     source = tmp_path / "running.ini"
     source.write_text("[GENERAL]\n# keep me\nDEVICE_TYPE = ct002\n")
@@ -340,7 +345,7 @@ def test_materialize_copies_a_config_that_already_has_a_file(tmp_path):
     assert "Written by AstraMeter" in body
 
 
-def test_materialize_renders_a_config_that_has_no_file(tmp_path):
+def test_materialize_renders_a_config_that_has_no_file(tmp_path: Path) -> None:
     """The add-on options case: the settings are the only source there is."""
     parser = new_config_parser()
     parser.read_string(
@@ -356,7 +361,7 @@ def test_materialize_renders_a_config_that_has_no_file(tmp_path):
     assert IniAppConfig(restored).ct("ct002").balance_gain == 0.4
 
 
-def test_materialize_never_clobbers_an_existing_file(tmp_path):
+def test_materialize_never_clobbers_an_existing_file(tmp_path: Path) -> None:
     target_dir = tmp_path / "config"
     target_dir.mkdir()
     existing = target_dir / "astrameter.ini"
@@ -374,7 +379,7 @@ def test_materialize_never_clobbers_an_existing_file(tmp_path):
 # -- the secret sentinel ----------------------------------------------
 
 
-def test_secrets_are_redacted_on_the_way_out():
+def test_secrets_are_redacted_on_the_way_out() -> None:
     sections = {
         "MQTT": {"PASSWORD": "hunter2", "BROKER": "10.0.0.2", "USERNAME": "bob"},
         "MARSTEK": {"MAILBOX": "a@b.c", "TIMEZONE": "Europe/Berlin"},
@@ -387,13 +392,13 @@ def test_secrets_are_redacted_on_the_way_out():
     assert "hunter2" not in repr(out)
 
 
-def test_uri_userinfo_is_redacted():
+def test_uri_userinfo_is_redacted() -> None:
     out = redact_sections({"MQTT_INSIGHTS": {"URI": "mqtt://bob:hunter2@broker:1883"}})
     assert "hunter2" not in out["MQTT_INSIGHTS"]["URI"]
     assert "broker:1883" in out["MQTT_INSIGHTS"]["URI"]
 
 
-def test_editing_a_uri_around_its_redacted_credential_keeps_both():
+def test_editing_a_uri_around_its_redacted_credential_keeps_both() -> None:
     """The bullets stand in for the userinfo only; the host and port are the
     user's to change in the same round trip."""
     current = {"MQTT_INSIGHTS": {"URI": "mqtt://bob:hunter2@old-host:1883"}}
@@ -403,7 +408,7 @@ def test_editing_a_uri_around_its_redacted_credential_keeps_both():
     assert restored["MQTT_INSIGHTS"]["URI"] == "mqtt://bob:hunter2@new-host:8883"
 
 
-def test_sentinel_round_trip_keeps_the_stored_secret():
+def test_sentinel_round_trip_keeps_the_stored_secret() -> None:
     """A client that never saw the real password cannot send it back, so an
     unrelated edit must not blank it."""
     current = {"MQTT": {"PASSWORD": "hunter2", "BROKER": "10.0.0.2"}}
@@ -413,13 +418,13 @@ def test_sentinel_round_trip_keeps_the_stored_secret():
     assert restored["MQTT"]["BROKER"] == "10.0.0.9"
 
 
-def test_a_real_new_secret_is_written_through():
+def test_a_real_new_secret_is_written_through() -> None:
     current = {"MQTT": {"PASSWORD": "old"}}
     restored = restore_sections({"MQTT": {"PASSWORD": "brand-new"}}, current)
     assert restored["MQTT"]["PASSWORD"] == "brand-new"
 
 
-def test_empty_secret_is_not_replaced_by_a_sentinel():
+def test_empty_secret_is_not_replaced_by_a_sentinel() -> None:
     """An unset password must render as empty, not as eight bullets the user
     would then have to clear."""
     out = redact_sections({"MQTT": {"PASSWORD": ""}})
@@ -429,7 +434,7 @@ def test_empty_secret_is_not_replaced_by_a_sentinel():
 # -- serializer helpers -----------------------------------------------
 
 
-def test_as_wire_dict_expands_nested_dataclasses_and_drops_none():
+def test_as_wire_dict_expands_nested_dataclasses_and_drops_none() -> None:
     @dataclasses.dataclass
     class Inner:
         a: int = 1

--- a/src/astrameter/udp_server.py
+++ b/src/astrameter/udp_server.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Coroutine
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 
 class DatagramSink(Protocol):
@@ -31,8 +31,11 @@ class _HandlerProtocol(asyncio.DatagramProtocol):
         # nobody holds can be collected mid-poll; the set is that reference.
         self._tasks: set[asyncio.Task] = set()
 
-    def connection_made(self, transport) -> None:
-        self._transport = transport
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        # Widened by the base class, and narrowed rather than checked: the
+        # concrete datagram transports do not inherit `DatagramTransport`, so
+        # an isinstance test here refuses the very object asyncio hands over.
+        self._transport = cast("asyncio.DatagramTransport", transport)
 
     def datagram_received(self, data: bytes, addr: tuple) -> None:
         assert self._transport is not None

--- a/src/astrameter/udp_server.py
+++ b/src/astrameter/udp_server.py
@@ -11,7 +11,14 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Coroutine
-from typing import Any
+from typing import Any, Protocol
+
+
+class DatagramSink(Protocol):
+    """The one thing a handler does with the transport it is handed."""
+
+    def sendto(self, data: bytes, addr: tuple) -> None: ...
+
 
 Handler = Callable[[bytes, tuple, asyncio.DatagramTransport], Coroutine[Any, Any, None]]
 

--- a/src/astrameter/web_config.py
+++ b/src/astrameter/web_config.py
@@ -16,6 +16,11 @@ from collections import OrderedDict
 
 from configupdater import ConfigUpdater
 
+from astrameter.config.config_loader import (
+    new_config_parser,
+    read_all_powermeter_configs,
+)
+
 
 def _load_config_editor_html() -> str:
     """Load the config editor HTML from the bundled static file."""
@@ -204,12 +209,7 @@ def validate_config(config_path: str) -> None:
     key, invalid value, etc.) so the caller can roll back before the
     service tries to restart with a broken config.
     """
-    import configparser as _cp
-    from collections import OrderedDict
-
-    from astrameter.config.config_loader import read_all_powermeter_configs
-
-    cfg = _cp.ConfigParser(dict_type=OrderedDict, interpolation=None)
+    cfg = new_config_parser()
     if not cfg.read(config_path):
         raise ValueError(f"Cannot read config file: {config_path}")
     read_all_powermeter_configs(cfg)

--- a/src/astrameter/web_config_test.py
+++ b/src/astrameter/web_config_test.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from astrameter.web_config import (
@@ -8,20 +10,20 @@ from astrameter.web_config import (
 
 
 @pytest.fixture()
-def ini_path(tmp_path):
+def ini_path(tmp_path: Path) -> str:
     return str(tmp_path / "test.ini")
 
 
 # ---------- read_config_as_dict ----------
 
 
-def test_read_nonexistent_file(ini_path):
+def test_read_nonexistent_file(ini_path: str) -> None:
     sections, order = read_config_as_dict(ini_path)
     assert sections == {}
     assert order == []
 
 
-def test_read_simple(ini_path):
+def test_read_simple(ini_path: str) -> None:
     with open(ini_path, "w") as f:
         f.write("[SEC1]\nKEY = val\n\n[SEC2]\nA = 1\n")
     sections, order = read_config_as_dict(ini_path)
@@ -29,7 +31,7 @@ def test_read_simple(ini_path):
     assert sections == {"SEC1": {"KEY": "val"}, "SEC2": {"A": "1"}}
 
 
-def test_read_preserves_key_case(ini_path):
+def test_read_preserves_key_case(ini_path: str) -> None:
     with open(ini_path, "w") as f:
         f.write("[S]\nMyKey = v\nANOTHER_KEY = w\n")
     sections, _ = read_config_as_dict(ini_path)
@@ -40,46 +42,46 @@ def test_read_preserves_key_case(ini_path):
 # ---------- _validate_config_payload ----------
 
 
-def test_validate_good_payload():
+def test_validate_good_payload() -> None:
     _validate_config_payload({"SEC": {"K": "V"}}, ["SEC"])
 
 
-def test_validate_order_not_list():
+def test_validate_order_not_list() -> None:
     with pytest.raises(ValueError, match="order"):
         _validate_config_payload({"S": {}}, "S")  # type: ignore[arg-type]
 
 
-def test_validate_empty_section_name():
+def test_validate_empty_section_name() -> None:
     with pytest.raises(ValueError, match="Invalid section name"):
         _validate_config_payload({"": {"K": "V"}}, [""])
 
 
-def test_validate_section_name_with_bracket():
+def test_validate_section_name_with_bracket() -> None:
     with pytest.raises(ValueError, match="Invalid section name"):
         _validate_config_payload({"a]b": {}}, ["a]b"])
 
 
-def test_validate_section_not_dict():
+def test_validate_section_not_dict() -> None:
     with pytest.raises(ValueError, match="must map to an object"):
         _validate_config_payload({"S": "bad"}, ["S"])  # type: ignore[dict-item]
 
 
-def test_validate_empty_key():
+def test_validate_empty_key() -> None:
     with pytest.raises(ValueError, match="Invalid key"):
         _validate_config_payload({"S": {"": "v"}}, ["S"])
 
 
-def test_validate_key_with_newline():
+def test_validate_key_with_newline() -> None:
     with pytest.raises(ValueError, match="Invalid key"):
         _validate_config_payload({"S": {"a\nb": "v"}}, ["S"])
 
 
-def test_validate_value_with_newline():
+def test_validate_value_with_newline() -> None:
     with pytest.raises(ValueError, match="Invalid value"):
         _validate_config_payload({"S": {"k": "a\nb"}}, ["S"])
 
 
-def test_validate_duplicate_order():
+def test_validate_duplicate_order() -> None:
     with pytest.raises(ValueError, match="duplicate section names"):
         _validate_config_payload({"S": {"k": "v"}}, ["S", "S"])
 
@@ -87,7 +89,7 @@ def test_validate_duplicate_order():
 # ---------- write_config_from_dict — new file ----------
 
 
-def test_write_new_file(ini_path):
+def test_write_new_file(ini_path: str) -> None:
     write_config_from_dict(
         ini_path,
         {"SEC1": {"A": "1"}, "SEC2": {"B": "2"}},
@@ -99,7 +101,7 @@ def test_write_new_file(ini_path):
     assert sections["SEC2"] == {"B": "2"}
 
 
-def test_write_new_file_respects_order(ini_path):
+def test_write_new_file_respects_order(ini_path: str) -> None:
     write_config_from_dict(
         ini_path,
         {"SEC2": {"B": "2"}, "SEC1": {"A": "1"}},
@@ -112,7 +114,7 @@ def test_write_new_file_respects_order(ini_path):
 # ---------- write_config_from_dict — update existing ----------
 
 
-def test_update_preserves_comments(ini_path):
+def test_update_preserves_comments(ini_path: str) -> None:
     with open(ini_path, "w") as f:
         f.write("# top comment\n[SEC]\n# about KEY\nKEY = old\n")
     write_config_from_dict(ini_path, {"SEC": {"KEY": "new"}}, ["SEC"])
@@ -124,7 +126,7 @@ def test_update_preserves_comments(ini_path):
     assert "old" not in content
 
 
-def test_update_preserves_semicolon_comments(ini_path):
+def test_update_preserves_semicolon_comments(ini_path: str) -> None:
     with open(ini_path, "w") as f:
         f.write("[SEC]\n; semicolon comment\nKEY = val\n")
     write_config_from_dict(ini_path, {"SEC": {"KEY": "val"}}, ["SEC"])
@@ -133,7 +135,7 @@ def test_update_preserves_semicolon_comments(ini_path):
     assert "; semicolon comment" in content
 
 
-def test_update_adds_new_key(ini_path):
+def test_update_adds_new_key(ini_path: str) -> None:
     with open(ini_path, "w") as f:
         f.write("[SEC]\nA = 1\n")
     write_config_from_dict(ini_path, {"SEC": {"A": "1", "B": "2"}}, ["SEC"])
@@ -141,7 +143,7 @@ def test_update_adds_new_key(ini_path):
     assert sections["SEC"] == {"A": "1", "B": "2"}
 
 
-def test_update_removes_key(ini_path):
+def test_update_removes_key(ini_path: str) -> None:
     with open(ini_path, "w") as f:
         f.write("[SEC]\nA = 1\nB = 2\n")
     write_config_from_dict(ini_path, {"SEC": {"A": "1"}}, ["SEC"])
@@ -149,7 +151,7 @@ def test_update_removes_key(ini_path):
     assert sections["SEC"] == {"A": "1"}
 
 
-def test_update_removes_section(ini_path):
+def test_update_removes_section(ini_path: str) -> None:
     with open(ini_path, "w") as f:
         f.write("[KEEP]\nA = 1\n\n[DROP]\nB = 2\n")
     write_config_from_dict(ini_path, {"KEEP": {"A": "1"}}, ["KEEP"])
@@ -158,7 +160,7 @@ def test_update_removes_section(ini_path):
     assert "DROP" not in sections
 
 
-def test_update_adds_section(ini_path):
+def test_update_adds_section(ini_path: str) -> None:
     with open(ini_path, "w") as f:
         f.write("[OLD]\nA = 1\n")
     write_config_from_dict(
@@ -171,7 +173,7 @@ def test_update_adds_section(ini_path):
     assert sections["NEW"] == {"B": "2"}
 
 
-def test_update_reorders_sections(ini_path):
+def test_update_reorders_sections(ini_path: str) -> None:
     with open(ini_path, "w") as f:
         f.write("[A]\nX = 1\n\n[B]\nY = 2\n\n[C]\nZ = 3\n")
     write_config_from_dict(
@@ -183,7 +185,7 @@ def test_update_reorders_sections(ini_path):
     assert order == ["C", "A", "B"]
 
 
-def test_update_preserves_case(ini_path):
+def test_update_preserves_case(ini_path: str) -> None:
     with open(ini_path, "w") as f:
         f.write("[My_Section]\nMyKey = old\n")
     write_config_from_dict(ini_path, {"My_Section": {"MyKey": "new"}}, ["My_Section"])
@@ -195,7 +197,7 @@ def test_update_preserves_case(ini_path):
 # ---------- round-trip ----------
 
 
-def test_roundtrip_identity(ini_path):
+def test_roundtrip_identity(ini_path: str) -> None:
     """Writing back the same data that was read should not change the file."""
     original = "[SEC1]\nA = 1\nB = 2\n\n[SEC2]\nC = 3\n"
     with open(ini_path, "w") as f:
@@ -207,7 +209,7 @@ def test_roundtrip_identity(ini_path):
     assert result.strip() == original.strip()
 
 
-def test_roundtrip_with_comments(ini_path):
+def test_roundtrip_with_comments(ini_path: str) -> None:
     original = "# file header\n[SEC]\n# key comment\nKEY = val\n"
     with open(ini_path, "w") as f:
         f.write(original)
@@ -221,7 +223,7 @@ def test_roundtrip_with_comments(ini_path):
 # ---------- sections in order not in dict are skipped ----------
 
 
-def test_order_with_extra_names(ini_path):
+def test_order_with_extra_names(ini_path: str) -> None:
     """Section names in *order* that aren't in *sections* are ignored."""
     write_config_from_dict(
         ini_path,
@@ -233,7 +235,7 @@ def test_order_with_extra_names(ini_path):
     assert sections == {"A": {"X": "1"}}
 
 
-def test_sections_not_in_order_appended(ini_path):
+def test_sections_not_in_order_appended(ini_path: str) -> None:
     """Sections present in *sections* but absent from *order* are appended."""
     write_config_from_dict(
         ini_path,
@@ -249,7 +251,7 @@ def test_sections_not_in_order_appended(ini_path):
 # ---------- _atomic_write_lines fallbacks ----------
 
 
-def test_atomic_write_creates_file(ini_path):
+def test_atomic_write_creates_file(ini_path: str) -> None:
     from astrameter.web_config import _atomic_write_lines
 
     _atomic_write_lines(ini_path, ["hello\n", "world\n"])
@@ -257,7 +259,7 @@ def test_atomic_write_creates_file(ini_path):
         assert f.read() == "hello\nworld\n"
 
 
-def test_atomic_write_overwrites(ini_path):
+def test_atomic_write_overwrites(ini_path: str) -> None:
     from astrameter.web_config import _atomic_write_lines
 
     with open(ini_path, "w") as f:

--- a/src/astrameter/web_guard.py
+++ b/src/astrameter/web_guard.py
@@ -15,11 +15,15 @@ from __future__ import annotations
 import html
 import ipaddress
 import json
-from collections.abc import Collection, Iterable
+from collections.abc import Awaitable, Callable, Collection, Iterable
+from typing import Any
 
 from aiohttp import web
 
 from astrameter.config.logger import logger
+
+#: An aiohttp route handler, as the wrappers below take and return one.
+Handler = Callable[[web.Request], Awaitable[web.StreamResponse]]
 
 #: How many distinct refused host names to remember for log deduplication.
 #: The name comes from the request, so this is a bound on what a caller can
@@ -27,7 +31,9 @@ from astrameter.config.logger import logger
 _REFUSED_HOST_LOG_CAP = 64
 
 
-def _json(payload, status=200, cache="no-store", **headers):
+def json_response(
+    payload: Any, status: int = 200, cache: str = "no-store", **headers: str
+) -> web.Response:
     """JSON response, ``Cache-Control: no-store`` unless *cache* says otherwise."""
     headers.setdefault("Cache-Control", cache)
     return web.Response(
@@ -38,13 +44,41 @@ def _json(payload, status=200, cache="no-store", **headers):
     )
 
 
-def _error(message, status):
+def error_response(message: str, status: int) -> web.Response:
     """The ``{"error": ...}`` shape every failing route answers with."""
-    return _json({"error": message}, status=status)
+    return json_response({"error": message}, status=status)
 
 
-def _forbidden():
-    return _error("Forbidden", status=403)
+def forbidden() -> web.Response:
+    return error_response("Forbidden", status=403)
+
+
+class ApiError(Exception):
+    """A refusal a route states in passing, instead of unwinding to a 500.
+
+    Raised wherever the reason is known — a malformed body, a Supervisor that
+    answered with an error — and turned into the response by
+    :func:`answers_api_errors`, which every API route is wrapped in. Handlers
+    are then free of the ``return error(...)`` plumbing between the check and
+    the work.
+    """
+
+    def __init__(self, message: str, status: int) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status = status
+
+
+def answers_api_errors(handler: Handler) -> Handler:
+    """Wrap *handler* so an :class:`ApiError` it raises becomes its response."""
+
+    async def guarded(request: web.Request) -> web.StreamResponse:
+        try:
+            return await handler(request)
+        except ApiError as exc:
+            return error_response(exc.message, status=exc.status)
+
+    return guarded
 
 
 def _refusal_page(title: str, heading: str, body: str) -> str:
@@ -122,12 +156,14 @@ Home Assistant add-on) if it is yours.</p>"""
 JSON_CONTENT_TYPE = "application/json"
 
 
-def requires_json_content_type(handler):
+def requires_json_content_type(handler: Handler) -> Handler:
     """Wrap *handler* so a request not declared as JSON is refused."""
 
-    async def guarded(request):
+    async def guarded(request: web.Request) -> web.StreamResponse:
         if request.content_type.casefold() != JSON_CONTENT_TYPE:
-            return _error(f"Content-Type must be {JSON_CONTENT_TYPE}", status=415)
+            return error_response(
+                f"Content-Type must be {JSON_CONTENT_TYPE}", status=415
+            )
         return await handler(request)
 
     return guarded
@@ -268,7 +304,7 @@ class RefusedHostLog:
             )
 
 
-def foreign_host_response(request, shown: str):
+def foreign_host_response(request: web.Request, shown: str) -> web.StreamResponse:
     """The 403 for a request whose ``Host`` the guard does not recognise.
 
     Prose for a page a person navigated to, JSON for the API the page polls.
@@ -278,7 +314,7 @@ def foreign_host_response(request, shown: str):
         "IP address, or add the name to DASHBOARD_ALLOWED_HOSTS."
     )
     if request.path.startswith("/api/"):
-        return _error(message, status=403)
+        return error_response(message, status=403)
     return web.Response(
         status=403,
         text=_refusal_page(

--- a/src/astrameter/web_server.py
+++ b/src/astrameter/web_server.py
@@ -6,30 +6,52 @@ Home Assistant addon watchdog) and, when enabled, the live status
 dashboard plus a browser-based configuration editor.
 """
 
+from __future__ import annotations
+
 import asyncio
 import errno
 import json
 import os
+import shutil
+import signal
+import tempfile
 import threading
-from collections.abc import Iterable
+from collections.abc import Awaitable, Iterable
+from typing import TYPE_CHECKING, Any
 
 from aiohttp import web
 
+from astrameter.addon_client import SupervisorClient
 from astrameter.config.logger import logger
 from astrameter.ct002.controls import CONSUMER_CONTROLS_BY_FIELD, apply_device_control
+from astrameter.status.assets import dashboard_html
+from astrameter.status.config_mode import materialize_config
 from astrameter.status.secrets import redact_sections, restore_sections
 from astrameter.version_info import get_git_commit_sha
+from astrameter.web_config import (
+    CONFIG_EDITOR_HTML,
+    SECTION_KEY_TYPES,
+    read_config_as_dict,
+    validate_config,
+    write_config_from_dict,
+)
 from astrameter.web_guard import (
     REFUSED_HTML,
+    ApiError,
+    Handler,
     RefusedHostLog,
-    _error,
-    _forbidden,
-    _json,
+    answers_api_errors,
+    error_response,
+    forbidden,
     foreign_host_response,
     is_allowed_host,
+    json_response,
     parse_allowed_hosts,
     requires_json_content_type,
 )
+
+if TYPE_CHECKING:
+    from astrameter.status.registry import StatusRegistry
 
 # Supervisor proxies every ingress request from this fixed address on the
 # hassio bridge.  It is the *peer* address, so unlike X-Ingress-Path or
@@ -37,8 +59,8 @@ from astrameter.web_guard import (
 # host-networked port directly.
 INGRESS_PEER = "172.30.32.2"
 
-#: How long a deferred Supervisor restart waits before firing, so the response
-#: that asked for it is on the wire before the container goes down.
+#: How long a deferred restart waits before firing, so the response that asked
+#: for it is on the wire before the container goes down.
 RESTART_GRACE_S = 0.5
 
 #: The health check, which is exempt from the host guard below: Docker's
@@ -46,8 +68,11 @@ RESTART_GRACE_S = 0.5
 #: operator's monitoring uses, and it neither reads state nor writes anything.
 HEALTH_PATHS = ("/health", "/health/", "/api", "/api/")
 
+#: What a malformed request body is answered with, whichever route read it.
+_BAD_BODY = (KeyError, TypeError, ValueError, json.JSONDecodeError)
 
-def addon_option_names(schema) -> set[str]:
+
+def addon_option_names(schema: Any) -> set[str]:
     """Every option name in an add-on schema, whichever shape it arrived in.
 
     Supervisor renders the add-on's declared schema before serving it: what
@@ -90,16 +115,35 @@ def _unrenderable_descriptors(schema: list) -> dict[str, str]:
     return odd
 
 
+async def _body(request: web.Request) -> dict[str, Any]:
+    """The request's JSON object, or an :class:`ApiError` naming what was wrong."""
+    try:
+        body = await request.json()
+        if not isinstance(body, dict):
+            raise ValueError("JSON body must be an object")
+    except _BAD_BODY as exc:
+        raise ApiError(f"Invalid request: {exc}", status=400) from exc
+    return body
+
+
+def _required(body: dict[str, Any], *keys: str) -> list[Any]:
+    """The values of *keys*, refusing the request when one is missing."""
+    try:
+        return [body[key] for key in keys]
+    except KeyError as exc:
+        raise ApiError(f"Invalid request: {exc}", status=400) from exc
+
+
 class WebServer:
     """Async HTTP server exposing health, dashboard, config and API routes."""
 
     def __init__(
         self,
-        port=52500,
-        bind_address="0.0.0.0",
+        port: int = 52500,
+        bind_address: str = "0.0.0.0",
         config_path: str | None = None,
         enable_web_config: bool | None = None,
-        status=None,
+        status: StatusRegistry | None = None,
         allowed_hosts: str | Iterable[str] | None = None,
     ):
         """Initialise the service; call ``start()`` to bind the port."""
@@ -115,12 +159,12 @@ class WebServer:
         # a link to routes this server does not serve.
         if status is not None and not self.serve_config_editor:
             status.config_editor = False
-        self._runner = None
+        self._runner: web.AppRunner | None = None
         self._refused_hosts = RefusedHostLog()
         #: Whether an unrenderable add-on schema has already been reported.
         self._logged_schema_shape = False
         #: Deferred restarts, held so the loop cannot collect them mid-flight.
-        self._pending_restarts: set = set()
+        self._pending_restarts: set[asyncio.Task[None]] = set()
 
     # -- gating --------------------------------------------------------
 
@@ -148,7 +192,7 @@ class WebServer:
             return self.enable_dashboard
         return self.enable_web_config
 
-    def _is_ingress(self, request) -> bool:
+    def _is_ingress(self, request: web.Request) -> bool:
         """True when the request arrived through Home Assistant ingress.
 
         Ingress requests are already authenticated by Home Assistant, which
@@ -157,7 +201,7 @@ class WebServer:
         """
         return request.remote == INGRESS_PEER
 
-    def _refuse_foreign_host(self, request):
+    def _refuse_foreign_host(self, request: web.Request) -> web.StreamResponse | None:
         """Refuse a request whose ``Host`` is a name that could be rebound.
 
         Returns the refusal, or ``None`` to let the request through. See
@@ -177,7 +221,7 @@ class WebServer:
         self._refused_hosts.log(shown, request.path)
         return foreign_host_response(request, shown)
 
-    def _trusted(self, request) -> bool:
+    def _trusted(self, request: web.Request) -> bool:
         """True when this request may see or change anything sensitive.
 
         Fail-closed under the add-on: with ``host_network: true`` the port is
@@ -189,12 +233,20 @@ class WebServer:
             return False
         return self._is_ingress(request) or self.status.serves_direct()
 
-    def _may_write(self, request) -> bool:
+    def _may_read(self, request: web.Request) -> bool:
+        """Like :meth:`_trusted`, but a server with no registry serves anyway.
+
+        The config editor can run standalone, with nothing to be trusted
+        *about*; its own ``serve_config_editor`` gate decided that already.
+        """
+        return self.status is None or self._trusted(request)
+
+    def _may_write(self, request: web.Request) -> bool:
         return self.status is not None and self.status.may_write(
             ingress=self._is_ingress(request)
         )
 
-    def _actor(self, request) -> str:
+    def _actor(self, request: web.Request) -> str:
         """Who made a mutating request, for the audit log."""
         # Home Assistant sets these on an ingress request. Reached directly the
         # port is on the LAN, where any client can send the same headers, so
@@ -208,7 +260,9 @@ class WebServer:
             return f"{name or 'unknown'} ({uid or 'no id'})"
         return f"direct {request.remote}"
 
-    def build_app(self):
+    # -- wiring --------------------------------------------------------
+
+    def build_app(self) -> web.Application:
         """Assemble the aiohttp application.
 
         Split out from ``start()`` so tests exercise the real route table
@@ -220,7 +274,9 @@ class WebServer:
         # directly below (``/`` and ``/config``), and a document served under a
         # rebound name is the request that goes on to drive the API.
         @web.middleware
-        async def host_guard(request, handler):
+        async def host_guard(
+            request: web.Request, handler: Handler
+        ) -> web.StreamResponse:
             refusal = self._refuse_foreign_host(request)
             if refusal is not None:
                 return refusal
@@ -263,46 +319,50 @@ class WebServer:
         app.router.add_route("*", "/{path:.*}", self._handle_not_found)
         return app
 
-    async def start(self):
+    @staticmethod
+    def _add(method: str, app: web.Application, path: str, handler: Handler) -> None:
+        """Register *path* both with and without a trailing slash.
+
+        A redirect would send a `Location` header, which both ingress hops
+        copy verbatim — navigating the user out of the ingress prefix.
+
+        Every API route is wrapped here rather than at each handler, so a route
+        added later cannot forget either wrapper: an :class:`ApiError` becomes
+        the response it names, and every ``POST`` passes the JSON content-type
+        guard — see :data:`astrameter.web_guard.JSON_CONTENT_TYPE` for what
+        that one defends against.
+        """
+        handler = answers_api_errors(handler)
+        if method == "POST":
+            handler = requires_json_content_type(handler)
+        app.router.add_route(method, path, handler)
+        app.router.add_route(method, path + "/", handler)
+
+    async def start(self) -> bool:
         """Bind the TCP port and start serving. Returns True on success, False on failure."""
         self._runner = web.AppRunner(self.build_app(), access_log=None)
         await self._runner.setup()
         site = web.TCPSite(self._runner, self.bind_address, self.port)
         try:
             await site.start()
-        except OSError as e:
-            if e.errno == errno.EADDRINUSE:
+        except OSError as exc:
+            if exc.errno == errno.EADDRINUSE:
                 logger.error(
-                    f"Port {self.port} is already in use. Web server not started."
+                    "Port %s is already in use. Web server not started.", self.port
                 )
             else:
-                logger.error(f"Failed to bind to {self.bind_address}:{self.port}: {e}")
+                logger.error(
+                    "Failed to bind to %s:%s: %s", self.bind_address, self.port, exc
+                )
             await self._runner.cleanup()
             self._runner = None
             return False
 
-        logger.info(f"Web server started on {self.bind_address}:{self.port}")
+        logger.info("Web server started on %s:%s", self.bind_address, self.port)
         self._log_access_posture()
         return True
 
-    @staticmethod
-    def _add(method, app, path, handler):
-        """Register *path* both with and without a trailing slash.
-
-        A redirect would send a `Location` header, which both ingress hops
-        copy verbatim — navigating the user out of the ingress prefix.
-
-        Every ``POST`` is wrapped in the JSON content-type guard here rather
-        than at each handler, so a route added later cannot forget it — see
-        :data:`astrameter.web_guard.JSON_CONTENT_TYPE` for what it defends
-        against.
-        """
-        if method == "POST":
-            handler = requires_json_content_type(handler)
-        app.router.add_route(method, path, handler)
-        app.router.add_route(method, path + "/", handler)
-
-    def _log_access_posture(self):
+    def _log_access_posture(self) -> None:
         if not self.enable_dashboard:
             if self.serve_config_editor and self.config_path:
                 logger.warning(
@@ -331,43 +391,38 @@ class WebServer:
                 self.port,
             )
 
-    async def stop(self):
+    async def stop(self) -> None:
         """Tear down the aiohttp runner and release the port."""
         if self._runner:
             await self._runner.cleanup()
             self._runner = None
             logger.info("Web server stopped")
 
-    def is_running(self):
+    def is_running(self) -> bool:
         """Return True if the HTTP server is currently running."""
         return self._runner is not None
 
-    async def _handle_health(self, request):
+    async def _handle_health(self, request: web.Request) -> web.StreamResponse:
         """Respond to GET /health and /api with a JSON healthy status."""
-        logger.debug(
-            "Health check request received from %s",
-            request.remote,
-        )
+        logger.debug("Health check request received from %s", request.remote)
         payload = {"status": "healthy", "service": "astrameter"}
         sha = get_git_commit_sha()
         if sha:
             payload["git_commit"] = sha
-        return _json(payload, cache="no-cache")
+        return json_response(payload, cache="no-cache")
 
     # -- dashboard -----------------------------------------------------
 
-    async def _handle_dashboard(self, request):
+    async def _handle_dashboard(self, request: web.Request) -> web.StreamResponse:
         """Serve the single-page dashboard."""
         if not self._trusted(request):
             # A person typed this into a browser, so answer in prose. The
             # frontend carries the same explanation for a refused poll, but it
             # never loads when the page itself is the thing being refused.
             return web.Response(status=403, text=REFUSED_HTML, content_type="text/html")
-        from astrameter.status.assets import dashboard_html
-
         html = dashboard_html()
         if html is None:
-            return _error("Dashboard asset missing from this build", status=503)
+            return error_response("Dashboard asset missing from this build", status=503)
         return web.Response(
             body=html,
             content_type="text/html",
@@ -375,70 +430,70 @@ class WebServer:
             headers={"Cache-Control": "no-cache, must-revalidate"},
         )
 
-    async def _handle_api_status(self, request):
+    async def _handle_api_status(self, request: web.Request) -> web.StreamResponse:
         """Live status snapshot, with a weak ETag for cheap polling."""
         if not self._trusted(request) or self.status is None:
-            return _forbidden()
+            return forbidden()
         etag = self.status.etag()
         if request.headers.get("If-None-Match") == etag:
             return web.Response(
                 status=304, headers={"ETag": etag, "Cache-Control": "no-store"}
             )
         snapshot = self.status.snapshot(ingress=self._is_ingress(request))
-        return _json(snapshot, ETag=etag)
+        return json_response(snapshot, ETag=etag)
 
     # -- live control --------------------------------------------------
 
-    def _device(self, device_id):
+    def _device(self, device_id: str) -> Any:
         if self.status is None:
             return None
         entry = self.status.devices.get(device_id)
         return entry.device if entry else None
 
-    async def _mirror_to_mqtt(self, method_name, kind, *args) -> None:
+    async def _mirror_to_mqtt(self, kind: str, publish: Awaitable[None]) -> None:
         """Mirror a control write to the retained MQTT command topic.
 
         Without it the broker's redelivery on the next reconnect reverts what
         the user just set.
         """
-        publish = getattr(getattr(self.status, "insights", None), method_name, None)
-        if publish is None:
-            return
         try:
-            await publish(*args)
+            await publish
         except Exception:
             logger.exception("Failed to mirror %s write to MQTT", kind)
 
-    def _applied(self):
-        """Acknowledge a control write with the revision it produced."""
-        self.status.bump()
-        return _json({"applied": True, "rev": self.status.revision()})
+    def _insights(self) -> Any:
+        """The MQTT Insights service, when one is running."""
+        return self.status.insights if self.status is not None else None
 
-    async def _handle_control_consumer(self, request):
+    def _applied(self) -> web.StreamResponse:
+        """Acknowledge a control write with the revision it produced."""
+        assert self.status is not None  # _may_write() already refused otherwise
+        self.status.bump()
+        return json_response({"applied": True, "rev": self.status.revision()})
+
+    async def _handle_control_consumer(
+        self, request: web.Request
+    ) -> web.StreamResponse:
         """Apply a per-battery control change."""
         if not self._may_write(request):
-            return _forbidden()
-        try:
-            body = await request.json()
-            device_id = body["device_id"]
-            consumer_id = body["consumer_id"]
-            field = body["field"]
-            value = body["value"]
-        except (KeyError, TypeError, json.JSONDecodeError) as exc:
-            return _error(f"Invalid request: {exc}", status=400)
+            return forbidden()
+        body = await _body(request)
+        device_id, consumer_id, field, value = _required(
+            body, "device_id", "consumer_id", "field", "value"
+        )
 
         device = self._device(device_id)
         control = CONSUMER_CONTROLS_BY_FIELD.get(field)
         if device is None or control is None:
-            return _error("Unknown device or field", status=404)
+            return error_response("Unknown device or field", status=404)
         try:
             control.apply(device, consumer_id, control.coerce(value))
         except AttributeError:
             # A device without this setter — a Shelly emulation, say — is
             # registered too, and has no per-battery controls.
-            return _error("Unknown device or field", status=404)
+            return error_response("Unknown device or field", status=404)
         except ValueError as exc:
-            return _error(str(exc), status=400)
+            return error_response(str(exc), status=400)
 
         logger.info(
             "Dashboard control: %s %s.%s = %r by %s",
@@ -448,36 +503,35 @@ class WebServer:
             value,
             self._actor(request),
         )
-        # The command topic carries the *entity* unit, the same one this
-        # request arrived in — mirror the wire value, not the scaled setter
-        # argument, or the replay on the next reconnect reapplies a percentage
-        # as a fraction.
-        await self._mirror_to_mqtt(
-            "publish_consumer_command", "control", device_id, consumer_id, field, value
-        )
+        insights = self._insights()
+        if insights is not None:
+            # The command topic carries the *entity* unit, the same one this
+            # request arrived in — mirror the wire value, not the scaled setter
+            # argument, or the replay on the next reconnect reapplies a
+            # percentage as a fraction.
+            await self._mirror_to_mqtt(
+                "control",
+                insights.publish_consumer_command(device_id, consumer_id, field, value),
+            )
         return self._applied()
 
-    async def _handle_control_device(self, request):
+    async def _handle_control_device(self, request: web.Request) -> web.StreamResponse:
         """Apply a device-wide control change."""
         if not self._may_write(request):
-            return _forbidden()
-        try:
-            body = await request.json()
-            device_id = body["device_id"]
-            field = body["field"]
-            value = body.get("value", True)
-        except (KeyError, TypeError, json.JSONDecodeError) as exc:
-            return _error(f"Invalid request: {exc}", status=400)
+            return forbidden()
+        body = await _body(request)
+        (device_id, field) = _required(body, "device_id", "field")
+        value = body.get("value", True)
 
         device = self._device(device_id)
         if device is None:
-            return _error("Unknown device", status=404)
+            return error_response("Unknown device", status=404)
         try:
             apply_device_control(device, field, bool(value))
         except KeyError:
-            return _error("Unknown field", status=404)
+            return error_response("Unknown field", status=404)
         except (AttributeError, ValueError) as exc:
-            return _error(str(exc), status=400)
+            return error_response(str(exc), status=400)
 
         logger.info(
             "Dashboard control: %s.%s = %r by %s",
@@ -486,40 +540,44 @@ class WebServer:
             value,
             self._actor(request),
         )
-        await self._mirror_to_mqtt(
-            "publish_device_command", "device", device_id, {field: value}
-        )
+        insights = self._insights()
+        if insights is not None:
+            await self._mirror_to_mqtt(
+                "device", insights.publish_device_command(device_id, {field: value})
+            )
         return self._applied()
 
     # -- Home Assistant add-on options ---------------------------------
 
-    def _supervisor(self, request):
-        """A Supervisor client, or an error response explaining why not."""
-        from astrameter.addon_client import SupervisorClient
-
+    def _supervisor(self, request: web.Request) -> SupervisorClient:
+        """A Supervisor client for a request allowed to write through it."""
         if not self._may_write(request):
-            return None, _forbidden()
+            raise ApiError("Forbidden", status=403)
         client = SupervisorClient()
         if not client.available():
-            return None, _error("Not running as a Home Assistant add-on", status=409)
-        return client, None
+            raise ApiError("Not running as a Home Assistant add-on", status=409)
+        return client
 
-    async def _handle_addon_options_get(self, request):
-        """Current add-on options plus their schema, secrets redacted."""
-        client, error = self._supervisor(request)
-        if error:
-            return error
+    @staticmethod
+    async def _addon_info(client: SupervisorClient) -> dict[str, Any]:
+        """The add-on's current options and schema, as Supervisor reports them."""
         try:
-            info = await client.get_info()
+            return await client.get_info()
         except Exception as exc:
-            return _error(str(exc), status=502)
+            raise ApiError(str(exc), status=502) from exc
+
+    async def _handle_addon_options_get(
+        self, request: web.Request
+    ) -> web.StreamResponse:
+        """Current add-on options plus their schema, secrets redacted."""
+        info = await self._addon_info(self._supervisor(request))
         options = dict(info.get("options") or {})
         # Not `or {}`: that flattens exactly the malformed shapes worth
         # reporting — `[]` would arrive here as an object and the diagnostic
         # would say nothing. `None` is Supervisor's documented "no schema".
         schema = info.get("schema")
         self._log_unrenderable_schema(schema)
-        return _json(
+        return json_response(
             {
                 "options": redact_sections({"o": options})["o"],
                 "schema": {} if schema is None else schema,
@@ -528,7 +586,7 @@ class WebServer:
             }
         )
 
-    def _log_unrenderable_schema(self, schema) -> None:
+    def _log_unrenderable_schema(self, schema: Any) -> None:
         """Name any schema entry the guided form cannot turn into a control.
 
         A repeated or nested option renders read-only, and without this the
@@ -564,69 +622,67 @@ class WebServer:
                 ", ".join(f"{k} ({t})" for k, t in sorted(odd.items())),
             )
 
-    async def _handle_addon_options_post(self, request):
+    async def _handle_addon_options_post(
+        self, request: web.Request
+    ) -> web.StreamResponse:
         """Write add-on options through Supervisor.
 
         Supervisor replaces the whole persisted overlay and silently drops
         keys absent from the schema, so a typo would lose a value with no
         error — every key is validated against the live schema first.
         """
-        client, error = self._supervisor(request)
-        if error:
-            return error
-        try:
-            body = await request.json()
-            options = body["options"]
-            if not isinstance(options, dict):
-                raise ValueError("'options' must be an object")
-        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
-            return _error(f"Invalid request: {exc}", status=400)
+        client = self._supervisor(request)
+        body = await _body(request)
+        (options,) = _required(body, "options")
+        if not isinstance(options, dict):
+            raise ApiError("Invalid request: 'options' must be an object", status=400)
 
-        try:
-            info = await client.get_info()
-        except Exception as exc:
-            return _error(str(exc), status=502)
+        info = await self._addon_info(client)
         unknown = sorted(set(options) - addon_option_names(info.get("schema")))
         if unknown:
-            return _error(f"Unknown add-on option(s): {', '.join(unknown)}", status=400)
+            return error_response(
+                f"Unknown add-on option(s): {', '.join(unknown)}", status=400
+            )
         merged = restore_sections(
             {"o": options}, {"o": dict(info.get("options") or {})}
         )["o"]
+        await self._set_options(client, merged)
 
-        try:
-            await client.set_options(merged)
-        except Exception as exc:
-            return _error(str(exc), status=400)
         logger.info("Add-on options updated by %s", self._actor(request))
         if body.get("restart"):
             self._restart_after_response(client)
-            return _json({"saved": True, "restart": "supervisor"})
-        return _json({"saved": True, "restart": "none"})
+            return json_response({"saved": True, "restart": "supervisor"})
+        return json_response({"saved": True, "restart": "none"})
 
-    async def _handle_ha_entities(self, request):
+    @staticmethod
+    async def _set_options(client: SupervisorClient, options: dict[str, Any]) -> None:
+        try:
+            await client.set_options(options)
+        except Exception as exc:
+            raise ApiError(str(exc), status=400) from exc
+
+    async def _handle_ha_entities(self, request: web.Request) -> web.StreamResponse:
         """Home Assistant sensors that could be a grid-power source.
 
         Powers the entity picker in the guided form: typing a raw entity id
         from memory is the single easiest way to misconfigure AstraMeter, and
         a wrong id fails at start-up rather than here.
         """
-        from astrameter.addon_client import SupervisorClient
-
         if not self._trusted(request):
-            return _forbidden()
+            return forbidden()
         client = SupervisorClient()
         if not client.available():
-            return _error("Not running as a Home Assistant add-on", status=409)
+            return error_response("Not running as a Home Assistant add-on", status=409)
         try:
             entities = await client.list_power_entities()
         except Exception as exc:
             # A failed lookup must not block the form — the field stays a
             # plain text input and the user can still type an id.
             logger.warning("Could not list Home Assistant entities: %s", exc)
-            return _json({"entities": [], "error": str(exc)})
-        return _json({"entities": entities}, cache="max-age=30")
+            return json_response({"entities": [], "error": str(exc)})
+        return json_response({"entities": entities}, cache="max-age=30")
 
-    def _restart_after_response(self, client) -> None:
+    def _restart_after_response(self, client: SupervisorClient) -> None:
         """Ask Supervisor to restart us, once this response is on the wire.
 
         The restart tears down the container serving the request, so awaiting
@@ -650,82 +706,74 @@ class WebServer:
         self._pending_restarts.add(task)
         task.add_done_callback(self._pending_restarts.discard)
 
-    async def _handle_addon_restart(self, request):
-        client, error = self._supervisor(request)
-        if error:
-            return error
+    async def _handle_addon_restart(self, request: web.Request) -> web.StreamResponse:
+        client = self._supervisor(request)
         logger.info("Add-on restart requested by %s", self._actor(request))
         self._restart_after_response(client)
-        return _json({"restarting": True}, status=202)
+        return json_response({"restarting": True}, status=202)
 
-    async def _handle_config_mode_post(self, request):
+    async def _handle_config_mode_post(
+        self, request: web.Request
+    ) -> web.StreamResponse:
         """Switch between add-on options and a custom ``config.ini``.
 
         Simple → file materialises the config the add-on just generated into
         the shared config dir, so the user starts from what is actually
         running rather than a blank file.
         """
-        client, error = self._supervisor(request)
-        if error:
-            return error
-        try:
-            body = await request.json()
-            target = body["mode"]
-        except (KeyError, TypeError, json.JSONDecodeError) as exc:
-            return _error(f"Invalid request: {exc}", status=400)
-
-        from astrameter.status.config_mode import materialize_config
+        client = self._supervisor(request)
+        body = await _body(request)
+        (target,) = _required(body, "mode")
 
         if target == "file":
             filename = (body.get("filename") or "astrameter.ini").strip()
-            try:
-                materialize_config(self.status.app_config, filename)
-            except ValueError as exc:
-                # A filename the user chose that target_path refuses.
-                return _error(str(exc), status=400)
-            except OSError as exc:
-                return _error(f"Cannot write config file: {exc}", status=500)
-            options = {"custom_config": filename}
+            options = {"custom_config": self._materialize(filename)}
         elif target == "options":
             options = {"custom_config": ""}
         else:
-            return _error("mode must be 'file' or 'options'", status=400)
+            return error_response("mode must be 'file' or 'options'", status=400)
 
-        try:
-            info = await client.get_info()
-            merged = {**(info.get("options") or {}), **options}
-            await client.set_options(merged)
-        except Exception as exc:
-            return _error(str(exc), status=400)
+        info = await self._addon_info(client)
+        await self._set_options(client, {**(info.get("options") or {}), **options})
         logger.info(
             "Configuration mode switched to %r by %s", target, self._actor(request)
         )
         self._restart_after_response(client)
-        return _json({"switched": True, "mode": target, "restart": "supervisor"})
+        return json_response(
+            {"switched": True, "mode": target, "restart": "supervisor"}
+        )
+
+    def _materialize(self, filename: str) -> str:
+        """Write the running config to *filename*, and return the name stored."""
+        assert self.status is not None  # _supervisor() already refused otherwise
+        try:
+            materialize_config(self.status.app_config, filename)
+        except ValueError as exc:
+            # A filename the user chose that target_path refuses.
+            raise ApiError(str(exc), status=400) from exc
+        except OSError as exc:
+            raise ApiError(f"Cannot write config file: {exc}", status=500) from exc
+        return filename
 
     # -- config.ini editor ---------------------------------------------
 
-    async def _handle_config_ui(self, request):
+    async def _handle_config_ui(self, request: web.Request) -> web.StreamResponse:
         """Serve the HTML configuration editor at GET /config."""
-        if not self._trusted(request) and self.status is not None:
-            return _forbidden()
-        from astrameter.web_config import CONFIG_EDITOR_HTML
-
+        if not self._may_read(request):
+            return forbidden()
         return web.Response(
             body=CONFIG_EDITOR_HTML.encode("utf-8"),
             content_type="text/html",
             charset="utf-8",
         )
 
-    async def _handle_api_key_types(self, request):
+    async def _handle_api_key_types(self, request: web.Request) -> web.StreamResponse:
         """Return the section key-type metadata as JSON at GET /api/key-types."""
-        if not self._trusted(request) and self.status is not None:
-            return _forbidden()
-        from astrameter.web_config import SECTION_KEY_TYPES
+        if not self._may_read(request):
+            return forbidden()
+        return json_response(SECTION_KEY_TYPES, cache="max-age=3600")
 
-        return _json(SECTION_KEY_TYPES, cache="max-age=3600")
-
-    def _config_write_blocked(self, request):
+    def _config_write_blocked(self, request: web.Request) -> str | None:
         """Why a config.ini write is refused, or None when it is allowed.
 
         The rule itself is ``StatusRegistry.config_writable``, so what the
@@ -743,91 +791,90 @@ class WebServer:
             )
         return None
 
-    async def _handle_api_config_get(self, request):
-        """Return the current config.ini contents as JSON at GET /api/config."""
-        if not self._trusted(request) and self.status is not None:
-            return _forbidden()
-        from astrameter.web_config import read_config_as_dict
-
+    def _require_config_path(self) -> str:
         if not self.config_path:
-            return _error("Config path not set", status=500)
+            raise ApiError("Config path not set", status=500)
+        return self.config_path
+
+    async def _handle_api_config_get(self, request: web.Request) -> web.StreamResponse:
+        """Return the current config.ini contents as JSON at GET /api/config."""
+        if not self._may_read(request):
+            return forbidden()
+        path = self._require_config_path()
         try:
-            sections, order = read_config_as_dict(self.config_path)
-            return _json({"sections": redact_sections(sections), "order": order})
+            sections, order = read_config_as_dict(path)
+            return json_response(
+                {"sections": redact_sections(sections), "order": order}
+            )
         except Exception:
             logger.exception("Error reading config")
-            return _error("Internal server error", status=500)
+            return error_response("Internal server error", status=500)
 
-    async def _handle_api_config_post(self, request):
+    async def _handle_api_config_post(self, request: web.Request) -> web.StreamResponse:
         """Write updated config sections from the JSON body at POST /api/config."""
-        import shutil
-        import tempfile
-
-        from astrameter.web_config import (
-            read_config_as_dict,
-            validate_config,
-            write_config_from_dict,
-        )
-
         blocked = self._config_write_blocked(request)
         if blocked:
-            return _error(blocked, status=403)
-        if not self.config_path:
-            return _error("Config path not set", status=500)
+            return error_response(blocked, status=403)
+        path = self._require_config_path()
+        body = await _body(request)
+
         try:
-            data = await request.json()
-            if not isinstance(data, dict):
-                raise ValueError("JSON body must be an object")
-            sections = data.get("sections", {})
+            sections = body.get("sections", {})
             if not isinstance(sections, dict):
                 raise ValueError("'sections' must be an object")
-            order = data.get("order", list(sections.keys()))
+            order = body.get("order", list(sections.keys()))
             if not isinstance(order, list):
                 raise ValueError("'order' must be a list")
             # A value still equal to the sentinel means "keep what is
             # stored", so a redacted secret is never written back as bullets.
-            current, _ = read_config_as_dict(self.config_path)
+            current, _ = read_config_as_dict(path)
             sections = restore_sections(sections, current)
-            # Write to a temp copy and validate before touching the live file.
-            dir_name = os.path.dirname(self.config_path) or "."
-            with tempfile.NamedTemporaryFile(
-                "w", dir=dir_name, suffix=".tmp", delete=False
-            ) as tmp:
-                tmp_path = tmp.name
-            try:
-                if os.path.exists(self.config_path):
-                    shutil.copyfile(self.config_path, tmp_path)
-                write_config_from_dict(tmp_path, sections, order)
-                validate_config(tmp_path)
-            except Exception:
-                os.unlink(tmp_path)
-                raise
-            os.unlink(tmp_path)
-            write_config_from_dict(self.config_path, sections, order)
-            logger.info("Configuration updated by %s", self._actor(request))
-            return _json({"success": True})
-        except (ValueError, json.JSONDecodeError) as e:
-            logger.error("Invalid config request: %s", e)
-            return _error(str(e), status=400)
+            _validate_config_write(path, sections, order)
+            write_config_from_dict(path, sections, order)
+        except (ValueError, json.JSONDecodeError) as exc:
+            logger.error("Invalid config request: %s", exc)
+            return error_response(str(exc), status=400)
         except Exception:
             logger.exception("Error saving config")
-            return _error("Internal server error", status=500)
+            return error_response("Internal server error", status=500)
 
-    async def _handle_api_restart(self, request):
+        logger.info("Configuration updated by %s", self._actor(request))
+        return json_response({"success": True})
+
+    async def _handle_api_restart(self, request: web.Request) -> web.StreamResponse:
         """Acknowledge POST /api/restart and schedule an in-process restart via SIGUSR1."""
-        import signal
-
         if self.status is not None and not self._may_write(request):
-            return _forbidden()
+            return forbidden()
         logger.info("Restart requested by %s", self._actor(request))
         if self.status is not None:
             self.status.restart_pending = True
             self.status.bump()
         # SIGUSR1 so the handler in main.py restarts the device cycle instead
         # of exiting.  The web server itself survives it.
-        threading.Timer(0.5, lambda: os.kill(os.getpid(), signal.SIGUSR1)).start()
-        return _json({"restarting": True}, status=202)
+        threading.Timer(
+            RESTART_GRACE_S, lambda: os.kill(os.getpid(), signal.SIGUSR1)
+        ).start()
+        return json_response({"restarting": True}, status=202)
 
-    async def _handle_not_found(self, request):
+    async def _handle_not_found(self, request: web.Request) -> web.StreamResponse:
         """Return a 404 JSON response for any unmatched route."""
-        return _error("Not Found", status=404)
+        return error_response("Not Found", status=404)
+
+
+def _validate_config_write(path: str, sections: dict, order: list) -> None:
+    """Trial-write *sections* beside *path* and load it, before touching the live file.
+
+    A config that fails to parse would otherwise take the service down on its
+    next start, with the editor reporting success.
+    """
+    with tempfile.NamedTemporaryFile(
+        "w", dir=os.path.dirname(path) or ".", suffix=".tmp", delete=False
+    ) as tmp:
+        trial = tmp.name
+    try:
+        if os.path.exists(path):
+            shutil.copyfile(path, trial)
+        write_config_from_dict(trial, sections, order)
+        validate_config(trial)
+    finally:
+        os.unlink(trial)

--- a/src/astrameter/web_server.py
+++ b/src/astrameter/web_server.py
@@ -145,7 +145,7 @@ class WebServer:
         enable_web_config: bool | None = None,
         status: StatusRegistry | None = None,
         allowed_hosts: str | Iterable[str] | None = None,
-    ):
+    ) -> None:
         """Initialise the service; call ``start()`` to bind the port."""
         self.port = port
         self.bind_address = bind_address

--- a/src/astrameter/web_server_test.py
+++ b/src/astrameter/web_server_test.py
@@ -4,6 +4,7 @@ the control-write validation."""
 import asyncio
 import dataclasses
 import json
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -23,7 +24,7 @@ class _InsightsSnapshot:
     connected: bool = True
 
 
-def _registry(tmp_path, **kwargs) -> StatusRegistry:
+def _registry(tmp_path: Path, **kwargs: Any) -> StatusRegistry:
     kwargs.setdefault("config_path", str(tmp_path / "config.ini"))
     kwargs.setdefault("log_level", "info")
     kwargs.setdefault("version", "9.9.9")
@@ -43,13 +44,14 @@ def _device() -> CT002:
     return device
 
 
-async def _client(registry, **kwargs) -> TestClient:
+async def _client(registry: StatusRegistry | None, **kwargs: Any) -> TestClient:
     """A test client. Requests appear to come from 127.0.0.1, i.e. NOT ingress.
 
     Uses the production ``build_app()`` so the routes under test are exactly
     the routes that ship.
     """
-    server = WebServer(config_path=registry.config_path, status=registry, **kwargs)
+    config_path = registry.config_path if registry is not None else None
+    server = WebServer(config_path=config_path, status=registry, **kwargs)
     client = TestClient(TestServer(server.build_app()))
     await client.start_server()
     return client
@@ -58,7 +60,7 @@ async def _client(registry, **kwargs) -> TestClient:
 # -- the access gate --------------------------------------------------
 
 
-async def test_health_is_always_reachable(tmp_path):
+async def test_health_is_always_reachable(tmp_path: Path) -> None:
     """The Docker HEALTHCHECK and the add-on watchdog both probe /health, so
     it must answer even when everything else is gated off."""
     client = await _client(_registry(tmp_path, direct_access=False))
@@ -67,7 +69,9 @@ async def test_health_is_always_reachable(tmp_path):
 
 
 @pytest.mark.parametrize("path", ["/", "/api/status", "/api/config"])
-async def test_direct_access_is_refused_by_default_under_the_addon(tmp_path, path):
+async def test_direct_access_is_refused_by_default_under_the_addon(
+    tmp_path: Path, path: str
+) -> None:
     """Under host networking the port is on the LAN with no authentication,
     so anything sensitive must fail closed."""
     client = await _client(
@@ -80,28 +84,33 @@ async def test_direct_access_is_refused_by_default_under_the_addon(tmp_path, pat
 class _FakeSupervisor:
     """Stands in for SupervisorClient, answering one canned /addons/self/info."""
 
-    def __init__(self, info):
+    def __init__(self, info: Any) -> None:
         self._info = info
-        self.written = None
+        self.written: dict[str, Any] | None = None
         self.restarts = 0
         self.restart_error: Exception | None = None
 
-    def available(self):
+    def available(self) -> bool:
         return True
 
-    async def get_info(self):
+    async def get_info(self) -> Any:
         return self._info
 
-    async def set_options(self, options):
+    async def set_options(self, options: dict[str, Any]) -> None:
         self.written = options
 
-    async def restart(self):
+    async def restart(self) -> None:
         self.restarts += 1
         if self.restart_error is not None:
             raise self.restart_error
 
 
-async def _addon_options(monkeypatch, tmp_path, info, supervisor=None):
+async def _addon_options(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    info: Any,
+    supervisor: _FakeSupervisor | None = None,
+) -> TestClient:
     """Drive the real route with a canned Supervisor response.
 
     One stand-in for every call, so a test can assert on what the route asked
@@ -130,8 +139,8 @@ SUPERVISOR_SCHEMA = [
 
 
 async def test_supervisors_own_schema_shape_is_served_and_not_flagged(
-    monkeypatch, tmp_path, caplog
-):
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """A list of field descriptors is what a real Home Assistant sends, so it
     is the normal case — warning about it would cry wolf on every install."""
     client = await _addon_options(
@@ -147,7 +156,9 @@ async def test_supervisors_own_schema_shape_is_served_and_not_flagged(
     await client.close()
 
 
-async def test_saving_validates_against_supervisors_schema_shape(monkeypatch, tmp_path):
+async def test_saving_validates_against_supervisors_schema_shape(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """The unknown-key check used to feed the schema straight to `set()`,
     which a list of descriptors cannot go through — so every save against a
     real Supervisor died with a 500 before it reached the write."""
@@ -166,7 +177,9 @@ async def test_saving_validates_against_supervisors_schema_shape(monkeypatch, tm
     await client.close()
 
 
-async def test_the_restart_waits_for_the_answer_to_go_out(monkeypatch, tmp_path):
+async def test_the_restart_waits_for_the_answer_to_go_out(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """Supervisor tears down the container as part of the restart, so awaiting
     it in the handler killed us mid-response: the browser saw a 502 from the
     ingress proxy for a switch that had in fact worked, and the page showed an
@@ -191,8 +204,8 @@ async def test_the_restart_waits_for_the_answer_to_go_out(monkeypatch, tmp_path)
 
 
 async def test_a_failed_deferred_restart_is_logged_not_lost(
-    monkeypatch, tmp_path, caplog
-):
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """Nothing is left to answer to by then, so the log is the only place it
     can surface."""
 
@@ -212,8 +225,8 @@ async def test_a_failed_deferred_restart_is_logged_not_lost(
 
 
 async def test_an_unrenderable_option_is_named_in_the_log(
-    monkeypatch, tmp_path, caplog
-):
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """The guided form shows such an option read-only, which on its own is a
     greyed-out box with no explanation anywhere an operator looks."""
     repeated = {"name": "extra_hosts", "multiple": True, "type": "string"}
@@ -242,8 +255,8 @@ async def test_an_unrenderable_option_is_named_in_the_log(
 
 
 async def test_the_add_ons_own_declared_schema_is_still_understood(
-    monkeypatch, tmp_path, caplog
-):
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """config.yaml's mapping form, in case a Supervisor ever serves it raw."""
     client = await _addon_options(
         monkeypatch,
@@ -259,8 +272,8 @@ async def test_the_add_ons_own_declared_schema_is_still_understood(
 
 
 async def test_a_schema_that_is_neither_shape_survives_to_be_diagnosed(
-    monkeypatch, tmp_path, caplog
-):
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """`or {}` would turn this into an empty object before anything looked at
     it — flattening precisely the malformed shape worth reporting, and hiding
     from the browser what Supervisor actually sent."""
@@ -275,8 +288,8 @@ async def test_a_schema_that_is_neither_shape_survives_to_be_diagnosed(
 
 
 async def test_a_null_schema_is_not_reported_as_malformed(
-    monkeypatch, tmp_path, caplog
-):
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """Supervisor documents `schema: null` for an add-on that declares none.
     The form says so on its own; a warning would be crying wolf."""
     client = await _addon_options(
@@ -289,7 +302,7 @@ async def test_a_null_schema_is_not_reported_as_malformed(
     await client.close()
 
 
-async def test_a_refused_page_explains_itself_in_prose(tmp_path):
+async def test_a_refused_page_explains_itself_in_prose(tmp_path: Path) -> None:
     """Someone typed the address into a browser. A raw JSON error tells them
     nothing about the sidebar or the option that would let this port work."""
     client = await _client(
@@ -305,7 +318,9 @@ async def test_a_refused_page_explains_itself_in_prose(tmp_path):
 
 
 @pytest.mark.parametrize("path", ["/", "/api/status"])
-async def test_standalone_serves_without_a_second_opt_in(tmp_path, path):
+async def test_standalone_serves_without_a_second_opt_in(
+    tmp_path: Path, path: str
+) -> None:
     """Outside the add-on there is no ingress peer, so the plain port is the
     only way in. Gating it behind a further flag would make DASHBOARD_ENABLED
     on its own do nothing at all — which is what a standalone user sets."""
@@ -316,7 +331,7 @@ async def test_standalone_serves_without_a_second_opt_in(tmp_path, path):
     await client.close()
 
 
-async def test_forged_ingress_headers_do_not_grant_access(tmp_path):
+async def test_forged_ingress_headers_do_not_grant_access(tmp_path: Path) -> None:
     """The gate is the peer address precisely because a LAN client can set
     any header it likes."""
     client = await _client(
@@ -333,13 +348,13 @@ async def test_forged_ingress_headers_do_not_grant_access(tmp_path):
     await client.close()
 
 
-async def test_direct_access_opt_in_allows_reads(tmp_path):
+async def test_direct_access_opt_in_allows_reads(tmp_path: Path) -> None:
     client = await _client(_registry(tmp_path, direct_access=True))
     assert (await client.get("/api/status")).status == 200
     await client.close()
 
 
-async def test_writes_need_both_trust_and_the_write_flag(tmp_path):
+async def test_writes_need_both_trust_and_the_write_flag(tmp_path: Path) -> None:
     registry = _registry(tmp_path, direct_access=True, allow_write=False)
     registry.register_device("ct-1", "ct002", _device())
     client = await _client(registry)
@@ -397,8 +412,8 @@ _WRITE_ROUTES: tuple[tuple[str, dict[str, Any]], ...] = (
 @pytest.mark.parametrize("path,body", _WRITE_ROUTES)
 @pytest.mark.parametrize("content_type", _SIMPLE_CONTENT_TYPES)
 async def test_writes_refuse_a_browser_simple_content_type(
-    tmp_path, path, body, content_type
-):
+    tmp_path: Path, path: str, body: dict, content_type: str
+) -> None:
     """A page the operator happens to visit must not be able to drive this.
 
     The trust gate cannot help: a request that website makes through their
@@ -418,7 +433,7 @@ async def test_writes_refuse_a_browser_simple_content_type(
     await client.close()
 
 
-async def test_a_declared_json_write_still_goes_through(tmp_path):
+async def test_a_declared_json_write_still_goes_through(tmp_path: Path) -> None:
     """The guard must refuse the browser's unasked-for encodings and nothing
     else, or it would take the dashboard's own controls down with them."""
     registry = _registry(tmp_path, direct_access=True, allow_write=True)
@@ -442,7 +457,7 @@ async def test_a_declared_json_write_still_goes_through(tmp_path):
     await client.close()
 
 
-async def test_the_guard_covers_every_post_route(tmp_path):
+async def test_the_guard_covers_every_post_route(tmp_path: Path) -> None:
     """A route added later must not be able to forget the guard.
 
     Driven off the shipped route table rather than the list above, so a new
@@ -502,7 +517,7 @@ _REBOUND_HOSTS = (
 
 
 @pytest.mark.parametrize("host", _REBOUND_HOSTS)
-async def test_a_rebound_name_cannot_read(tmp_path, host):
+async def test_a_rebound_name_cannot_read(tmp_path: Path, host: str) -> None:
     """The page has no login, so a name the attacker controls must not reach
     it — the reply to a same-origin read is theirs to keep."""
     client = await _client(_registry(tmp_path, direct_access=True))
@@ -512,7 +527,9 @@ async def test_a_rebound_name_cannot_read(tmp_path, host):
 
 
 @pytest.mark.parametrize("path,body", _WRITE_ROUTES)
-async def test_a_rebound_name_cannot_write(tmp_path, path, body):
+async def test_a_rebound_name_cannot_write(
+    tmp_path: Path, path: str, body: dict
+) -> None:
     """Rebinding defeats the content-type guard — the request is same-origin,
     so `application/json` needs no preflight. This is what stops the write."""
     registry = _registry(tmp_path, direct_access=True, allow_write=True)
@@ -545,7 +562,7 @@ async def test_a_rebound_name_cannot_write(tmp_path, path, body):
         "Homeassistant.LOCAL",
     ],
 )
-async def test_an_unrebindable_address_is_served(tmp_path, host):
+async def test_an_unrebindable_address_is_served(tmp_path: Path, host: str) -> None:
     """An IP literal needs no lookup, and localhost/.local/.home.arpa do not
     reach a nameserver an outsider can answer for. None can be aimed here."""
     client = await _client(_registry(tmp_path, direct_access=True))
@@ -554,7 +571,7 @@ async def test_an_unrebindable_address_is_served(tmp_path, host):
     await client.close()
 
 
-async def test_a_named_host_is_served_once_configured(tmp_path):
+async def test_a_named_host_is_served_once_configured(tmp_path: Path) -> None:
     """A reverse proxy or a private DNS entry is a real setup; the operator
     says so and it works, without opening the port to every other name."""
     client = await _client(
@@ -569,7 +586,7 @@ async def test_a_named_host_is_served_once_configured(tmp_path):
     await client.close()
 
 
-async def test_the_health_check_answers_under_any_name(tmp_path):
+async def test_the_health_check_answers_under_any_name(tmp_path: Path) -> None:
     """Docker's HEALTHCHECK and the watchdog reach it under whatever name the
     operator's monitoring uses, and it exposes nothing worth rebinding for."""
     client = await _client(_registry(tmp_path, direct_access=True))
@@ -579,7 +596,9 @@ async def test_the_health_check_answers_under_any_name(tmp_path):
     await client.close()
 
 
-async def test_ingress_is_not_subject_to_the_host_guard(tmp_path, monkeypatch):
+async def test_ingress_is_not_subject_to_the_host_guard(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Home Assistant is reached under a name we cannot know and has already
     authenticated the user; the peer address is what proves the hop."""
 
@@ -594,7 +613,7 @@ async def test_ingress_is_not_subject_to_the_host_guard(tmp_path, monkeypatch):
     await client.close()
 
 
-async def test_a_refused_host_explains_itself_in_prose(tmp_path):
+async def test_a_refused_host_explains_itself_in_prose(tmp_path: Path) -> None:
     """Most refusals are the operator's own hostname, not an attack, so the
     page has to say which option fixes it."""
     client = await _client(_registry(tmp_path, direct_access=True))
@@ -607,7 +626,9 @@ async def test_a_refused_host_explains_itself_in_prose(tmp_path):
     await client.close()
 
 
-def test_a_refused_host_is_logged_once_and_the_log_is_capped(caplog):
+def test_a_refused_host_is_logged_once_and_the_log_is_capped(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """The name is the caller's to choose, so the set that dedupes the log is
     a set an attacker could otherwise grow without bound."""
     from astrameter.web_guard import _REFUSED_HOST_LOG_CAP, RefusedHostLog
@@ -626,7 +647,7 @@ def test_a_refused_host_is_logged_once_and_the_log_is_capped(caplog):
         assert caplog.text.count("not logging") == 1
 
 
-def test_is_allowed_host_reads_the_header_the_way_a_browser_writes_it():
+def test_is_allowed_host_reads_the_header_the_way_a_browser_writes_it() -> None:
     """Unit-level edges the route tests would need a server to reach."""
     from astrameter.web_server import is_allowed_host, parse_allowed_hosts
 
@@ -681,21 +702,21 @@ _ADDRESSES = (
 
 
 @pytest.mark.parametrize("host", _NOT_ADDRESSES)
-def test_a_colon_does_not_make_something_an_address(host):
+def test_a_colon_does_not_make_something_an_address(host: str) -> None:
     from astrameter.web_server import is_allowed_host
 
     assert not is_allowed_host(host)
 
 
 @pytest.mark.parametrize("host", _ADDRESSES)
-def test_the_real_ipv6_forms_are_addresses(host):
+def test_the_real_ipv6_forms_are_addresses(host: str) -> None:
     from astrameter.web_server import is_allowed_host
 
     assert is_allowed_host(host)
     assert is_allowed_host(f"[{host}]:52500")
 
 
-async def test_dashboard_off_serves_no_routes(tmp_path):
+async def test_dashboard_off_serves_no_routes(tmp_path: Path) -> None:
     client = await _client(_registry(tmp_path, dashboard_enabled=False))
     assert (await client.get("/api/status")).status == 404
     assert (await client.get("/health")).status == 200
@@ -705,7 +726,7 @@ async def test_dashboard_off_serves_no_routes(tmp_path):
 # -- status -----------------------------------------------------------
 
 
-async def test_status_returns_a_snapshot_and_revalidates(tmp_path):
+async def test_status_returns_a_snapshot_and_revalidates(tmp_path: Path) -> None:
     registry = _registry(tmp_path, direct_access=True)
     registry.register_device("ct-1", "ct002", _device())
     client = await _client(registry)
@@ -723,7 +744,7 @@ async def test_status_returns_a_snapshot_and_revalidates(tmp_path):
     await client.close()
 
 
-async def test_no_handler_emits_a_location_header(tmp_path):
+async def test_no_handler_emits_a_location_header(tmp_path: Path) -> None:
     """Both ingress hops copy Location verbatim, so a redirect would navigate
     the user straight out of the panel."""
     registry = _registry(tmp_path, direct_access=True)
@@ -735,7 +756,7 @@ async def test_no_handler_emits_a_location_header(tmp_path):
     await client.close()
 
 
-async def test_trailing_slash_variants_are_registered(tmp_path):
+async def test_trailing_slash_variants_are_registered(tmp_path: Path) -> None:
     client = await _client(_registry(tmp_path, direct_access=True))
     assert (await client.get("/api/status/")).status == 200
     await client.close()
@@ -744,7 +765,9 @@ async def test_trailing_slash_variants_are_registered(tmp_path):
 # -- control writes ---------------------------------------------------
 
 
-async def test_control_write_applies_through_the_validated_setter(tmp_path):
+async def test_control_write_applies_through_the_validated_setter(
+    tmp_path: Path,
+) -> None:
     registry = _registry(tmp_path, direct_access=True, allow_write=True)
     device = _device()
     registry.register_device("ct-1", "ct002", device)
@@ -779,7 +802,9 @@ async def test_control_write_applies_through_the_validated_setter(tmp_path):
         ("manual_target", True),
     ],
 )
-async def test_out_of_range_control_writes_are_rejected(tmp_path, field, value):
+async def test_out_of_range_control_writes_are_rejected(
+    tmp_path: Path, field: str, value: object
+) -> None:
     """The CT002 setters do not bound their inputs — the ranges live in the
     MQTT handlers. A value MQTT would reject must be rejected here too, or the
     broker's retained state would silently revert it on the next reconnect."""
@@ -799,7 +824,9 @@ async def test_out_of_range_control_writes_are_rejected(tmp_path, field, value):
     await client.close()
 
 
-async def test_consumer_write_to_a_device_without_that_control_is_404(tmp_path):
+async def test_consumer_write_to_a_device_without_that_control_is_404(
+    tmp_path: Path,
+) -> None:
     """A Shelly emulation is registered too and has no per-battery setters;
     a write aimed at one must not surface as a 500."""
     from astrameter.shelly import Shelly
@@ -821,7 +848,7 @@ async def test_consumer_write_to_a_device_without_that_control_is_404(tmp_path):
     await client.close()
 
 
-async def test_unknown_device_or_field_is_a_404(tmp_path):
+async def test_unknown_device_or_field_is_a_404(tmp_path: Path) -> None:
     registry = _registry(tmp_path, direct_access=True, allow_write=True)
     registry.register_device("ct-1", "ct002", _device())
     client = await _client(registry)
@@ -836,7 +863,7 @@ async def test_unknown_device_or_field_is_a_404(tmp_path):
 # -- config -----------------------------------------------------------
 
 
-async def test_config_get_redacts_and_post_restores_secrets(tmp_path):
+async def test_config_get_redacts_and_post_restores_secrets(tmp_path: Path) -> None:
     config = tmp_path / "config.ini"
     config.write_text(
         "[GENERAL]\nDEVICE_TYPE = ct002\n\n[MQTT_INSIGHTS]\nBROKER = 10.0.0.2\nPASSWORD = hunter2\n"
@@ -858,7 +885,7 @@ async def test_config_get_redacts_and_post_restores_secrets(tmp_path):
     await client.close()
 
 
-async def test_simple_mode_refuses_config_writes(tmp_path):
+async def test_simple_mode_refuses_config_writes(tmp_path: Path) -> None:
     """The add-on regenerates config.ini on every start, so a write here
     would vanish at the next restart."""
     config = tmp_path / "config.ini"
@@ -882,7 +909,9 @@ async def test_simple_mode_refuses_config_writes(tmp_path):
 _EDITOR_ROUTES = ("/config", "/api/config", "/api/key-types")
 
 
-async def test_web_config_off_closes_the_editor_the_dashboard_would_open(tmp_path):
+async def test_web_config_off_closes_the_editor_the_dashboard_would_open(
+    tmp_path: Path,
+) -> None:
     """`WEB_CONFIG_ENABLED = False` is someone's explicit answer, given when
     the editor was the only thing on this port. The dashboard now defaults on
     and writable, so ignoring it would reopen, on upgrade, exactly what they
@@ -907,7 +936,9 @@ async def test_web_config_off_closes_the_editor_the_dashboard_would_open(tmp_pat
     await client.close()
 
 
-async def test_no_config_surface_is_announced_when_the_editor_is_off(tmp_path):
+async def test_no_config_surface_is_announced_when_the_editor_is_off(
+    tmp_path: Path,
+) -> None:
     """The page hides its Configuration tab when the backend names no
     config_mode — the same signal an ESPHome device sends. Without it the tab
     would stay, linking to routes that are no longer there."""
@@ -925,7 +956,9 @@ async def test_no_config_surface_is_announced_when_the_editor_is_off(tmp_path):
 
 
 @pytest.mark.parametrize("path", _EDITOR_ROUTES)
-async def test_the_editor_follows_the_dashboard_when_unset(tmp_path, path):
+async def test_the_editor_follows_the_dashboard_when_unset(
+    tmp_path: Path, path: str
+) -> None:
     """Unset is the default, and a new user should not have to find a flag to
     get the Configuration tab the page advertises."""
     (tmp_path / "config.ini").write_text("[GENERAL]\nDEVICE_TYPE = ct002\n")
@@ -934,7 +967,9 @@ async def test_the_editor_follows_the_dashboard_when_unset(tmp_path, path):
     await client.close()
 
 
-async def test_web_config_on_still_serves_the_editor_without_a_dashboard(tmp_path):
+async def test_web_config_on_still_serves_the_editor_without_a_dashboard(
+    tmp_path: Path,
+) -> None:
     """What the flag meant before there was a dashboard, unchanged."""
     (tmp_path / "config.ini").write_text("[GENERAL]\nDEVICE_TYPE = ct002\n")
     registry = _registry(tmp_path, dashboard_enabled=False)
@@ -947,7 +982,7 @@ async def test_web_config_on_still_serves_the_editor_without_a_dashboard(tmp_pat
 # -- device-wide controls (the MQTT switch + button) ------------------
 
 
-async def test_active_control_can_be_toggled(tmp_path):
+async def test_active_control_can_be_toggled(tmp_path: Path) -> None:
     registry = _registry(tmp_path, direct_access=True, allow_write=True)
     device = _device()
     registry.register_device("ct-1", "ct002", device)
@@ -961,7 +996,7 @@ async def test_active_control_can_be_toggled(tmp_path):
     await client.close()
 
 
-async def test_force_rotation_is_accepted(tmp_path):
+async def test_force_rotation_is_accepted(tmp_path: Path) -> None:
     registry = _registry(tmp_path, direct_access=True, allow_write=True)
     registry.register_device("ct-1", "ct002", _device())
     client = await _client(registry)
@@ -974,7 +1009,7 @@ async def test_force_rotation_is_accepted(tmp_path):
     await client.close()
 
 
-async def test_unknown_device_field_is_404(tmp_path):
+async def test_unknown_device_field_is_404(tmp_path: Path) -> None:
     registry = _registry(tmp_path, direct_access=True, allow_write=True)
     registry.register_device("ct-1", "ct002", _device())
     client = await _client(registry)
@@ -987,7 +1022,7 @@ async def test_unknown_device_field_is_404(tmp_path):
     await client.close()
 
 
-async def test_device_control_needs_the_write_flag(tmp_path):
+async def test_device_control_needs_the_write_flag(tmp_path: Path) -> None:
     registry = _registry(tmp_path, direct_access=True, allow_write=False)
     registry.register_device("ct-1", "ct002", _device())
     client = await _client(registry)
@@ -1003,7 +1038,9 @@ async def test_device_control_needs_the_write_flag(tmp_path):
 # -- units match the MQTT entity, not the setter ----------------------
 
 
-async def test_efficiency_window_weight_is_a_percentage_on_the_wire(tmp_path):
+async def test_efficiency_window_weight_is_a_percentage_on_the_wire(
+    tmp_path: Path,
+) -> None:
     """The MQTT entity is a 0-100 percentage while the setter takes a 0-1
     fraction, and the two must not disagree: 50 over HTTP has to mean the
     same thing as 50 over MQTT."""
@@ -1017,10 +1054,12 @@ async def test_efficiency_window_weight_is_a_percentage_on_the_wire(tmp_path):
         # The registry serialises whatever `status_snapshot` returns into the
         # `integrations` block, so a fake standing in for the service has to
         # answer it too.
-        def status_snapshot(self):
+        def status_snapshot(self) -> _InsightsSnapshot:
             return _InsightsSnapshot()
 
-        async def publish_consumer_command(self, device_id, consumer_id, field, value):
+        async def publish_consumer_command(
+            self, device_id: str, consumer_id: str, field: str, value: object
+        ) -> None:
             mirrored.append((device_id, consumer_id, field, value))
 
     registry.insights = _Insights()
@@ -1052,7 +1091,7 @@ async def test_efficiency_window_weight_is_a_percentage_on_the_wire(tmp_path):
     await client.close()
 
 
-async def test_full_efficiency_window_is_accepted(tmp_path):
+async def test_full_efficiency_window_is_accepted(tmp_path: Path) -> None:
     registry = _registry(tmp_path, direct_access=True, allow_write=True)
     device = _device()
     registry.register_device("ct-1", "ct002", device)

--- a/src/astrameter/web_server_test.py
+++ b/src/astrameter/web_server_test.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 from aiohttp.test_utils import TestClient, TestServer
 
+from astrameter import web_server
 from astrameter.ct002 import CT002
 from astrameter.status import StatusRegistry
 from astrameter.status.secrets import SENTINEL
@@ -106,10 +107,8 @@ async def _addon_options(monkeypatch, tmp_path, info, supervisor=None):
     One stand-in for every call, so a test can assert on what the route asked
     it to do.
     """
-    import astrameter.addon_client as addon_client
-
     fake = supervisor if supervisor is not None else _FakeSupervisor(info)
-    monkeypatch.setattr(addon_client, "SupervisorClient", lambda *a, **k: fake)
+    monkeypatch.setattr(web_server, "SupervisorClient", lambda *a, **k: fake)
     registry = _registry(
         tmp_path, allow_write=True, direct_access=True, config_mode="ha_simple"
     )
@@ -172,7 +171,6 @@ async def test_the_restart_waits_for_the_answer_to_go_out(monkeypatch, tmp_path)
     it in the handler killed us mid-response: the browser saw a 502 from the
     ingress proxy for a switch that had in fact worked, and the page showed an
     error for it."""
-    import astrameter.web_server as web_server
 
     monkeypatch.setattr(web_server, "RESTART_GRACE_S", 0.01)
     fake = _FakeSupervisor({"options": {}, "schema": SUPERVISOR_SCHEMA})
@@ -197,7 +195,6 @@ async def test_a_failed_deferred_restart_is_logged_not_lost(
 ):
     """Nothing is left to answer to by then, so the log is the only place it
     can surface."""
-    import astrameter.web_server as web_server
 
     monkeypatch.setattr(web_server, "RESTART_GRACE_S", 0.01)
     fake = _FakeSupervisor({"options": {}, "schema": SUPERVISOR_SCHEMA})
@@ -585,12 +582,11 @@ async def test_the_health_check_answers_under_any_name(tmp_path):
 async def test_ingress_is_not_subject_to_the_host_guard(tmp_path, monkeypatch):
     """Home Assistant is reached under a name we cannot know and has already
     authenticated the user; the peer address is what proves the hop."""
-    import astrameter.web_server as web_server_module
 
     client = await _client(
         _registry(tmp_path, direct_access=False, config_mode="ha_advanced")
     )
-    monkeypatch.setattr(web_server_module, "INGRESS_PEER", "127.0.0.1")
+    monkeypatch.setattr(web_server, "INGRESS_PEER", "127.0.0.1")
     response = await client.get(
         "/api/status", headers={"Host": "homeassistant.example.com:8123"}
     )

--- a/tests/components/ct002/test_codegen.py
+++ b/tests/components/ct002/test_codegen.py
@@ -16,7 +16,9 @@ import shutil
 import subprocess
 import sys
 import threading
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -33,7 +35,7 @@ import ct002 as ct002_component  # noqa: E402
 
 
 @contextlib.contextmanager
-def _target_platform(platform):
+def _target_platform(platform: str) -> Iterator[Any]:
     """Point CORE at *platform* for the duration, then put it back as it was.
 
     Restoring means *deleting* a key that was absent, not writing None over it:
@@ -56,49 +58,49 @@ def _target_platform(platform):
 
 
 @pytest.fixture
-def esp32_core():
+def esp32_core() -> Iterator[Any]:
     """CORE pointed at an ESP32, which is where the dashboard exists."""
     with _target_platform(esphome.const.PLATFORM_ESP32) as core:
         yield core
 
 
 @pytest.fixture
-def host_core():
+def host_core() -> Iterator[Any]:
     """CORE pointed at the host platform, which has no ESPHome web server."""
     with _target_platform(esphome.const.PLATFORM_HOST) as core:
         yield core
 
 
-def test_validate_ct_mac_accepts_empty():
+def test_validate_ct_mac_accepts_empty() -> None:
     assert ct002_component._validate_ct_mac("") == ""
 
 
-def test_validate_ct_mac_normalizes_colons_and_case():
+def test_validate_ct_mac_normalizes_colons_and_case() -> None:
     assert ct002_component._validate_ct_mac("02:B2:50:12:AB:CD") == "02b25012abcd"
     assert ct002_component._validate_ct_mac("02-B2-50-12-AB-CD") == "02b25012abcd"
     assert ct002_component._validate_ct_mac("02b25012abcd") == "02b25012abcd"
 
 
-def test_validate_ct_mac_rejects_wrong_length():
+def test_validate_ct_mac_rejects_wrong_length() -> None:
     import esphome.config_validation as cv
 
     with pytest.raises(cv.Invalid):
         ct002_component._validate_ct_mac("02b250")
 
 
-def test_validate_ct_mac_rejects_non_hex():
+def test_validate_ct_mac_rejects_non_hex() -> None:
     import esphome.config_validation as cv
 
     with pytest.raises(cv.Invalid):
         ct002_component._validate_ct_mac("zzbb250012abcd"[:12])
 
 
-def test_three_phase_validator_accepts_l1_only():
+def test_three_phase_validator_accepts_l1_only() -> None:
     config = {ct002_component.CONF_POWER_SENSOR_L1: "grid_l1"}
     assert ct002_component._validate_three_phase_sensors(config) is config
 
 
-def test_three_phase_validator_accepts_all_three():
+def test_three_phase_validator_accepts_all_three() -> None:
     config = {
         ct002_component.CONF_POWER_SENSOR_L1: "grid_l1",
         ct002_component.CONF_POWER_SENSOR_L2: "grid_l2",
@@ -107,7 +109,7 @@ def test_three_phase_validator_accepts_all_three():
     assert ct002_component._validate_three_phase_sensors(config) is config
 
 
-def test_three_phase_validator_rejects_only_l2():
+def test_three_phase_validator_rejects_only_l2() -> None:
     import esphome.config_validation as cv
 
     config = {
@@ -118,7 +120,7 @@ def test_three_phase_validator_rejects_only_l2():
         ct002_component._validate_three_phase_sensors(config)
 
 
-def test_three_phase_validator_rejects_only_l3():
+def test_three_phase_validator_rejects_only_l3() -> None:
     import esphome.config_validation as cv
 
     config = {
@@ -129,32 +131,32 @@ def test_three_phase_validator_rejects_only_l3():
         ct002_component._validate_three_phase_sensors(config)
 
 
-def test_power_unit_scale_accepts_power_units():
+def test_power_unit_scale_accepts_power_units() -> None:
     assert ct002_component._power_unit_scale("W") == 1.0
     assert ct002_component._power_unit_scale("kW") == 1000.0
     assert ct002_component._power_unit_scale("MW") == 1e6
     assert ct002_component._power_unit_scale("mW") == 0.001
 
 
-def test_power_unit_scale_assumes_watts_when_undeclared():
+def test_power_unit_scale_assumes_watts_when_undeclared() -> None:
     assert ct002_component._power_unit_scale(None) == 1.0
     assert ct002_component._power_unit_scale("") == 1.0
 
 
-def test_power_unit_scale_rejects_non_power_units():
+def test_power_unit_scale_rejects_non_power_units() -> None:
     # Case matters ("mW" milli vs "MW" mega), so "KW"/"w" are not accepted;
     # non-power units (temperature, energy, ...) must map to None → rejected.
     for unit in ("°C", "%", "V", "A", "kWh", "Wh", "KW", "w"):
         assert ct002_component._power_unit_scale(unit) is None
 
 
-def test_validate_power_unit_accepts_watts_and_undeclared():
+def test_validate_power_unit_accepts_watts_and_undeclared() -> None:
     ct002_component._validate_power_unit("power_sensor_l1", "grid_l1", "W")
     ct002_component._validate_power_unit("power_sensor_l1", "grid_l1", "kW")
     ct002_component._validate_power_unit("power_sensor_l1", "grid_l1", None)
 
 
-def test_validate_power_unit_rejects_celsius():
+def test_validate_power_unit_rejects_celsius() -> None:
     import esphome.config_validation as cv
 
     with pytest.raises(cv.Invalid) as exc_info:
@@ -162,14 +164,14 @@ def test_validate_power_unit_rejects_celsius():
     assert "not a power unit" in str(exc_info.value)
 
 
-def test_validate_power_unit_rejects_energy_unit():
+def test_validate_power_unit_rejects_energy_unit() -> None:
     import esphome.config_validation as cv
 
     with pytest.raises(cv.Invalid):
         ct002_component._validate_power_unit("power_sensor_l2", "meter_total", "kWh")
 
 
-def test_mqtt_insights_device_id_defaults_to_python_default():
+def test_mqtt_insights_device_id_defaults_to_python_default() -> None:
     # A blank device_id must fall back to the same default the Python add-on
     # uses, so both stacks publish HA discovery under astrameter_ct002_device-1
     # (regression: ESPHome used to derive it from the ct002: component id,
@@ -178,11 +180,11 @@ def test_mqtt_insights_device_id_defaults_to_python_default():
     assert ct002_component._resolve_mqtt_insights_device_id("") == "device-1"
 
 
-def test_mqtt_insights_device_id_uses_explicit_value():
+def test_mqtt_insights_device_id_uses_explicit_value() -> None:
     assert ct002_component._resolve_mqtt_insights_device_id("garage") == "garage"
 
 
-def test_mqtt_insights_schema_device_id_blank_by_default():
+def test_mqtt_insights_schema_device_id_blank_by_default() -> None:
     # The schema default must stay blank so _resolve_mqtt_insights_device_id
     # (not the schema) owns the fallback at to_code time. The sub-block schema
     # gates on an `mqtt:` component via cv.requires_component, so mark it loaded.
@@ -208,19 +210,19 @@ def test_mqtt_insights_schema_device_id_blank_by_default():
 # ── dashboard sub-block ────────────────────────────────────────────────
 
 
-def test_dashboard_shorthand_accepts_bare_key_and_true():
+def test_dashboard_shorthand_accepts_bare_key_and_true() -> None:
     # Turning the dashboard on must not require knowing an option name:
     # `dashboard:` and `dashboard: true` both mean "on, with the defaults".
     assert ct002_component._dashboard_shorthand(None) == {}
     assert ct002_component._dashboard_shorthand(True) == {}
 
 
-def test_dashboard_shorthand_passes_a_block_through():
+def test_dashboard_shorthand_passes_a_block_through() -> None:
     block = {"path": "/astrameter"}
     assert ct002_component._dashboard_shorthand(block) is block
 
 
-def test_dashboard_off_by_substitution_string(esp32_core):
+def test_dashboard_off_by_substitution_string(esp32_core: Any) -> None:
     # `dashboard: ${enable_dashboard}` expands to a string, not a bool, so the
     # two spellings have to mean the same thing.
     for spelling in ("false", "False", "no", "off"):
@@ -230,20 +232,20 @@ def test_dashboard_off_by_substitution_string(esp32_core):
         }, spelling
 
 
-def test_dashboard_on_by_substitution_string(esp32_core):
+def test_dashboard_on_by_substitution_string(esp32_core: Any) -> None:
     config = {"power_sensor_l1": "grid_l1", "dashboard": "true"}
     ct002_component._resolve_dashboard(config)
     assert ct002_component._dashboard_shorthand(config["dashboard"]) == {}
 
 
-def test_dashboard_false_drops_the_key_entirely(esp32_core):
+def test_dashboard_false_drops_the_key_entirely(esp32_core: Any) -> None:
     # `dashboard: false` must leave nothing behind, so a disabled dashboard
     # pulls in no HTTP server and no page in flash.
     config = {"power_sensor_l1": "grid_l1", "dashboard": False}
     assert ct002_component._resolve_dashboard(config) == {"power_sensor_l1": "grid_l1"}
 
 
-def test_dashboard_absent_means_on(esp32_core):
+def test_dashboard_absent_means_on(esp32_core: Any) -> None:
     # The whole point of opt-out: a configuration that never mentions the
     # dashboard still gets one.
     config = {"power_sensor_l1": "grid_l1"}
@@ -253,14 +255,14 @@ def test_dashboard_absent_means_on(esp32_core):
     }
 
 
-def test_dashboard_absent_stays_absent_off_esp32(host_core):
+def test_dashboard_absent_stays_absent_off_esp32(host_core: Any) -> None:
     # ESPHome has no HTTP server for the other targets, so the default must
     # not conjure a block the schema would then reject.
     config = {"power_sensor_l1": "grid_l1"}
     assert ct002_component._resolve_dashboard(config) == {"power_sensor_l1": "grid_l1"}
 
 
-def test_dashboard_path_normalizes_to_a_prefix():
+def test_dashboard_path_normalizes_to_a_prefix() -> None:
     # The mount prefix is concatenated with "/api/status" at runtime, so it
     # must never carry a trailing slash; the root becomes the empty prefix.
     assert ct002_component._validate_dashboard_path("/") == ""
@@ -268,21 +270,21 @@ def test_dashboard_path_normalizes_to_a_prefix():
     assert ct002_component._validate_dashboard_path("/astrameter/") == "/astrameter"
 
 
-def test_dashboard_path_requires_a_leading_slash():
+def test_dashboard_path_requires_a_leading_slash() -> None:
     import esphome.config_validation as cv
 
     with pytest.raises(cv.Invalid):
         ct002_component._validate_dashboard_path("astrameter")
 
 
-def test_dashboard_path_rejects_a_query_string():
+def test_dashboard_path_rejects_a_query_string() -> None:
     import esphome.config_validation as cv
 
     with pytest.raises(cv.Invalid):
         ct002_component._validate_dashboard_path("/astrameter?x=1")
 
 
-def test_auto_load_pulls_the_web_server_only_for_a_resolved_dashboard():
+def test_auto_load_pulls_the_web_server_only_for_a_resolved_dashboard() -> None:
     # A parameterized AUTO_LOAD runs *after* CONFIG_SCHEMA, so it is handed the
     # validated config — one _resolve_dashboard has already been through. There
     # the key is present exactly when a dashboard was asked for, which is the
@@ -292,7 +294,9 @@ def test_auto_load_pulls_the_web_server_only_for_a_resolved_dashboard():
     assert "web_server_base" not in ct002_component.AUTO_LOAD({})
 
 
-def test_auto_load_matches_resolve_dashboard_for_every_spelling(esp32_core):
+def test_auto_load_matches_resolve_dashboard_for_every_spelling(
+    esp32_core: Any,
+) -> None:
     # Belt and braces on the above: run each spelling through the resolver the
     # way ESPHome does, and check AUTO_LOAD agrees with the outcome.
     for spelling, wants_server in (
@@ -308,25 +312,25 @@ def test_auto_load_matches_resolve_dashboard_for_every_spelling(esp32_core):
         assert loaded is wants_server, f"{spelling} -> {resolved}"
 
 
-def test_auto_load_leaves_the_web_server_out_off_esp32(host_core):
+def test_auto_load_leaves_the_web_server_out_off_esp32(host_core: Any) -> None:
     assert "web_server_base" not in ct002_component.AUTO_LOAD(
         ct002_component._resolve_dashboard({})
     )
 
 
-def test_auto_load_always_carries_the_sub_block_infrastructure(esp32_core):
+def test_auto_load_always_carries_the_sub_block_infrastructure(esp32_core: Any) -> None:
     for component in ("socket", "json", "md5"):
         assert component in ct002_component.AUTO_LOAD({})
 
 
-def test_dashboard_without_a_path_takes_the_root():
+def test_dashboard_without_a_path_takes_the_root() -> None:
     # No `web_server:` in the configuration, so the root is the dashboard's.
     config = {ct002_component.CONF_DASHBOARD: {}}
     ct002_component._final_validate_dashboard_path(config, {})
     assert config[ct002_component.CONF_DASHBOARD][ct002_component.CONF_PATH] == ""
 
 
-def test_dashboard_steps_aside_for_the_esphome_web_server():
+def test_dashboard_steps_aside_for_the_esphome_web_server() -> None:
     # A default-on dashboard must never be the reason an existing
     # `web_server:` build stops working, so it moves rather than collides.
     config = {ct002_component.CONF_DASHBOARD: {}}
@@ -337,7 +341,7 @@ def test_dashboard_steps_aside_for_the_esphome_web_server():
     )
 
 
-def test_dashboard_at_the_root_conflicts_with_esphome_web_server():
+def test_dashboard_at_the_root_conflicts_with_esphome_web_server() -> None:
     # Both mount on the shared HTTP server and the first handler to claim a
     # URL wins, so "/" for two pages would resolve on codegen order alone.
     import esphome.config_validation as cv
@@ -348,26 +352,26 @@ def test_dashboard_at_the_root_conflicts_with_esphome_web_server():
     assert "path: /astrameter" in str(exc_info.value)
 
 
-def test_dashboard_on_its_own_path_coexists_with_the_web_server():
+def test_dashboard_on_its_own_path_coexists_with_the_web_server() -> None:
     config = {
         ct002_component.CONF_DASHBOARD: {ct002_component.CONF_PATH: "/astrameter"}
     }
     ct002_component._final_validate_dashboard_path(config, {"web_server": {}})
 
 
-def test_dashboard_at_the_root_is_fine_without_the_web_server():
+def test_dashboard_at_the_root_is_fine_without_the_web_server() -> None:
     config = {ct002_component.CONF_DASHBOARD: {ct002_component.CONF_PATH: ""}}
     ct002_component._final_validate_dashboard_path(config, {})
 
 
-def test_astrameter_version_is_read_from_the_repo():
+def test_astrameter_version_is_read_from_the_repo() -> None:
     # The page shows this on its Diagnostics tab; an unusual layout must show
     # nothing rather than something wrong.
     version = ct002_component._astrameter_version()
     assert version and version[0].isdigit()
 
 
-def test_astrameter_git_commit_is_read_from_the_checkout():
+def test_astrameter_git_commit_is_read_from_the_checkout() -> None:
     # The firmware has no CI step to bake a SHA in, so the page's commit comes
     # from the repo the sources were compiled out of.
     root = Path(ct002_component.__file__).resolve().parents[3]
@@ -377,7 +381,9 @@ def test_astrameter_git_commit_is_read_from_the_checkout():
     assert ct002_component._is_sha(sha), sha
 
 
-def test_astrameter_git_commit_is_empty_without_a_repo(monkeypatch, tmp_path):
+def test_astrameter_git_commit_is_empty_without_a_repo(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     # Vendored into a config directory rather than fetched as a checkout: the
     # page must then show no commit rather than one from an unrelated repo.
     fake = tmp_path / "esphome" / "components" / "ct002" / "__init__.py"
@@ -387,7 +393,9 @@ def test_astrameter_git_commit_is_empty_without_a_repo(monkeypatch, tmp_path):
     assert ct002_component._astrameter_git_commit() == ""
 
 
-def test_astrameter_git_commit_ignores_a_surrounding_repo(monkeypatch, tmp_path):
+def test_astrameter_git_commit_ignores_a_surrounding_repo(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     # ESPHome also accepts a top-level `components/ct002` layout. There the
     # root this walks up to sits *above* the vendor directory, so an ESPHome
     # config kept in git — most are — would otherwise hand us its own HEAD and
@@ -406,7 +414,9 @@ def test_astrameter_git_commit_ignores_a_surrounding_repo(monkeypatch, tmp_path)
     assert ct002_component._astrameter_git_commit() == ""
 
 
-def test_astrameter_git_commit_reads_a_linked_worktree(monkeypatch, tmp_path):
+def test_astrameter_git_commit_reads_a_linked_worktree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     # `git worktree add` leaves `.git` as a pointer to a private directory that
     # holds this worktree's HEAD — but the branch HEAD names lives in the
     # shared directory, so resolving it means following `commondir` too.
@@ -414,7 +424,7 @@ def test_astrameter_git_commit_reads_a_linked_worktree(monkeypatch, tmp_path):
         pytest.skip("git is not installed")
     repo = tmp_path / "repo"
 
-    def git(cwd, *args):
+    def git(cwd, *args: Any) -> None:
         subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
 
     git(tmp_path, "init", "-q", "-b", "main", str(repo))
@@ -454,7 +464,7 @@ def _dashboard_default(key: str):
     raise AssertionError(f"{key} is not a dashboard option")
 
 
-def test_dashboard_controls_are_off_by_default():
+def test_dashboard_controls_are_off_by_default() -> None:
     # The page has no login of its own, so steering someone's batteries from
     # the LAN has to be asked for — matching DASHBOARD_ALLOW_WRITE on the
     # Python side, which also defaults to off outside the add-on.
@@ -468,7 +478,7 @@ _DATA_DIR_ENV = ("ESPHOME_DATA_DIR", "ESPHOME_IS_HA_ADDON")
 
 
 @contextlib.contextmanager
-def _core_paths(tmp_path, name="device"):
+def _core_paths(tmp_path: Path, name="device"):
     """Point CORE's config directory and device name at *tmp_path*, then restore.
 
     The web-server link is generated during validation, so it needs somewhere
@@ -490,7 +500,7 @@ def _core_paths(tmp_path, name="device"):
                 os.environ[key] = value
 
 
-def _link_config(path=None, **dashboard):
+def _link_config(path=None, **dashboard: Any):
     """A validated-shaped ct002 config with the dashboard's path settled."""
     dashboard.setdefault(ct002_component.CONF_PATH, path)
     if dashboard[ct002_component.CONF_PATH] is None:
@@ -502,7 +512,7 @@ def _generated_js():
     return ct002_component._web_server_link_path().read_text(encoding="utf-8")
 
 
-def test_web_server_link_is_injected_into_the_esphome_page(tmp_path):
+def test_web_server_link_is_injected_into_the_esphome_page(tmp_path: Path) -> None:
     # ESPHome's own frontend renders a fixed set of entity domains and
     # text-binds every name and state, so no entity can be a link and the page
     # would otherwise never mention the dashboard beside it. `js_include:` is
@@ -518,7 +528,7 @@ def test_web_server_link_is_injected_into_the_esphome_page(tmp_path):
         assert '"/astrameter/"' in _generated_js()
 
 
-def test_web_server_link_points_at_a_custom_path(tmp_path):
+def test_web_server_link_points_at_a_custom_path(tmp_path: Path) -> None:
     with _core_paths(tmp_path):
         config = _link_config("/power")
         ct002_component._final_validate_web_server_link(
@@ -527,21 +537,21 @@ def test_web_server_link_points_at_a_custom_path(tmp_path):
         assert '"/power/"' in _generated_js()
 
 
-def test_web_server_link_keeps_the_trailing_slash():
+def test_web_server_link_keeps_the_trailing_slash() -> None:
     # The dashboard answers the bare prefix with a redirect, so a link without
     # the slash costs every visitor a round trip.
     assert ct002_component._link_href(_link_config("/astrameter")) == "/astrameter/"
     assert ct002_component._link_href(_link_config("")) == "/"
 
 
-def test_web_server_link_is_absent_without_the_esphome_page(tmp_path):
+def test_web_server_link_is_absent_without_the_esphome_page(tmp_path: Path) -> None:
     # Nothing to link *from*: the dashboard has the root to itself.
     with _core_paths(tmp_path):
         ct002_component._final_validate_web_server_link(_link_config(""), {})
         assert not ct002_component._web_server_link_path().exists()
 
 
-def test_web_server_link_can_be_turned_off(tmp_path):
+def test_web_server_link_can_be_turned_off(tmp_path: Path) -> None:
     with _core_paths(tmp_path):
         web_server = {}
         ct002_component._final_validate_web_server_link(
@@ -552,7 +562,7 @@ def test_web_server_link_can_be_turned_off(tmp_path):
         assert not ct002_component._web_server_link_path().exists()
 
 
-def test_web_server_link_is_absent_for_a_dashboardless_build(tmp_path):
+def test_web_server_link_is_absent_for_a_dashboardless_build(tmp_path: Path) -> None:
     with _core_paths(tmp_path):
         web_server = {}
         ct002_component._final_validate_web_server_link(
@@ -572,7 +582,9 @@ def test_web_server_link_is_absent_for_a_dashboardless_build(tmp_path):
     ],
     ids=["version-1", "local"],
 )
-def test_web_server_link_steps_aside_where_js_include_is_ignored(tmp_path, web_server):
+def test_web_server_link_steps_aside_where_js_include_is_ignored(
+    tmp_path: Path, web_server
+) -> None:
     # Both are deliberate user choices, and the dashboard is reachable either
     # way — so this is a no-op with a log line, never a build failure.
     with _core_paths(tmp_path):
@@ -582,7 +594,7 @@ def test_web_server_link_steps_aside_where_js_include_is_ignored(tmp_path, web_s
         assert not ct002_component._web_server_link_path().exists()
 
 
-def test_web_server_link_keeps_a_user_js_include(tmp_path):
+def test_web_server_link_keeps_a_user_js_include(tmp_path: Path) -> None:
     # We are claiming a slot the user may already be using, so theirs has to
     # survive — it runs first, then ours.
     with _core_paths(tmp_path):
@@ -597,7 +609,7 @@ def test_web_server_link_keeps_a_user_js_include(tmp_path):
         assert web_server[esphome.const.CONF_JS_INCLUDE] != str(theirs)
 
 
-def test_web_server_link_does_not_stack_on_revalidation(tmp_path):
+def test_web_server_link_does_not_stack_on_revalidation(tmp_path: Path) -> None:
     # Guards the footgun in the line above: if the generated file were ever
     # read back as "the user's", every run would append another copy.
     with _core_paths(tmp_path):
@@ -614,7 +626,7 @@ def test_web_server_link_does_not_stack_on_revalidation(tmp_path):
         assert _generated_js().count("document.body.prepend") == 1
 
 
-def test_web_server_link_survives_an_unwritable_data_directory(tmp_path):
+def test_web_server_link_survives_an_unwritable_data_directory(tmp_path: Path) -> None:
     # A convenience must never be the reason a build fails.
     with _core_paths(tmp_path) as core:
         core.data_dir.parent.mkdir(parents=True, exist_ok=True)
@@ -626,11 +638,13 @@ def test_web_server_link_survives_an_unwritable_data_directory(tmp_path):
         assert esphome.const.CONF_JS_INCLUDE not in web_server
 
 
-def test_web_server_link_is_on_by_default():
+def test_web_server_link_is_on_by_default() -> None:
     assert _dashboard_default(ct002_component.CONF_WEB_SERVER_LINK) is True
 
 
-def test_web_server_link_is_not_written_into_the_build_directory(tmp_path, monkeypatch):
+def test_web_server_link_is_not_written_into_the_build_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # Regression: the build directory is the obvious home for a generated
     # file and the wrong one. `write_cpp` calls `update_storage_json` first,
     # which full-wipes that directory whenever the storage sidecar changed
@@ -654,7 +668,7 @@ def test_web_server_link_is_not_written_into_the_build_directory(tmp_path, monke
         assert not generated.is_relative_to(CORE.build_path)
 
 
-def test_web_server_link_is_namespaced_per_device(tmp_path):
+def test_web_server_link_is_namespaced_per_device(tmp_path: Path) -> None:
     # ESPHome's data directory is shared by every configuration beside it.
     with _core_paths(tmp_path, name="kitchen"):
         kitchen = ct002_component._web_server_link_path()
@@ -662,7 +676,7 @@ def test_web_server_link_is_namespaced_per_device(tmp_path):
         assert ct002_component._web_server_link_path() != kitchen
 
 
-def _run_module(source: str, tmp_path):
+def _run_module(source: str, tmp_path: Path):
     """Execute *source* as an ES module against a stub DOM, return the anchor.
 
     Parsing it is not enough. The failure this guards against — a user's
@@ -694,7 +708,7 @@ console.log(JSON.stringify(globalThis.__anchor ?? null));
     return json.loads(result.stdout.strip().splitlines()[-1])
 
 
-def test_the_generated_module_actually_builds_the_anchor(tmp_path):
+def test_the_generated_module_actually_builds_the_anchor(tmp_path: Path) -> None:
     with _core_paths(tmp_path):
         ct002_component._final_validate_web_server_link(
             _link_config(), {ct002_component.CONF_WEB_SERVER: {}}
@@ -704,7 +718,9 @@ def test_the_generated_module_actually_builds_the_anchor(tmp_path):
     assert "AstraMeter" in anchor["textContent"]
 
 
-def test_the_generated_module_runs_after_a_user_file_without_a_semicolon(tmp_path):
+def test_the_generated_module_runs_after_a_user_file_without_a_semicolon(
+    tmp_path: Path,
+) -> None:
     # Both end up in one module, so a user file ending on an expression would
     # otherwise take our IIFE for its argument list — `window.name\n(() => {})()`
     # parses fine and throws "window.name is not a function" at runtime, so
@@ -723,7 +739,7 @@ def test_the_generated_module_runs_after_a_user_file_without_a_semicolon(tmp_pat
     assert anchor["href"] == "/astrameter/"
 
 
-def test_web_server_link_leaves_a_non_utf8_user_file_alone(tmp_path):
+def test_web_server_link_leaves_a_non_utf8_user_file_alone(tmp_path: Path) -> None:
     # `cv.file_` only checks that the path exists, so a user's js_include can
     # be any bytes at all. Decoding it is the one step here that fails on a
     # file that is otherwise perfectly fine, and a convenience must not take
@@ -739,7 +755,7 @@ def test_web_server_link_leaves_a_non_utf8_user_file_alone(tmp_path):
         assert web_server[esphome.const.CONF_JS_INCLUDE] == "latin1.js"
 
 
-def test_web_server_link_does_not_stack_through_an_aliased_path(tmp_path):
+def test_web_server_link_does_not_stack_through_an_aliased_path(tmp_path: Path) -> None:
     # The self-reference check has to survive a path that reaches our output
     # by another spelling — a symlink, a `..` hop, a bind-mounted config dir.
     # Comparing the configured spelling alone would read the last build's
@@ -763,7 +779,7 @@ def test_web_server_link_does_not_stack_through_an_aliased_path(tmp_path):
         assert _generated_js().count("document.body.prepend") == 1
 
 
-def test_web_server_link_does_not_stack_through_a_copy(tmp_path):
+def test_web_server_link_does_not_stack_through_a_copy(tmp_path: Path) -> None:
     # And a *copy* of our output has neither the same path nor any business
     # being prepended, so the content is checked too.
     with _core_paths(tmp_path):
@@ -782,7 +798,7 @@ def test_web_server_link_does_not_stack_through_a_copy(tmp_path):
         assert _generated_js().count("document.body.prepend") == 1
 
 
-def test_web_server_link_is_handed_back_as_a_path(tmp_path):
+def test_web_server_link_is_handed_back_as_a_path(tmp_path: Path) -> None:
     # `cv.file_` produces a Path, so writing a str back would leave the
     # validated document inconsistent with web_server's own schema.
     with _core_paths(tmp_path):
@@ -793,7 +809,7 @@ def test_web_server_link_is_handed_back_as_a_path(tmp_path):
         assert isinstance(web_server[esphome.const.CONF_JS_INCLUDE], Path)
 
 
-def test_web_server_link_leaves_no_temporary_file_behind(tmp_path):
+def test_web_server_link_leaves_no_temporary_file_behind(tmp_path: Path) -> None:
     with _core_paths(tmp_path):
         ct002_component._final_validate_web_server_link(
             _link_config(), {ct002_component.CONF_WEB_SERVER: {}}
@@ -803,8 +819,8 @@ def test_web_server_link_leaves_no_temporary_file_behind(tmp_path):
 
 
 def test_concurrent_writes_do_not_delete_each_others_temporary_file(
-    tmp_path, monkeypatch
-):
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # Two validations of the same device inside one process are exactly what
     # the atomic write exists for — the ESPHome dashboard validates in-process
     # as you type. A temporary name keyed only on the pid would hand both
@@ -834,7 +850,7 @@ def test_concurrent_writes_do_not_delete_each_others_temporary_file(
 
     monkeypatch.setattr(os, "replace", synchronized_replace)
 
-    def write():
+    def write() -> None:
         try:
             ct002_component._write_atomically(target, content)
         except BaseException as exc:  # reported to the test, not swallowed

--- a/tests/components/ct002/test_dashboard_e2e.py
+++ b/tests/components/ct002/test_dashboard_e2e.py
@@ -14,8 +14,10 @@ here, and the wire format itself by ``host_status_json_test.cpp``.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
-from test_shared_e2e import _running_esphome_backend
+from test_shared_e2e import Backend, _running_esphome_backend
 
 from astrameter.ct002.controls import coerce_consumer_control
 
@@ -26,7 +28,7 @@ CONSUMER_ID = MAC.lower()
 
 
 @pytest.fixture
-def esphome():
+def esphome() -> Iterator[Backend]:
     """The host binary, with one battery reporting on phase A into a 300 W import."""
     with _running_esphome_backend() as backend:
         backend.set_clock(1000)
@@ -35,15 +37,15 @@ def esphome():
         yield backend
 
 
-def _device(backend) -> dict:
+def _device(backend: Backend) -> dict:
     return backend.status()["devices"][0]
 
 
-def _consumer(backend) -> dict:
+def _consumer(backend: Backend) -> dict:
     return _device(backend)["consumers"][0]
 
 
-def test_document_carries_the_live_battery(esphome) -> None:
+def test_document_carries_the_live_battery(esphome: Backend) -> None:
     device = _device(esphome)
     assert device["kind"] == "ct002"
     consumer = device["consumers"][0]
@@ -57,7 +59,7 @@ def test_document_carries_the_live_battery(esphome) -> None:
     assert consumer["balancer"]["last_target_w"] > 0
 
 
-def test_document_carries_the_grid_and_its_buckets(esphome) -> None:
+def test_document_carries_the_grid_and_its_buckets(esphome: Backend) -> None:
     device = _device(esphome)
     assert device["grid"]["l1_w"] == 300
     assert device["grid"]["grid_total_w"] == 300
@@ -70,7 +72,7 @@ def test_document_carries_the_grid_and_its_buckets(esphome) -> None:
     assert set(device["buckets"]) == {"x", "A", "B", "C", "ABC"}
 
 
-def test_document_carries_the_power_source(esphome) -> None:
+def test_document_carries_the_power_source(esphome: Backend) -> None:
     meter = esphome.status()["powermeters"][0]
     assert meter["kind"] == "SensorBackedPowermeter"
     assert meter["online"] is True
@@ -81,7 +83,7 @@ def test_document_carries_the_power_source(esphome) -> None:
     assert "pipeline" not in meter
 
 
-def test_document_carries_the_balancer_internals(esphome) -> None:
+def test_document_carries_the_balancer_internals(esphome: Backend) -> None:
     balancer = _device(esphome)["balancer"]
     assert balancer["predictor"]["grid_estimate_w"] == 300
     assert "trust" in balancer["predictor"]
@@ -90,7 +92,7 @@ def test_document_carries_the_balancer_internals(esphome) -> None:
     assert "probe" not in balancer
 
 
-def test_document_carries_the_control_quality_verdict(esphome) -> None:
+def test_document_carries_the_control_quality_verdict(esphome: Backend) -> None:
     quality = _device(esphome)["balancer"]["control_quality"]
     # One poll in: the loop is being judged but has nothing to say yet.
     assert quality["verdict"] in {"idle", "warmup", "stable", "off_target", "limited"}
@@ -104,7 +106,7 @@ def test_document_carries_the_control_quality_verdict(esphome) -> None:
         assert "crossings_per_min" not in quality
 
 
-def test_document_omits_what_the_firmware_cannot_produce(esphome) -> None:
+def test_document_omits_what_the_firmware_cannot_produce(esphome: Backend) -> None:
     document = esphome.status()
     # No SNTP on this binary: ages are reported, dates are not invented.
     assert "generated_at" not in document
@@ -119,7 +121,7 @@ def test_document_omits_what_the_firmware_cannot_produce(esphome) -> None:
     assert document["service"]["runtime"] == "esphome"
 
 
-def test_a_manual_target_write_lands_in_the_document(esphome) -> None:
+def test_a_manual_target_write_lands_in_the_document(esphome: Backend) -> None:
     assert esphome.control("manual_target", -250, CONSUMER_ID).startswith("ok")
     consumer = _consumer(esphome)
     assert consumer["manual_target_w"] == -250
@@ -130,7 +132,7 @@ def test_a_manual_target_write_lands_in_the_document(esphome) -> None:
     assert consumer["manual_enabled"] is False
 
 
-def test_auto_target_off_is_what_enters_manual_mode(esphome) -> None:
+def test_auto_target_off_is_what_enters_manual_mode(esphome: Backend) -> None:
     assert esphome.control("manual_target", -250, CONSUMER_ID).startswith("ok")
     assert esphome.control("auto_target", "false", CONSUMER_ID).startswith("ok")
     consumer = _consumer(esphome)
@@ -141,21 +143,21 @@ def test_auto_target_off_is_what_enters_manual_mode(esphome) -> None:
     assert _consumer(esphome)["mode"] == "auto"
 
 
-def test_deactivating_a_battery_shows_up_as_inactive(esphome) -> None:
+def test_deactivating_a_battery_shows_up_as_inactive(esphome: Backend) -> None:
     assert esphome.control("active", "false", CONSUMER_ID).startswith("ok")
     consumer = _consumer(esphome)
     assert consumer["active"] is False
     assert consumer["mode"] == "inactive"
 
 
-def test_efficiency_window_weight_round_trips_as_a_percentage(esphome) -> None:
+def test_efficiency_window_weight_round_trips_as_a_percentage(esphome: Backend) -> None:
     # The wire unit is a percentage (matching the MQTT entity of that name)
     # and the setter's is a fraction; the scale has to cancel out exactly.
     assert esphome.control("efficiency_window_weight", 50, CONSUMER_ID).startswith("ok")
     assert _consumer(esphome)["efficiency_window_weight_pct"] == 50
 
 
-def test_a_device_wide_write_lands_too(esphome) -> None:
+def test_a_device_wide_write_lands_too(esphome: Backend) -> None:
     assert esphome.control("active_control", "false").startswith("ok")
     assert _device(esphome)["control"]["active_control"] is False
 
@@ -170,7 +172,7 @@ def test_a_device_wide_write_lands_too(esphome) -> None:
     ],
 )
 def test_out_of_range_is_refused_with_python_s_own_message(
-    esphome, field, value
+    esphome: Backend, field, value
 ) -> None:
     """The firmware must refuse exactly what the Python dashboard refuses.
 
@@ -186,16 +188,16 @@ def test_out_of_range_is_refused_with_python_s_own_message(
     assert str(exc_info.value) in reply
 
 
-def test_a_boolean_field_refuses_a_number(esphome) -> None:
+def test_a_boolean_field_refuses_a_number(esphome: Backend) -> None:
     reply = esphome.control("active", 3, CONSUMER_ID)
     assert "must be true or false" in reply
 
 
-def test_an_unknown_field_is_refused(esphome) -> None:
+def test_an_unknown_field_is_refused(esphome: Backend) -> None:
     assert "Unknown" in esphome.control("nonsense", 1, CONSUMER_ID)
 
 
-def test_a_write_to_an_unknown_battery_is_refused(esphome) -> None:
+def test_a_write_to_an_unknown_battery_is_refused(esphome: Backend) -> None:
     """A stale page — or anyone poking the endpoint — must not mint batteries.
 
     Every consumer setter creates the entry when it is missing, which is what
@@ -209,7 +211,7 @@ def test_a_write_to_an_unknown_battery_is_refused(esphome) -> None:
     assert len(_device(esphome)["consumers"]) == before
 
 
-def test_a_saved_setting_for_an_absent_battery_stays_writable(esphome) -> None:
+def test_a_saved_setting_for_an_absent_battery_stays_writable(esphome: Backend) -> None:
     """...but a battery the document DOES show must stay settable.
 
     A consumer that has been evicted still has its saved override, and the

--- a/tests/components/ct002/test_host_e2e.py
+++ b/tests/components/ct002/test_host_e2e.py
@@ -22,6 +22,7 @@ import signal
 import socket
 import subprocess
 import time
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -83,7 +84,7 @@ def host_binary() -> Path:
 
 
 @pytest.fixture
-def running_binary(host_binary: Path):
+def running_binary(host_binary: Path) -> Iterator[subprocess.Popen]:
     """Spawn the host binary; tear it down after the test."""
     # Wait for any previous test's binary to fully release the port.
     deadline = time.monotonic() + 5.0

--- a/tests/components/ct002/test_shared_e2e.py
+++ b/tests/components/ct002/test_shared_e2e.py
@@ -30,6 +30,7 @@ import signal
 import socket
 import subprocess
 import time
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -360,8 +361,13 @@ def _running_esphome_backend():
             proc.wait()
 
 
+#: The control interface both stacks implement; the `backend` fixture
+#: yields each in turn so every shared scenario runs against both.
+Backend = PythonBackend | EsphomeBackend
+
+
 @pytest.fixture(params=["python", "esphome"])
-def backend(request):
+def backend(request: pytest.FixtureRequest) -> Iterator[Backend]:
     """Yield each CT002 backend implementing the shared control interface.
 
     The ``python`` backend always runs; ``esphome`` skips without the CLI.
@@ -380,7 +386,7 @@ def backend(request):
 
 
 @pytest.mark.timeout(30, func_only=True)
-def test_grid_injection_sign(backend) -> None:
+def test_grid_injection_sign(backend: Backend) -> None:
     """Injected grid power steers the battery in the correct direction on
     both stacks: import (+) -> discharge (+), export (-) -> charge (-)."""
     backend.set_clock(1000)
@@ -399,7 +405,7 @@ def test_grid_injection_sign(backend) -> None:
 
 
 @pytest.mark.timeout(30, func_only=True)
-def test_convergence(backend) -> None:
+def test_convergence(backend: Backend) -> None:
     """Closing the loop drives the target toward zero on both stacks.
 
     Each poll the battery reports the output it has integrated so far and the
@@ -439,7 +445,7 @@ def test_convergence(backend) -> None:
 
 
 @pytest.mark.timeout(30, func_only=True)
-def test_nan_meter_reading_holds_then_control_recovers(backend) -> None:
+def test_nan_meter_reading_holds_then_control_recovers(backend: Backend) -> None:
     """A NaN grid reading is answered with a zero-delta hold and leaves no
     trace in the controller: the next finite reading steers normally.
 
@@ -480,7 +486,7 @@ def test_nan_meter_reading_holds_then_control_recovers(backend) -> None:
 
 
 @pytest.mark.timeout(30, func_only=True)
-def test_clock_gated_dedup(backend) -> None:
+def test_clock_gated_dedup(backend: Backend) -> None:
     """The dedup window is driven by the (mock) clock on both stacks: a repeat
     poll inside the window is dropped; advancing the clock past it un-gates
     the poll."""
@@ -503,7 +509,7 @@ def test_clock_gated_dedup(backend) -> None:
 
 
 @pytest.mark.timeout(30, func_only=True)
-def test_deduped_poll_still_counts_as_alive(backend) -> None:
+def test_deduped_poll_still_counts_as_alive(backend: Backend) -> None:
     """A poll the dedup window suppressed still proves the battery is there.
 
     The window suppresses the *reply*, not the battery: booking the report
@@ -535,7 +541,7 @@ def test_deduped_poll_still_counts_as_alive(backend) -> None:
 
 @pytest.mark.timeout(30, func_only=True)
 @pytest.mark.parametrize("phase,idx", [("A", 4), ("B", 5), ("C", 6)])
-def test_phase_routing(backend, phase, idx) -> None:
+def test_phase_routing(backend: Backend, phase, idx) -> None:
     """A single battery's target lands only on the phase it reports.
 
     ``split_by_phase`` places the whole target on the reporting consumer's
@@ -565,7 +571,7 @@ _A_CHRG, _A_DCHRG = 15, 20
 
 
 @pytest.mark.timeout(30, func_only=True)
-def test_crosstalk_discharge_signals_other_battery(backend) -> None:
+def test_crosstalk_discharge_signals_other_battery(backend: Backend) -> None:
     """A discharging battery shows up as *discharge* in another's cross-talk.
 
     When battery X on phase A is instructed to discharge (grid import), a poll
@@ -595,7 +601,7 @@ def test_crosstalk_discharge_signals_other_battery(backend) -> None:
 
 
 @pytest.mark.timeout(30, func_only=True)
-def test_crosstalk_charge_signals_other_battery(backend) -> None:
+def test_crosstalk_charge_signals_other_battery(backend: Backend) -> None:
     """A charging battery shows up as *charge* (negative) in cross-talk.
 
     Mirror of the discharge case under grid export: X on phase A is instructed
@@ -627,7 +633,7 @@ _ABC_NB, _ABC_CHRG, _ABC_DCHRG = 11, 18, 23
 
 
 @pytest.mark.timeout(30, func_only=True)
-def test_relay_buckets_carry_reported_power(backend) -> None:
+def test_relay_buckets_carry_reported_power(backend: Backend) -> None:
     """Relay mode forwards each battery's *reported* power in the cross-talk
     buckets — not reported+grid — matching the real CT (issue #457)."""
     backend.set_clock(15000)
@@ -648,7 +654,7 @@ def test_relay_buckets_carry_reported_power(backend) -> None:
 
 
 @pytest.mark.timeout(30, func_only=True)
-def test_inspection_reporter_lands_in_x_bucket(backend) -> None:
+def test_inspection_reporter_lands_in_x_bucket(backend: Backend) -> None:
     """An inspection ('0') reporter populates the x bucket and is excluded
     from phase A's count/aggregate (issue #460)."""
     backend.set_clock(16000)
@@ -674,7 +680,7 @@ def test_inspection_reporter_lands_in_x_bucket(backend) -> None:
 
 
 @pytest.mark.timeout(30, func_only=True)
-def test_combined_phase_d_lands_in_abc_bucket(backend) -> None:
+def test_combined_phase_d_lands_in_abc_bucket(backend: Backend) -> None:
     """A combined-mode (phase 'D') reporter populates the ABC bucket and
     ABC_chrg_nb instead of phase A (issue #460)."""
     backend.set_clock(17000)
@@ -699,7 +705,9 @@ def test_combined_phase_d_lands_in_abc_bucket(backend) -> None:
 
 
 @pytest.mark.timeout(30, func_only=True)
-def test_adaptive_eviction_drops_silent_battery_from_relay_count(backend) -> None:
+def test_adaptive_eviction_drops_silent_battery_from_relay_count(
+    backend: Backend,
+) -> None:
     """With the default adaptive TTL, a battery that misses ~2 of its own
     poll cycles drops out of the relay count/aggregate (issue #462)."""
     backend.set_clock(18000)
@@ -727,7 +735,7 @@ def test_adaptive_eviction_drops_silent_battery_from_relay_count(backend) -> Non
 
 
 @pytest.mark.timeout(30, func_only=True)
-def test_manual_override_survives_eviction(backend) -> None:
+def test_manual_override_survives_eviction(backend: Backend) -> None:
     """A user-set manual target/mode is re-seeded onto the fresh consumer when a
     silent battery is evicted and later returns — on both stacks (issue #520)."""
     backend.set_clock(1000)
@@ -763,7 +771,7 @@ def test_manual_override_survives_eviction(backend) -> None:
 
 
 @pytest.mark.timeout(30, func_only=True)
-def test_manual_target_does_not_auto_enter_manual_mode(backend) -> None:
+def test_manual_target_does_not_auto_enter_manual_mode(backend: Backend) -> None:
     """Setting the Manual Target alone must not flip the battery into manual
     mode — Manual Target and Auto Target are independent controls on both
     stacks (the number sets the value; the switch chooses the mode)."""

--- a/tests/test_addon_container.py
+++ b/tests/test_addon_container.py
@@ -224,7 +224,7 @@ class RunningAddon:
 
 
 @pytest.fixture
-def addon(tmp_path) -> Iterator[RunningAddon]:
+def addon(tmp_path: Path) -> Iterator[RunningAddon]:
     """The add-on running from its image, configured only by add-on options."""
     instance = RunningAddon(
         {
@@ -247,12 +247,12 @@ def addon(tmp_path) -> Iterator[RunningAddon]:
         instance.stop()
 
 
-def test_the_image_starts_and_reports_healthy(addon):
+def test_the_image_starts_and_reports_healthy(addon) -> None:
     health = addon.wait_for_health()
     assert health.get("status") in ("healthy", "ok", "starting"), health
 
 
-def test_the_container_serves_the_home_assistant_reading(addon):
+def test_the_container_serves_the_home_assistant_reading(addon) -> None:
     addon.wait_for_health()
     reply = addon.poll_until(lambda r: r["A_phase_power"] != "0")
 
@@ -261,7 +261,7 @@ def test_the_container_serves_the_home_assistant_reading(addon):
     assert reply["meter_mac_code"].lower() == CT_MAC.lower()
 
 
-def test_the_add_on_reads_its_options_and_the_supervisor(addon):
+def test_the_add_on_reads_its_options_and_the_supervisor(addon) -> None:
     addon.wait_for_health()
     logs = addon.logs()
 
@@ -275,7 +275,7 @@ def test_the_add_on_reads_its_options_and_the_supervisor(addon):
     assert "config.ini" not in logs
 
 
-def test_the_container_keeps_running(addon):
+def test_the_container_keeps_running(addon) -> None:
     addon.wait_for_health()
     time.sleep(10)
     assert addon.running(), f"add-on container stopped:\n{addon.logs()}"
@@ -283,7 +283,7 @@ def test_the_container_keeps_running(addon):
     assert addon.logs().count("started astrameter application") == 1
 
 
-def test_credentials_never_reach_the_log(tmp_path):
+def test_credentials_never_reach_the_log(tmp_path: Path) -> None:
     """The add-on logs its own configuration; secrets must not come with it."""
     instance = RunningAddon(
         {

--- a/tests/test_addon_e2e.py
+++ b/tests/test_addon_e2e.py
@@ -18,7 +18,10 @@ import contextlib
 import json
 import socket
 import threading
+from collections.abc import Callable, Iterator
 from dataclasses import replace
+from pathlib import Path
+from typing import Any
 
 import pytest
 from _ct002_e2e_backend import find_free_ports
@@ -144,7 +147,7 @@ class PortOverrideAddonConfig(AddonAppConfig):
     comes from the add-on options.
     """
 
-    def __init__(self, options, supervisor, udp_port: int) -> None:
+    def __init__(self, options, supervisor: FakeSupervisor, udp_port: int) -> None:
         super().__init__(options, supervisor)
         self._udp_port = udp_port
 
@@ -178,12 +181,14 @@ async def running_addon(options: dict, supervisor: FakeSupervisor, udp_port: int
 
 
 @pytest.fixture
-def addon_options(tmp_path, monkeypatch):
+def addon_options(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Callable[..., dict]:
     """A realistic /data/options.json, read the way the add-on reads it."""
     monkeypatch.setenv("SUPERVISOR_TOKEN", SUPERVISOR_TOKEN)
     udp_port = find_free_ports(1)[0]
 
-    def write(**overrides) -> dict:
+    def write(**overrides: Any) -> dict:
         options = {
             "power_input_alias": GRID_SENSOR,
             "power_output_alias": "",
@@ -204,7 +209,7 @@ def addon_options(tmp_path, monkeypatch):
 
 
 @pytest.fixture
-def supervisor():
+def supervisor() -> Iterator[FakeSupervisor]:
     server = FakeSupervisor(watts=321.0)
     server.start()
     try:
@@ -215,8 +220,8 @@ def supervisor():
 
 @pytest.mark.timeout(60)
 async def test_addon_serves_the_home_assistant_reading_over_udp(
-    addon_options, supervisor
-):
+    addon_options: Callable[..., dict], supervisor: FakeSupervisor
+) -> None:
     options = addon_options()
 
     async with running_addon(options, supervisor, addon_options.udp_port):
@@ -232,7 +237,9 @@ async def test_addon_serves_the_home_assistant_reading_over_udp(
 
 
 @pytest.mark.timeout(60)
-async def test_add_on_options_reach_the_running_emulator(addon_options, supervisor):
+async def test_add_on_options_reach_the_running_emulator(
+    addon_options: Callable[..., dict], supervisor: FakeSupervisor
+) -> None:
     """A tuning option set in the add-on UI changes what the battery is told."""
     options = addon_options(power_offset="100", ct_mac="AABBCCDDEE01")
 
@@ -248,7 +255,9 @@ async def test_add_on_options_reach_the_running_emulator(addon_options, supervis
     assert reply["meter_mac_code"].lower() == "aabbccddee01"
 
 
-async def test_supervisor_endpoints_answer_the_add_on(supervisor):
+async def test_supervisor_endpoints_answer_the_add_on(
+    supervisor: FakeSupervisor,
+) -> None:
     """The Supervisor lookups the add-on makes at startup, against a real server."""
     supervisor.mqtt = {
         "host": "core-mosquitto",
@@ -266,7 +275,9 @@ async def test_supervisor_endpoints_answer_the_add_on(supervisor):
     assert supervisor.unauthorized == 0
 
 
-async def test_a_wrong_token_is_not_silently_accepted(supervisor):
+async def test_a_wrong_token_is_not_silently_accepted(
+    supervisor: FakeSupervisor,
+) -> None:
     client = SupervisorClient(base_url=supervisor.base_url, token="wrong")
     assert await asyncio.to_thread(client.home_assistant_ready) is False
     assert supervisor.unauthorized == 1

--- a/tests/test_addon_golden_settings.py
+++ b/tests/test_addon_golden_settings.py
@@ -63,7 +63,7 @@ def config() -> AddonAppConfig:
 ALTERNATIVES = {"custom_config", "mqtt_uri"}
 
 
-def test_the_fixture_covers_every_add_on_option():
+def test_the_fixture_covers_every_add_on_option() -> None:
     """A fixture that skips options would pin nothing about them."""
     from astrameter.config.addon_schema_test import schema_options
 
@@ -71,25 +71,25 @@ def test_the_fixture_covers_every_add_on_option():
     assert not missing, f"options missing from the golden fixture: {sorted(missing)}"
 
 
-def test_general_settings_match_the_add_on_2x_behaviour(config):
+def test_general_settings_match_the_add_on_2x_behaviour(config) -> None:
     assert asdict(config.general()) == GOLDEN["general"]
 
 
-def test_ct_settings_match_the_add_on_2x_behaviour(config):
+def test_ct_settings_match_the_add_on_2x_behaviour(config) -> None:
     assert asdict(config.ct("ct002")) == GOLDEN["ct002"]
 
 
-def test_marstek_settings_match_the_add_on_2x_behaviour(config):
+def test_marstek_settings_match_the_add_on_2x_behaviour(config) -> None:
     assert asdict(config.marstek()) == GOLDEN["marstek"]
 
 
-def test_mqtt_settings_match_the_add_on_2x_behaviour(config):
+def test_mqtt_settings_match_the_add_on_2x_behaviour(config) -> None:
     insights = config.mqtt_insights()
     assert insights is not None
     assert asdict(insights) == GOLDEN["mqtt"]
 
 
-def test_power_source_conditioning_matches_the_add_on_2x_behaviour(config):
+def test_power_source_conditioning_matches_the_add_on_2x_behaviour(config) -> None:
     """The signal options land on the power source, not in the global defaults.
 
     Offsets, smoothing, the Hampel filter and the PID are applied where the

--- a/tests/test_b2500_e2e.py
+++ b/tests/test_b2500_e2e.py
@@ -10,6 +10,8 @@ setpoint that droops instead of nulling the grid).
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from _ct002_e2e_backend import HarnessClock, find_free_ports
 
@@ -132,7 +134,9 @@ class _MixedHarness:
             batteries=[], load_model=self.load_model, host="127.0.0.1", port=http_port
         )
 
-        def mk(mac: str, dev: str, initial_soc: float = 0.5, **kw) -> BatterySimulator:
+        def mk(
+            mac: str, dev: str, initial_soc: float = 0.5, **kw: Any
+        ) -> BatterySimulator:
             return BatterySimulator(
                 mac=mac,
                 phase="A",

--- a/tests/test_balancer.py
+++ b/tests/test_balancer.py
@@ -1,6 +1,7 @@
 """Unit tests for balancer components: BalancerConsumerState, SaturationTracker, LoadBalancer."""
 
 import time
+from typing import Any
 
 import pytest
 
@@ -27,15 +28,15 @@ class TestToGridReading:
     (``new_output = reported + reading``); positive = grid import.
     """
 
-    def test_raise_output_toward_target(self):
+    def test_raise_output_toward_target(self) -> None:
         # Want 25 W net out, already at 10 W -> reading of +15 lands on target.
         assert to_grid_reading(NetOutputW(25), reported=10) == 15
 
-    def test_steer_to_zero_from_discharge(self):
+    def test_steer_to_zero_from_discharge(self) -> None:
         # Want 0 W net out while reporting 200 W -> reading of -200 (charge).
         assert to_grid_reading(NetOutputW(0), reported=200) == -200
 
-    def test_reported_plus_reading_lands_on_target(self):
+    def test_reported_plus_reading_lands_on_target(self) -> None:
         for target, reported in ((25.0, 10.0), (0.0, 200.0), (-100.0, 50.0)):
             reading = to_grid_reading(NetOutputW(target), reported)
             assert reported + reading == target
@@ -63,7 +64,7 @@ class _FakeClock:
 
 
 class TestBalancerConsumerState:
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         s = BalancerConsumerState()
         assert s.last_target is None
         assert s.fade_weight == 1.0
@@ -71,7 +72,7 @@ class TestBalancerConsumerState:
         assert s.saturation_grace_until == 0.0
         assert s.saturation_grace_started_at == 0.0
 
-    def test_fields_mutate_independently(self):
+    def test_fields_mutate_independently(self) -> None:
         s = BalancerConsumerState()
         s.last_target = 100.0
         s.fade_weight = 0.5
@@ -86,7 +87,7 @@ class TestBalancerConsumerState:
 
 
 class TestSaturationTracker:
-    def _make_tracker(self, **kwargs):
+    def _make_tracker(self, **kwargs: Any):
         defaults = dict(
             alpha=0.15,
             min_target=20,
@@ -97,7 +98,7 @@ class TestSaturationTracker:
         defaults.update(kwargs)
         return SaturationTracker(**defaults)
 
-    def _make_tracker_with_clock(self, **kwargs):
+    def _make_tracker_with_clock(self, **kwargs: Any):
         """Return (tracker, clock) for time-weighted EMA tests.
 
         The clock is a :class:`_FakeClock` that the caller must
@@ -108,31 +109,31 @@ class TestSaturationTracker:
         tracker = self._make_tracker(clock=clock, **kwargs)
         return tracker, clock
 
-    def test_update_noop_when_disabled(self):
+    def test_update_noop_when_disabled(self) -> None:
         tracker = self._make_tracker(enabled=False)
         state = BalancerConsumerState()
         tracker.update(state, 200, 0, 0.0)
         assert state.saturation_score == 0.0
 
-    def test_update_noop_when_last_target_none(self):
+    def test_update_noop_when_last_target_none(self) -> None:
         tracker = self._make_tracker()
         state = BalancerConsumerState()
         tracker.update(state, None, 0, 0.0)
         assert state.saturation_score == 0.0
 
-    def test_update_saturated_when_actual_below_min_target(self):
+    def test_update_saturated_when_actual_below_min_target(self) -> None:
         tracker = self._make_tracker(alpha=1.0, min_target=20)
         state = BalancerConsumerState()
         tracker.update(state, 200, 5, 0.0)  # actual=5 < min_target=20
         assert state.saturation_score == 1.0
 
-    def test_update_not_saturated_when_actual_at_min_target(self):
+    def test_update_not_saturated_when_actual_at_min_target(self) -> None:
         tracker = self._make_tracker(alpha=1.0, min_target=20)
         state = BalancerConsumerState()
         tracker.update(state, 200, 20, 0.0)  # actual=20 >= min_target=20
         assert state.saturation_score == 0.0
 
-    def test_update_ema_smoothing(self):
+    def test_update_ema_smoothing(self) -> None:
         tracker, clock = self._make_tracker_with_clock(alpha=0.5, min_target=20)
         state = BalancerConsumerState()
         # First update: saturated.  The first sample is treated as one
@@ -145,26 +146,26 @@ class TestSaturationTracker:
         tracker.update(state, 200, 0, 0.0)
         assert state.saturation_score == 0.75  # 0.5*1.0 + 0.5*0.5
 
-    def test_update_decays_when_target_below_min(self):
+    def test_update_decays_when_target_below_min(self) -> None:
         tracker = self._make_tracker(decay_factor=0.9, min_target=20)
         state = BalancerConsumerState(saturation_score=0.5)
         tracker.update(state, 10, 10, 0.0)  # target_abs=10 < min_target=20
         assert abs(state.saturation_score - 0.45) < 1e-6  # 0.5 * 0.9
 
-    def test_update_decay_floor(self):
+    def test_update_decay_floor(self) -> None:
         tracker = self._make_tracker(decay_factor=0.5, min_target=20)
         state = BalancerConsumerState(saturation_score=0.001)
         tracker.update(state, 10, 10, 0.0)
         # 0.001 * 0.5 = 0.0005 < 0.001 → floored to 0.0
         assert state.saturation_score == 0.0
 
-    def test_grace_period_skips_update(self):
+    def test_grace_period_skips_update(self) -> None:
         tracker = self._make_tracker(alpha=1.0, min_target=20)
         state = BalancerConsumerState(saturation_grace_until=time.time() + 100)
         tracker.update(state, 200, 0, 0.0)  # actual=0, would saturate
         assert state.saturation_score == 0.0  # skipped due to grace
 
-    def test_grace_clears_early_on_meaningful_output(self):
+    def test_grace_clears_early_on_meaningful_output(self) -> None:
         tracker = self._make_tracker(alpha=1.0, min_target=20)
         now = time.time()
         state = BalancerConsumerState(
@@ -176,7 +177,7 @@ class TestSaturationTracker:
         assert state.saturation_grace_started_at == 0.0
         assert state.saturation_score == 0.0  # not saturated
 
-    def test_grace_expires(self):
+    def test_grace_expires(self) -> None:
         tracker = self._make_tracker(alpha=1.0, min_target=20)
         state = BalancerConsumerState(
             saturation_grace_until=time.time() - 1,
@@ -187,7 +188,7 @@ class TestSaturationTracker:
         assert state.saturation_grace_started_at == 0.0
         assert state.saturation_score == 1.0  # grace expired, saturated
 
-    def test_grace_stall_marks_immediate_saturation_after_timeout(self):
+    def test_grace_stall_marks_immediate_saturation_after_timeout(self) -> None:
         tracker = self._make_tracker(
             alpha=0.15, min_target=20, stall_timeout_seconds=4.0
         )
@@ -201,7 +202,7 @@ class TestSaturationTracker:
         assert state.saturation_grace_until == 0.0
         assert state.saturation_grace_started_at == 0.0
 
-    def test_clear(self):
+    def test_clear(self) -> None:
         tracker = self._make_tracker()
         state = BalancerConsumerState(
             saturation_score=0.8,
@@ -213,19 +214,19 @@ class TestSaturationTracker:
         assert state.saturation_grace_until == 0.0
         assert state.saturation_grace_started_at == 0.0
 
-    def test_set_grace(self):
+    def test_set_grace(self) -> None:
         tracker = self._make_tracker()
         state = BalancerConsumerState()
         tracker.set_grace(state, 42.0)
         assert state.saturation_grace_until == 42.0
         assert state.saturation_grace_started_at > 0.0
 
-    def test_get(self):
+    def test_get(self) -> None:
         tracker = self._make_tracker()
         state = BalancerConsumerState(saturation_score=0.7)
         assert tracker.get(state) == 0.7
 
-    def test_sign_reversal_decays_instead_of_accumulating(self):
+    def test_sign_reversal_decays_instead_of_accumulating(self) -> None:
         """When target and actual have opposite signs (direction reversal),
         saturation should decay rather than accumulate."""
         tracker = self._make_tracker(alpha=0.15, min_target=20, decay_factor=0.995)
@@ -245,7 +246,7 @@ class TestSaturationTracker:
             f"accumulate during sign reversal"
         )
 
-    def test_sign_reversal_existing_score_decays(self):
+    def test_sign_reversal_existing_score_decays(self) -> None:
         """Pre-existing saturation score decays during sign reversal."""
         tracker = self._make_tracker(decay_factor=0.9)
         state = BalancerConsumerState(saturation_score=0.5)
@@ -257,7 +258,7 @@ class TestSaturationTracker:
             f"Score should decay during sign reversal, got {state.saturation_score:.3f}"
         )
 
-    def test_same_sign_low_output_still_accumulates(self):
+    def test_same_sign_low_output_still_accumulates(self) -> None:
         """When signs agree but output is below min_target, saturation
         should still accumulate (genuine saturation)."""
         tracker, clock = self._make_tracker_with_clock(alpha=0.15, min_target=20)
@@ -275,7 +276,7 @@ class TestSaturationTracker:
             f"when signs agree but output is low"
         )
 
-    def test_actual_zero_during_reversal_does_not_trigger_guard(self):
+    def test_actual_zero_during_reversal_does_not_trigger_guard(self) -> None:
         """actual=0 should NOT activate the sign-reversal guard (actual
         has no sign), so saturation accumulates normally."""
         tracker, clock = self._make_tracker_with_clock(alpha=0.15, min_target=20)
@@ -290,7 +291,7 @@ class TestSaturationTracker:
             f"when actual is zero (no sign to disagree)"
         )
 
-    def test_target_zero_does_not_trigger_guard(self):
+    def test_target_zero_does_not_trigger_guard(self) -> None:
         """target=0 should NOT activate the sign-reversal guard."""
         tracker = self._make_tracker(alpha=0.15, min_target=20, decay_factor=0.995)
         state = BalancerConsumerState(saturation_score=0.5)
@@ -302,7 +303,7 @@ class TestSaturationTracker:
         # Score should have decayed via the low-target path
         assert state.saturation_score < 0.5
 
-    def test_sign_reversal_then_same_sign_resumes_accumulation(self):
+    def test_sign_reversal_then_same_sign_resumes_accumulation(self) -> None:
         """After a sign reversal period, once actual crosses zero to match
         target sign, saturation tracking resumes normally."""
         tracker, clock = self._make_tracker_with_clock(alpha=0.15, min_target=20)
@@ -324,7 +325,7 @@ class TestSaturationTracker:
             f"once signs agree again"
         )
 
-    def test_saturation_rise_is_sample_rate_invariant(self):
+    def test_saturation_rise_is_sample_rate_invariant(self) -> None:
         """Two trackers polled at different cadences must converge to
         the same score after the same wall-clock window.
 
@@ -368,7 +369,7 @@ class TestSaturationTracker:
         # stuck at zero and the "invariance" is vacuous.
         assert fast > 0.4
 
-    def test_saturation_decay_is_sample_rate_invariant(self):
+    def test_saturation_decay_is_sample_rate_invariant(self) -> None:
         """Decay branch of the EMA must also be rate-invariant.
 
         Same wall-clock window, pre-seeded with a non-trivial score and
@@ -399,7 +400,7 @@ class TestSaturationTracker:
         # Sanity: the decay must actually progress over 60 s.
         assert fast < 0.8
 
-    def test_long_gap_between_updates_is_dropped(self):
+    def test_long_gap_between_updates_is_dropped(self) -> None:
         """Gaps above SATURATION_LONG_GAP_SECONDS re-seed instead of
         dosing the EMA with one huge rise/decay step."""
         from astrameter.ct002.balancer import SATURATION_LONG_GAP_SECONDS
@@ -418,7 +419,7 @@ class TestSaturationTracker:
 
 
 class TestLoadBalancerLifecycle:
-    def _make_balancer(self, **kwargs):
+    def _make_balancer(self, **kwargs: Any):
         cfg_kwargs = {}
         balancer_kwargs = {}
         cfg_fields = {f.name for f in BalancerConfig.__dataclass_fields__.values()}
@@ -443,14 +444,14 @@ class TestLoadBalancerLifecycle:
             **balancer_kwargs,
         )
 
-    def test_get_consumer_auto_vivifies(self):
+    def test_get_consumer_auto_vivifies(self) -> None:
         lb = self._make_balancer()
         state = lb._get_consumer("x")
         assert state.last_target is None
         assert state.fade_weight == 1.0
         assert "x" in lb._consumers
 
-    def test_get_consumer_returns_existing(self):
+    def test_get_consumer_returns_existing(self) -> None:
         lb = self._make_balancer()
         s1 = lb._get_consumer("x")
         s1.last_target = 42.0
@@ -458,7 +459,7 @@ class TestLoadBalancerLifecycle:
         assert s2.last_target == 42.0
         assert s1 is s2
 
-    def test_remove_consumer(self):
+    def test_remove_consumer(self) -> None:
         lb = self._make_balancer()
         lb._get_consumer("x")
         lb._priority.append("x")
@@ -468,11 +469,11 @@ class TestLoadBalancerLifecycle:
         assert "x" not in lb._priority
         assert "x" not in lb._deprioritized
 
-    def test_remove_nonexistent_is_noop(self):
+    def test_remove_nonexistent_is_noop(self) -> None:
         lb = self._make_balancer()
         lb.remove_consumer("nope")  # should not raise
 
-    def test_reset_consumer(self):
+    def test_reset_consumer(self) -> None:
         lb = self._make_balancer()
         state = lb._get_consumer("x")
         state.last_target = 100.0
@@ -487,7 +488,7 @@ class TestLoadBalancerLifecycle:
         # The rotation fade is the one thing a returning consumer keeps.
         assert state.fade_weight == 0.4
 
-    def test_detach_from_auto_pool(self):
+    def test_detach_from_auto_pool(self) -> None:
         lb = self._make_balancer()
         lb._get_consumer("x")
         lb._priority.append("x")
@@ -497,11 +498,11 @@ class TestLoadBalancerLifecycle:
         assert "x" not in lb._priority
         assert "x" not in lb._deprioritized
 
-    def test_get_saturation_unknown_consumer(self):
+    def test_get_saturation_unknown_consumer(self) -> None:
         lb = self._make_balancer()
         assert lb.get_saturation("unknown") == 0.0
 
-    def test_get_last_target_unknown_consumer(self):
+    def test_get_last_target_unknown_consumer(self) -> None:
         lb = self._make_balancer()
         assert lb.get_last_target("unknown") is None
 
@@ -514,7 +515,7 @@ class TestPaceReading:
     clock at the reference cadence (1 s per poll), where the time-based
     law reduces to the original per-poll semantics."""
 
-    def _make_balancer(self, **cfg_kwargs):
+    def _make_balancer(self, **cfg_kwargs: Any):
         cfg_kwargs.setdefault("fair_distribution", False)
         # These tests exercise ramp pacing in isolation, asserting the cap
         # against a residual that equals the raw grid; the adaptive grid-state
@@ -540,7 +541,7 @@ class TestPaceReading:
             "a", ConsumerMode("auto"), reports, grid, frozenset(), frozenset(), ()
         )[0]
 
-    def test_caps_grows_when_tracking_and_resets_on_reversal(self):
+    def test_caps_grows_when_tracking_and_resets_on_reversal(self) -> None:
         lb = self._make_balancer(pace_base_step=50, pace_max_step=200)
         # First poll: a 600 W demand is capped to the base step.
         assert self._auto(lb, 0, 600) == 50.0
@@ -557,7 +558,7 @@ class TestPaceReading:
         # Direction reversal: cap resets to the base step.
         assert self._auto(lb, 600, -300) == -50.0
 
-    def test_slow_firmware_crawl_still_bootstraps_the_cap(self):
+    def test_slow_firmware_crawl_still_bootstraps_the_cap(self) -> None:
         """Issue #469 follow-up: the HMG ramp law can step as little as
         10 W/poll on a constant reading (its sqrt term collapses when its
         internal reference captures the reading itself).  The tracking
@@ -570,7 +571,7 @@ class TestPaceReading:
         assert self._auto(lb, 10, 1990) == 100.0
         assert self._auto(lb, 20, 1980) == 200.0
 
-    def test_fast_poller_clamp_scales_with_cadence(self):
+    def test_fast_poller_clamp_scales_with_cadence(self) -> None:
         """The caps are W per reference second: a 0.5 s poller's grown cap
         clamps at half the per-poll value (same W/s slew), floored at the
         base step so coarse hysteresis regulators still get a reading big
@@ -590,7 +591,7 @@ class TestPaceReading:
         # battery integrates the same 200 W/s either way.
         assert self._auto(lb, 160, 440, dt=0.5) == pytest.approx(100.0, abs=0.01)
 
-    def test_cap_clamped_to_max_after_fast_polls(self):
+    def test_cap_clamped_to_max_after_fast_polls(self) -> None:
         # The else branch back-computes the cap as abs(reading) / dt_ratio; a
         # very fast poll could push that above pace_max_step. It must be
         # clamped so a later normal-cadence poll can't slew past pace_max_step.
@@ -603,7 +604,7 @@ class TestPaceReading:
         # pace_max_step (200), not the inflated cap.
         assert self._auto(lb, 0, 5000, dt=1.0) == pytest.approx(200.0, abs=0.01)
 
-    def test_deprioritized_wind_down_is_paced(self):
+    def test_deprioritized_wind_down_is_paced(self) -> None:
         """A consumer faded out by efficiency mode is steered to zero
         through the pacing cap — the firmware applies a charge-direction
         reading in full in one cycle, so an unpaced wind-down would dump
@@ -637,19 +638,19 @@ class TestPaceReading:
         assert all(d >= -200.0 for d in deltas)
         assert min(deltas) < 0
 
-    def test_zero_base_disables_pacing(self):
+    def test_zero_base_disables_pacing(self) -> None:
         lb = self._make_balancer(pace_base_step=0)
         assert self._auto(lb, 0, 600) == 600.0
 
-    def test_pace_max_clamped_to_at_least_base(self):
+    def test_pace_max_clamped_to_at_least_base(self) -> None:
         cfg = BalancerConfig(pace_base_step=80, pace_max_step=10)
         assert cfg.pace_max_step == 80
 
-    def test_small_errors_pass_unclamped(self):
+    def test_small_errors_pass_unclamped(self) -> None:
         lb = self._make_balancer(pace_base_step=50, pace_max_step=200)
         assert self._auto(lb, 0, 30) == 30.0
 
-    def test_manual_and_inactive_paths_are_not_paced(self):
+    def test_manual_and_inactive_paths_are_not_paced(self) -> None:
         lb = self._make_balancer(pace_base_step=50, pace_max_step=200)
         reports = {"a": ConsumerReport(device_type="HMG-50", phase="A", power=600)}
         manual = lb.compute_target(
@@ -674,7 +675,7 @@ class TestGridPredictor:
     (``fair_distribution=False`` ⇒ residual = fair_share = predicted grid).
     """
 
-    def _make(self, **cfg):
+    def _make(self, **cfg: Any):
         cfg.setdefault("fair_distribution", False)
         cfg.setdefault("pace_base_step", 0.0)
         cfg.setdefault("osc_damp_max", 0.0)
@@ -698,17 +699,17 @@ class TestGridPredictor:
             "a", ConsumerMode("auto"), reports, grid, frozenset(), frozenset(), (grid,)
         )[0]
 
-    def test_disabled_is_raw_passthrough(self):
+    def test_disabled_is_raw_passthrough(self) -> None:
         lb = self._make(grid_predict_trust=0.0)
         assert self._grid(lb, 0, 300) == 300.0
         # Reported output never feeds back when the predictor is off.
         assert self._grid(lb, 100, 300) == 300.0
 
-    def test_first_sample_returns_raw_grid(self):
+    def test_first_sample_returns_raw_grid(self) -> None:
         lb = self._make(grid_predict_trust=0.5)
         assert self._grid(lb, 0, 300) == 300.0
 
-    def test_credits_delivered_output_within_a_sample(self):
+    def test_credits_delivered_output_within_a_sample(self) -> None:
         """Between meter refreshes (same sample_id) the estimate falls by the
         pool's reported output change, so the loop commands only the remainder
         instead of re-issuing the in-flight correction."""
@@ -718,14 +719,14 @@ class TestGridPredictor:
         assert self._grid(lb, 120, 300) == pytest.approx(180.0)
         assert self._grid(lb, 300, 300) == pytest.approx(0.0)
 
-    def test_meter_correction_uses_trust_on_a_fresh_sample(self):
+    def test_meter_correction_uses_trust_on_a_fresh_sample(self) -> None:
         lb = self._make(grid_predict_trust=0.5)
         assert self._grid(lb, 0, 0) == 0.0  # init, trust seeded to 0.5
         # Fresh sample: innovation 200, first significant one raises trust to
         # 0.7 (0.5 seed + PRED_TRUST_RAISE_STEP), estimate += 0.7 * 200.
         assert self._grid(lb, 0, 200) == pytest.approx(140.0)
 
-    def test_trust_rises_on_sustained_step_and_collapses_on_reversal(self):
+    def test_trust_rises_on_sustained_step_and_collapses_on_reversal(self) -> None:
         lb = self._make(grid_predict_trust=0.5)
         self._grid(lb, 0, 0)
         # A sustained same-sign run drives the trust up to the cap.
@@ -745,7 +746,7 @@ class TestConcentrateDeadband:
     imbalance (issue #523). Mirrored by the C++ port and the differential parity
     suite."""
 
-    def _lb(self, **cfg):
+    def _lb(self, **cfg: Any):
         # Disable the grid predictor so the test exercises the raw control grid
         # directly (concentration acts on the same control grid either way).
         cfg.setdefault("grid_predict_trust", 0.0)
@@ -771,14 +772,14 @@ class TestConcentrateDeadband:
             cid, ConsumerMode("auto"), reports, grid, frozenset(), frozenset(), ()
         )[0]
 
-    def test_disabled_splits_the_correction(self):
+    def test_disabled_splits_the_correction(self) -> None:
         lb = self._lb(concentrate_deadband=0)  # explicitly off
         reports = self._reports()
         a = self._target(lb, "a", reports, 30)
         b = self._target(lb, "b", reports, 30)
         assert a > 0 and b > 0
 
-    def test_cross_phase_pool_is_not_concentrated(self):
+    def test_cross_phase_pool_is_not_concentrated(self) -> None:
         # control_grid sums phases, so concentration must not fire when the
         # batteries are on different phases (it would over-correct one phase).
         lb = self._lb(concentrate_deadband=60)
@@ -798,7 +799,7 @@ class TestConcentrateDeadband:
         # concentration had fired, the non-designated battery's total would be 0.
         assert total("a") != 0 and total("b") != 0
 
-    def test_small_error_concentrated_on_most_active_battery(self):
+    def test_small_error_concentrated_on_most_active_battery(self) -> None:
         lb = self._lb(concentrate_deadband=60)
         # An *already-balanced* pool (both within balance_deadband of their
         # 150 W fair share): concentration is safe here. 30 W error < 60 W
@@ -813,7 +814,7 @@ class TestConcentrateDeadband:
         assert a == pytest.approx(30.0, abs=1.0)
         assert b == pytest.approx(0.0, abs=1e-6)
 
-    def test_imbalanced_pool_is_not_concentrated(self):
+    def test_imbalanced_pool_is_not_concentrated(self) -> None:
         # Regression for issue #523: two Venus E3 charging unevenly (one at
         # 88 W, the other at 890 W). The grid error is small (< 60 W), so the
         # pre-fix concentration handed the whole correction to the most-active
@@ -831,7 +832,7 @@ class TestConcentrateDeadband:
         b = self._target(lb, "b", reports, -30)
         assert b < -1.0
 
-    def test_imbalanced_pool_equalizes_from_both_sides(self):
+    def test_imbalanced_pool_equalizes_from_both_sides(self) -> None:
         # Issue #523 regression-cost fix: the equalizing swap is zero-sum across
         # the phase, so it must move *both* batteries — the under-charging one
         # charges more AND the over-charging one backs off. The over-charging
@@ -850,7 +851,7 @@ class TestConcentrateDeadband:
         assert b < 0  # under-charging battery charges more
         assert a > 0  # over-charging battery backs off (was clamped to 0 before)
 
-    def test_large_error_still_split(self):
+    def test_large_error_still_split(self) -> None:
         lb = self._lb(concentrate_deadband=60)
         reports = self._reports()
         # 200 W error >= 60 W threshold: normal fair-share split, both react.
@@ -858,12 +859,12 @@ class TestConcentrateDeadband:
         b = self._target(lb, "b", reports, 200)
         assert a > 0 and b > 0
 
-    def test_single_battery_unaffected(self):
+    def test_single_battery_unaffected(self) -> None:
         lb = self._lb(concentrate_deadband=60)
         reports = {"a": ConsumerReport(device_type="HMG-50", phase="A", power=200)}
         assert self._target(lb, "a", reports, 30) == pytest.approx(30.0, abs=1.0)
 
-    def test_zero_weight_battery_not_designated(self):
+    def test_zero_weight_battery_not_designated(self) -> None:
         lb = self._lb(concentrate_deadband=60)
         # ``a`` is the most-active (200 W) but configured to take no share
         # (weight 0). It must not be picked as the concentration designee —
@@ -894,7 +895,7 @@ class TestImportTrim:
     covers the few watts of real load its deadband would otherwise leave
     importing. Mirrored by the C++ port and the differential parity suite."""
 
-    def _lb(self, **cfg):
+    def _lb(self, **cfg: Any):
         # Raw control grid (predictor off), no pacing / damping, so the returned
         # reading equals the (possibly trimmed) control grid directly.
         cfg.setdefault("grid_predict_trust", 0.0)
@@ -924,14 +925,14 @@ class TestImportTrim:
             "a", ConsumerMode("auto"), reports, grid, frozenset(), frozenset(), sample
         )[0]
 
-    def test_disabled_never_trims(self):
+    def test_disabled_never_trims(self) -> None:
         lb = self._lb(import_trim_w=0)
         r = 0.0
         for _ in range(IMPORT_TRIM_DWELL + 4):
             r = self._reading(lb, 60)
         assert r == pytest.approx(60.0, abs=1e-6)
 
-    def test_engages_only_after_dwell(self):
+    def test_engages_only_after_dwell(self) -> None:
         lb = self._lb(import_trim_w=15)
         readings = [self._reading(lb, 60) for _ in range(IMPORT_TRIM_DWELL + 2)]
         # Below the dwell threshold the residual is untrimmed; the trim only
@@ -939,7 +940,7 @@ class TestImportTrim:
         assert readings[IMPORT_TRIM_DWELL - 2] == pytest.approx(60.0, abs=1e-6)
         assert readings[-1] == pytest.approx(75.0, abs=1e-6)
 
-    def test_large_import_above_gate_not_trimmed(self):
+    def test_large_import_above_gate_not_trimmed(self) -> None:
         lb = self._lb(import_trim_w=15)
         grid = IMPORT_TRIM_GATE_W + 80.0  # a real disturbance, above the band
         r = 0.0
@@ -947,7 +948,7 @@ class TestImportTrim:
             r = self._reading(lb, grid)
         assert r == pytest.approx(grid, abs=1e-6)
 
-    def test_export_resets_the_dwell(self):
+    def test_export_resets_the_dwell(self) -> None:
         lb = self._lb(import_trim_w=15)
         for _ in range(IMPORT_TRIM_DWELL + 2):
             self._reading(lb, 60)  # trimming now
@@ -955,7 +956,7 @@ class TestImportTrim:
         # Dwell restarts from zero, so the next steady-import poll is untrimmed.
         assert self._reading(lb, 60) == pytest.approx(60.0, abs=1e-6)
 
-    def test_frozen_meter_never_trims(self):
+    def test_frozen_meter_never_trims(self) -> None:
         # A repeated (stale / frozen) sample_id carries no fresh feedback, so the
         # trim must stay silent however long the import persists — otherwise it
         # would wind a blind bias the meter can never correct.
@@ -991,7 +992,7 @@ class TestEfficiencyDemandSmoothing:
             clock=_FakeClock(),
         )
 
-    def _poll(self, lb, grid, tick):
+    def _poll(self, lb, grid, tick) -> None:
         # Two batteries on one phase, 200 W each: demand = |400 + grid|. A fresh
         # sample_id per poll so the efficiency demand EMA advances each call.
         reports = {
@@ -1002,7 +1003,7 @@ class TestEfficiencyDemandSmoothing:
             "a", ConsumerMode("auto"), reports, grid, frozenset(), frozenset(), (tick,)
         )
 
-    def test_smoothing_absorbs_a_noise_dip(self):
+    def test_smoothing_absorbs_a_noise_dip(self) -> None:
         # Steady demand 400 W (200 W/unit, above the 150 W floor) keeps both
         # active; a single-poll dip to 250 W (125 W/unit) would, unsmoothed, drop
         # below the floor and deprioritize a unit.
@@ -1013,7 +1014,7 @@ class TestEfficiencyDemandSmoothing:
         self._poll(smoothed, -150.0, 8)  # demand 250 for one poll
         assert smoothed._deprioritized == set()  # EMA ~385 -> still both active
 
-    def test_disabled_thrashes_on_the_same_dip(self):
+    def test_disabled_thrashes_on_the_same_dip(self) -> None:
         instant = self._lb(alpha=1.0)  # smoothing off: react to every sample
         for t in range(8):
             self._poll(instant, 0.0, t)
@@ -1027,7 +1028,7 @@ class TestDampOscillation:
     host test ``LoadBalancer.DampOscillation`` and the differential parity
     suite (both stacks run the same damper on the same residual stream)."""
 
-    def _lb(self, **cfg):
+    def _lb(self, **cfg: Any):
         cfg.setdefault("osc_damp_max", 0.8)
         # Intentionally above BalancerConfig's 0.15 default: a larger alpha
         # accumulates the score in fewer reversals, so the assertions below
@@ -1045,13 +1046,13 @@ class TestDampOscillation:
             saturation_enabled=False,
         )
 
-    def test_steady_same_sign_is_not_damped(self):
+    def test_steady_same_sign_is_not_damped(self) -> None:
         # A genuine load step holds one sign: the residual passes through.
         lb = self._lb()
         for _ in range(10):
             assert lb._damp_oscillation("a", 100.0) == pytest.approx(100.0)
 
-    def test_sustained_reversals_are_damped(self):
+    def test_sustained_reversals_are_damped(self) -> None:
         # A hunting limit cycle (sign flips every poll) accumulates the score
         # and shrinks the residual toward (1 - osc_damp_max) of its magnitude.
         lb = self._lb()
@@ -1064,7 +1065,7 @@ class TestDampOscillation:
         assert abs(outs[1]) > abs(outs[-1])
         assert abs(outs[-1]) == pytest.approx(20.0, abs=2.0)
 
-    def test_large_residual_bypasses_damping_even_while_hunting(self):
+    def test_large_residual_bypasses_damping_even_while_hunting(self) -> None:
         # Drive the score up with small reversals, then a step above the
         # threshold must react at full gain (not be bled by the prior hunt).
         lb = self._lb(osc_damp_threshold=450)
@@ -1072,7 +1073,7 @@ class TestDampOscillation:
             lb._damp_oscillation("a", 100.0 if i % 2 == 0 else -100.0)
         assert lb._damp_oscillation("a", 1500.0) == pytest.approx(1500.0)
 
-    def test_single_reversal_barely_damps(self):
+    def test_single_reversal_barely_damps(self) -> None:
         # One sign flip (e.g. a solar ramp crossing zero once) only adds
         # osc_damp_alpha to the score, so the response stays near full gain.
         lb = self._lb()
@@ -1082,7 +1083,7 @@ class TestDampOscillation:
         # score == alpha (0.25) -> factor 1 - 0.8*0.25 = 0.8 -> ~80 of 100.
         assert abs(out) == pytest.approx(80.0, abs=1.0)
 
-    def test_disabled_when_max_zero(self):
+    def test_disabled_when_max_zero(self) -> None:
         lb = self._lb(osc_damp_max=0.0)
         for i in range(10):
             r = 100.0 if i % 2 == 0 else -100.0

--- a/tests/test_balancer_distribution_weight.py
+++ b/tests/test_balancer_distribution_weight.py
@@ -38,7 +38,7 @@ def _report(power: float, weight: float = 1.0, phase: str = "A") -> ConsumerRepo
     return ConsumerReport(phase=phase, power=power, device_type="HMA-2", weight=weight)
 
 
-def test_fair_share_honours_weight():
+def test_fair_share_honours_weight() -> None:
     """With balancing off, the raw fair-share split follows the weight ratio."""
     lb = _make_balancer(fair_distribution=False)
     reports = {"a": _report(0.0, weight=1.5), "b": _report(0.0, weight=1.0)}
@@ -53,7 +53,7 @@ def test_fair_share_honours_weight():
     assert b_out[0] == 200.0
 
 
-def test_zero_weight_takes_no_share():
+def test_zero_weight_takes_no_share() -> None:
     """Weight 0.0 means the battery is parked at 0 W; the rest absorb the load."""
     lb = _make_balancer(fair_distribution=False)
     reports = {"a": _report(0.0, weight=0.0), "b": _report(0.0, weight=1.0)}
@@ -67,7 +67,7 @@ def test_zero_weight_takes_no_share():
     assert b_out[0] == 400.0
 
 
-def test_neutral_weight_matches_equal_split():
+def test_neutral_weight_matches_equal_split() -> None:
     """Default weight 1.0 (and an absent weight key) split demand evenly."""
     weighted = {"a": _report(0.0), "b": _report(0.0)}
     # An absent "weight" key must behave exactly like the neutral default.
@@ -83,7 +83,7 @@ def test_neutral_weight_matches_equal_split():
         assert out[0] == 200.0
 
 
-def test_balance_correction_targets_weighted_share():
+def test_balance_correction_targets_weighted_share() -> None:
     """Two equally-loaded batteries get nudged toward the weighted ratio.
 
     Both report 250 W; with weights 1.5/1.0 the heavier battery's target sits

--- a/tests/test_balancer_efficiency_window_weight.py
+++ b/tests/test_balancer_efficiency_window_weight.py
@@ -61,7 +61,7 @@ def _report(power: float, eff_weight: float = 1.0) -> ConsumerReport:
     )
 
 
-def test_zero_weight_battery_stays_deprioritized_while_limiting():
+def test_zero_weight_battery_stays_deprioritized_while_limiting() -> None:
     """A 0-weight battery is parked while limiting (enough non-zero peers)."""
     clock = _FakeClock()
     lb = _make_balancer(clock)
@@ -77,7 +77,7 @@ def test_zero_weight_battery_stays_deprioritized_while_limiting():
     assert lb._priority[-1] == "b"
 
 
-def test_zero_weight_battery_runs_when_all_needed():
+def test_zero_weight_battery_runs_when_all_needed() -> None:
     """When demand needs every battery (slots == n), the 0-weight one runs too."""
     clock = _FakeClock()
     lb = _make_balancer(clock)
@@ -89,7 +89,7 @@ def test_zero_weight_battery_runs_when_all_needed():
     assert lb._deprioritized == set()
 
 
-def test_low_weight_battery_sinks_below_alphabetical_order():
+def test_low_weight_battery_sinks_below_alphabetical_order() -> None:
     """The weight sort overrides the alphabetical fill order."""
     clock = _FakeClock()
     lb = _make_balancer(clock)
@@ -103,7 +103,7 @@ def test_low_weight_battery_sinks_below_alphabetical_order():
     assert lb._deprioritized == {"a"}
 
 
-def test_full_weight_head_rotates_after_full_interval():
+def test_full_weight_head_rotates_after_full_interval() -> None:
     """A weight-1.0 head holds its slot for the whole rotation interval."""
     clock = _FakeClock()
     lb = _make_balancer(clock, rotation_interval=900.0)
@@ -123,7 +123,7 @@ def test_full_weight_head_rotates_after_full_interval():
     assert lb._last_rotation > rot0
 
 
-def test_half_weight_head_rotates_after_half_interval():
+def test_half_weight_head_rotates_after_half_interval() -> None:
     """A weight-0.5 head gives up its slot after ~half the interval."""
     clock = _FakeClock()
     lb = _make_balancer(clock, rotation_interval=900.0)

--- a/tests/test_balancer_steer_logging.py
+++ b/tests/test_balancer_steer_logging.py
@@ -12,6 +12,7 @@ cases apart.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import pytest
 
@@ -34,7 +35,7 @@ def _reports() -> dict:
     }
 
 
-def _steer(caplog: pytest.LogCaptureFixture, **cfg) -> dict[str, str]:
+def _steer(caplog: pytest.LogCaptureFixture, **cfg: Any) -> dict[str, str]:
     """Drive one poll of each mode; return the steer line per consumer."""
     clock = [1000.0]
     lb = LoadBalancer(

--- a/tests/test_control_quality.py
+++ b/tests/test_control_quality.py
@@ -8,6 +8,7 @@ The cases that pin *what it refuses to claim* matter just as much — see
 """
 
 import time
+from typing import Any
 
 import pytest
 
@@ -37,7 +38,7 @@ class _FakeClock:
         self._t += dt
 
 
-def _feed(tracker, values, *, limited=False, dt=1.0, clock=None):
+def _feed(tracker, values, *, limited=False, dt=1.0, clock=None) -> None:
     for value in values:
         if clock is not None:
             clock.advance(dt)
@@ -49,11 +50,11 @@ class TestControlQualityTracker:
         clock = _FakeClock()
         return ControlQualityTracker(band=band, clock=clock), clock
 
-    def test_idle_before_anything_is_steered(self):
+    def test_idle_before_anything_is_steered(self) -> None:
         tracker, _ = self._make()
         assert tracker.snapshot().verdict == "idle"
 
-    def test_idle_while_nothing_is_being_steered(self):
+    def test_idle_while_nothing_is_being_steered(self) -> None:
         tracker, clock = self._make()
         for _ in range(40):
             clock.advance(1.0)
@@ -62,14 +63,14 @@ class TestControlQualityTracker:
         # failure — there is no loop to grade.
         assert tracker.snapshot().verdict == "idle"
 
-    def test_warmup_until_enough_has_been_observed(self):
+    def test_warmup_until_enough_has_been_observed(self) -> None:
         tracker, clock = self._make()
         _feed(tracker, [0.0] * 9, clock=clock)
         assert tracker.snapshot().verdict == "warmup"
         _feed(tracker, [0.0], clock=clock)
         assert tracker.snapshot().verdict == "stable"
 
-    def test_warmup_is_a_duration_not_a_sample_count(self):
+    def test_warmup_is_a_duration_not_a_sample_count(self) -> None:
         """A CT is polled once per battery, so samples arrive N times faster
         with N batteries. Counting them would let a six-battery pool publish a
         verdict off well under a second of observation, while a single battery
@@ -85,7 +86,7 @@ class TestControlQualityTracker:
         assert slow.snapshot().verdict == "stable"
         assert CONTROL_QUALITY_WARMUP_SECONDS == 10.0
 
-    def test_stable_when_the_grid_sits_inside_the_band(self):
+    def test_stable_when_the_grid_sits_inside_the_band(self) -> None:
         tracker, clock = self._make()
         _feed(tracker, [5.0, -8.0, 3.0, -2.0] * 10, clock=clock)
         snap = tracker.snapshot()
@@ -93,7 +94,7 @@ class TestControlQualityTracker:
         assert snap.score > 95.0
         assert snap.in_band_fraction > 0.9
 
-    def test_a_busy_house_that_keeps_coming_back_is_still_stable(self):
+    def test_a_busy_house_that_keeps_coming_back_is_still_stable(self) -> None:
         """Calibration guard (see CONTROL_QUALITY_STABLE_BANDS).
 
         A real house steps constantly and every step lands on the meter before
@@ -114,7 +115,7 @@ class TestControlQualityTracker:
         _feed(far, [200.0] * 200, clock=far_clock)
         assert far.snapshot().verdict == "off_target"
 
-    def test_score_stays_a_gradient_across_realistic_errors(self):
+    def test_score_stays_a_gradient_across_realistic_errors(self) -> None:
         """A score that pins at 0 for every imperfect house says nothing.
 
         The scale is set so the range real installs produce (tens to a few
@@ -129,7 +130,7 @@ class TestControlQualityTracker:
         assert scores[0] > 95.0
         assert all(0.0 < s < 100.0 for s in scores[1:])
 
-    def test_off_target_whether_the_error_crosses_zero_or_not(self):
+    def test_off_target_whether_the_error_crosses_zero_or_not(self) -> None:
         """The verdict describes the grid; it does not guess at a cause.
 
         A limit cycle and a one-sided offset are both reported as
@@ -148,7 +149,7 @@ class TestControlQualityTracker:
         assert hunting.snapshot().crossings_per_second > 0.4
         assert parked.snapshot().crossings_per_second == 0.0
 
-    def test_crossing_rate_is_per_second_not_per_sample(self):
+    def test_crossing_rate_is_per_second_not_per_sample(self) -> None:
         """The rate must describe the house, not the installation.
 
         A CT is polled once per battery, so a per-sample reversal *fraction*
@@ -173,7 +174,7 @@ class TestControlQualityTracker:
         for rate in rates:
             assert abs(rate - 2.0 / 30.0) < 0.01, rates
 
-    def test_a_jittery_meter_is_not_counted_as_crossings(self):
+    def test_a_jittery_meter_is_not_counted_as_crossings(self) -> None:
         """Small-amplitude dither crosses zero constantly and means nothing.
 
         Counting it would score the noisiest installation worst rather than
@@ -183,13 +184,13 @@ class TestControlQualityTracker:
         _feed(tracker, [60.0, -60.0] * 100, clock=clock)
         assert tracker.snapshot().crossings_per_second == 0.0
 
-    def test_limited_needs_to_hold_for_the_window_it_excuses(self):
+    def test_limited_needs_to_hold_for_the_window_it_excuses(self) -> None:
         tracker, clock = self._make()
         _feed(tracker, [250.0] * 120, limited=True, clock=clock)
         # Same numbers as the off-target case; the difference is whose fault.
         assert tracker.snapshot().verdict == "limited"
 
-    def test_one_saturated_sample_does_not_excuse_a_whole_window(self):
+    def test_one_saturated_sample_does_not_excuse_a_whole_window(self) -> None:
         """The error figure averages ~50 s, so the fault claim must too.
 
         Otherwise a single saturated poll retroactively excuses a minute of
@@ -201,12 +202,12 @@ class TestControlQualityTracker:
         _feed(tracker, [250.0], limited=True, clock=clock)
         assert tracker.snapshot().verdict == "off_target"
 
-    def test_a_held_grid_reads_stable_even_with_no_headroom(self):
+    def test_a_held_grid_reads_stable_even_with_no_headroom(self) -> None:
         tracker, clock = self._make()
         _feed(tracker, [4.0] * 40, limited=True, clock=clock)
         assert tracker.snapshot().verdict == "stable"
 
-    def test_the_score_has_no_value_until_it_has_evidence(self):
+    def test_the_score_has_no_value_until_it_has_evidence(self) -> None:
         """Absent, not perfect.
 
         The EMAs start at zero, which reads as a flawlessly held grid — so a
@@ -229,12 +230,12 @@ class TestControlQualityTracker:
         assert tracker.snapshot().verdict == "idle"
         assert tracker.snapshot().score is None
 
-    def test_score_bottoms_out_rather_than_going_negative(self):
+    def test_score_bottoms_out_rather_than_going_negative(self) -> None:
         tracker, clock = self._make()
         _feed(tracker, [50_000.0] * 120, clock=clock)
         assert tracker.snapshot().score == 0.0
 
-    def test_first_sample_seeds_the_window(self):
+    def test_first_sample_seeds_the_window(self) -> None:
         tracker, clock = self._make()
         clock.advance(1.0)
         tracker.update(900.0, steering=True, limited=False)
@@ -242,19 +243,19 @@ class TestControlQualityTracker:
         # of a loop that is nowhere near it.
         assert tracker.snapshot().error_ema == 900.0
 
-    def test_band_floor_protects_a_zero_deadband_config(self):
+    def test_band_floor_protects_a_zero_deadband_config(self) -> None:
         tracker, clock = self._make(band=0.0)
         _feed(tracker, [10.0, -10.0] * 30, clock=clock)
         snap = tracker.snapshot()
         assert snap.band == 25.0
         assert snap.verdict == "stable"
 
-    def test_wider_deadband_widens_what_counts_as_stable(self):
+    def test_wider_deadband_widens_what_counts_as_stable(self) -> None:
         tracker, clock = self._make(band=150.0)
         _feed(tracker, [100.0] * 60, clock=clock)
         assert tracker.snapshot().verdict == "stable"
 
-    def test_pace_independent_verdict(self):
+    def test_pace_independent_verdict(self) -> None:
         """A 0.45 s poller and a 3 s poller must agree about the same house."""
         fast, fast_clock = self._make()
         _feed(fast, [250.0] * 300, dt=0.45, clock=fast_clock)
@@ -263,7 +264,7 @@ class TestControlQualityTracker:
         assert fast.snapshot().verdict == slow.snapshot().verdict == "off_target"
         assert abs(fast.snapshot().score - slow.snapshot().score) < 1.0
 
-    def test_a_long_gap_starts_a_new_window(self):
+    def test_a_long_gap_starts_a_new_window(self) -> None:
         tracker, clock = self._make()
         _feed(tracker, [400.0] * 60, clock=clock)
         assert tracker.snapshot().verdict == "off_target"
@@ -273,7 +274,7 @@ class TestControlQualityTracker:
         assert tracker.snapshot().verdict == "warmup"
         assert tracker.snapshot().error_ema == 0.0
 
-    def test_verdict_goes_idle_once_the_samples_stop(self):
+    def test_verdict_goes_idle_once_the_samples_stop(self) -> None:
         tracker, clock = self._make()
         _feed(tracker, [0.0] * 40, clock=clock)
         assert tracker.snapshot().verdict == "stable"
@@ -282,7 +283,7 @@ class TestControlQualityTracker:
         # a pool that no longer exists.
         assert tracker.snapshot().verdict == "idle"
 
-    def test_states_cover_every_verdict_the_tracker_can_emit(self):
+    def test_states_cover_every_verdict_the_tracker_can_emit(self) -> None:
         assert set(CONTROL_QUALITY_STATES) == {
             "idle",
             "warmup",
@@ -295,7 +296,7 @@ class TestControlQualityTracker:
 class TestControlQualityInBalancer:
     """The tracker as the balancer drives it, through real target computes."""
 
-    def _make(self, **cfg):
+    def _make(self, **cfg: Any):
         clock = _FakeClock()
         balancer = LoadBalancer(
             config=BalancerConfig(**cfg),
@@ -309,7 +310,9 @@ class TestControlQualityInBalancer:
         )
         return balancer, clock
 
-    def _poll(self, balancer, clock, grid, *, reported=0.0, device_type="HMG-50"):
+    def _poll(
+        self, balancer, clock, grid, *, reported=0.0, device_type="HMG-50"
+    ) -> None:
         clock.advance(1.0)
         reports = {
             "a": ConsumerReport(device_type=device_type, phase="A", power=reported)
@@ -324,14 +327,14 @@ class TestControlQualityInBalancer:
             (grid, 0, 0),
         )
 
-    def test_snapshot_carries_the_verdict(self):
+    def test_snapshot_carries_the_verdict(self) -> None:
         balancer, clock = self._make()
         for _ in range(40):
             self._poll(balancer, clock, 0.0)
         assert balancer.status_snapshot().control_quality.verdict == "stable"
         assert balancer.control_quality().verdict == "stable"
 
-    def test_a_repeated_reading_still_counts(self):
+    def test_a_repeated_reading_still_counts(self) -> None:
         """A perfectly settled loop repeats its meter reading.
 
         The import trim skips repeated samples (it must not integrate a blind
@@ -351,7 +354,7 @@ class TestControlQualityInBalancer:
         assert snap.verdict == "stable"
         assert snap.samples >= 100
 
-    def test_a_discharging_dc_battery_still_has_room_for_a_surplus(self):
+    def test_a_discharging_dc_battery_still_has_room_for_a_surplus(self) -> None:
         """A B2500 cannot charge from AC, but it absorbs a surplus by
         discharging *less* — it only runs out of room at its MIN_DC_OUTPUT
         floor. Excusing every surplus on device type alone reported a
@@ -375,14 +378,14 @@ class TestControlQualityInBalancer:
             )
         assert balancer.control_quality().verdict == "off_target"
 
-    def test_a_dc_battery_at_its_floor_really_is_out_of_room(self):
+    def test_a_dc_battery_at_its_floor_really_is_out_of_room(self) -> None:
         balancer, clock = self._make(min_dc_output=50.0)
         for _ in range(120):
             # Already down at the floor: it cannot reduce any further.
             self._poll(balancer, clock, -400.0, reported=50.0, device_type="HMA-1")
         assert balancer.control_quality().verdict == "limited"
 
-    def test_surplus_with_no_ac_chargeable_battery_reads_as_limited(self):
+    def test_surplus_with_no_ac_chargeable_battery_reads_as_limited(self) -> None:
         # A DC-only pack (B2500) under surplus physically cannot absorb; the
         # export that remains is not the controller mis-steering.
         balancer, clock = self._make()
@@ -390,7 +393,7 @@ class TestControlQualityInBalancer:
             self._poll(balancer, clock, -400.0, reported=0.0, device_type="HMA-1")
         assert balancer.control_quality().verdict == "limited"
 
-    def test_a_saturated_pool_reads_as_limited(self):
+    def test_a_saturated_pool_reads_as_limited(self) -> None:
         balancer, clock = self._make()
         for _ in range(60):
             self._poll(balancer, clock, 400.0)
@@ -403,10 +406,10 @@ class TestControlQualityInBalancer:
             self._poll(balancer, clock, 400.0)
         assert balancer.control_quality().verdict == "limited"
 
-    def test_one_healthy_battery_keeps_the_pool_accountable(self):
+    def test_one_healthy_battery_keeps_the_pool_accountable(self) -> None:
         balancer, clock = self._make()
 
-        def poll_pair():
+        def poll_pair() -> None:
             clock.advance(1.0)
             reports = {
                 "a": ConsumerReport(device_type="HMG-50", phase="A", power=0.0),
@@ -438,7 +441,7 @@ class TestControlQualityOnTheMqttWire:
     add-on) gets "off target" and nothing to act on.
     """
 
-    def _quality(self, **kwargs):
+    def _quality(self, **kwargs: Any):
         clock = _FakeClock()
         tracker = ControlQualityTracker(band=25.0, clock=clock)
         for value in kwargs.get("values", []):
@@ -446,7 +449,7 @@ class TestControlQualityOnTheMqttWire:
             tracker.update(value, steering=True, limited=False)
         return tracker.snapshot()
 
-    def test_evidence_is_published_in_the_units_the_docs_describe(self):
+    def test_evidence_is_published_in_the_units_the_docs_describe(self) -> None:
         quality = self._quality(values=[250.0, -250.0] * 60)
         evidence = _control_quality_evidence(quality)
         # Percent, not a 0..1 fraction; per minute, not per second.
@@ -457,7 +460,7 @@ class TestControlQualityOnTheMqttWire:
         assert evidence["control_quality_error_w"] == pytest.approx(250.0, abs=1.0)
         assert evidence["control_quality_band_w"] == 25.0
 
-    def test_evidence_is_absent_before_anything_is_measured(self):
+    def test_evidence_is_absent_before_anything_is_measured(self) -> None:
         evidence = _control_quality_evidence(self._quality())
         assert evidence["control_quality_error_w"] is None
         assert evidence["control_quality_in_band_pct"] is None
@@ -465,7 +468,7 @@ class TestControlQualityOnTheMqttWire:
         # The band is configuration, not a measurement: always meaningful.
         assert evidence["control_quality_band_w"] == 25.0
 
-    def test_evidence_is_real_during_warmup(self):
+    def test_evidence_is_real_during_warmup(self) -> None:
         """The EMAs are seeded from the first sample, so they are honest well
         before the score is — only a window with nothing in it is absent."""
         quality = self._quality(values=[900.0])

--- a/tests/test_ct002_active_control.py
+++ b/tests/test_ct002_active_control.py
@@ -2,12 +2,13 @@
 
 import dataclasses
 import time
+from typing import Any
 
 from astrameter.ct002.balancer import ConsumerReport, ProbeState, split_balancer_knobs
 from astrameter.ct002.ct002 import CT002
 
 
-def _ct002(**kwargs) -> CT002:
+def _ct002(**kwargs: Any) -> CT002:
     """CT002 with ramp pacing disabled.
 
     These tests pin the raw distribution / saturation / efficiency math;
@@ -22,7 +23,7 @@ def _ct002(**kwargs) -> CT002:
 class TestActiveControl:
     """Tests for smooth target and load splitting."""
 
-    def test_smooth_target_splits_across_consumers(self):
+    def test_smooth_target_splits_across_consumers(self) -> None:
         device = _ct002(active_control=True, fair_distribution=False)
         device._update_consumer_report("a", "A", 100)
         device._update_consumer_report("b", "A", 100)
@@ -31,19 +32,19 @@ class TestActiveControl:
         assert out[1] == 0
         assert out[2] == 0
 
-    def test_active_control_off_passes_through_values(self):
+    def test_active_control_off_passes_through_values(self) -> None:
         device = _ct002(active_control=False)
         device._update_consumer_report("a", "A", 0)
         out = device._compute_smooth_target([100, 50, 25], "a")
         assert out == [100, 50, 25]
 
-    def test_no_consumer_id_returns_fair_share(self):
+    def test_no_consumer_id_returns_fair_share(self) -> None:
         device = _ct002(active_control=True, fair_distribution=False)
         device._update_consumer_report("a", "A", 0)
         out = device._compute_smooth_target([300, 0, 0], None)
         assert out[0] == 300
 
-    def test_active_control_splits_target_across_detected_phases(self):
+    def test_active_control_splits_target_across_detected_phases(self) -> None:
         device = _ct002(active_control=True, fair_distribution=False)
         device._update_consumer_report("a", "A", 0)
         device._update_consumer_report("b", "B", 0)
@@ -54,7 +55,7 @@ class TestActiveControl:
         assert out[1] == 100
         assert out[2] == 0
 
-    def test_single_phase_input_runs_balancer(self):
+    def test_single_phase_input_runs_balancer(self) -> None:
         # 1-phase configurations supply a single grid reading; the balancer
         # collapses values to a scalar internally, so it must still run
         # rather than passing the raw reading through unmodified.
@@ -69,7 +70,7 @@ class TestActiveControl:
 class TestFairDistribution:
     """Tests for fair load distribution across consumers."""
 
-    def test_underperforming_consumer_gets_higher_target(self):
+    def test_underperforming_consumer_gets_higher_target(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=True,
@@ -83,7 +84,7 @@ class TestFairDistribution:
         out_a = device._compute_smooth_target([400, 0, 0], "a")
         assert out_a[0] > 200
 
-    def test_overperforming_consumer_gets_lower_target(self):
+    def test_overperforming_consumer_gets_lower_target(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=True,
@@ -97,7 +98,7 @@ class TestFairDistribution:
         out_b = device._compute_smooth_target([400, 0, 0], "b")
         assert out_b[0] < 200
 
-    def test_fair_distribution_off_gives_equal_share(self):
+    def test_fair_distribution_off_gives_equal_share(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=False,
@@ -108,7 +109,7 @@ class TestFairDistribution:
         out_b = device._compute_smooth_target([400, 0, 0], "b")
         assert out_a[0] == out_b[0] == 200
 
-    def test_balance_gain_zero_no_correction(self):
+    def test_balance_gain_zero_no_correction(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=True,
@@ -123,7 +124,7 @@ class TestFairDistribution:
         out_b = device._compute_smooth_target([400, 0, 0], "b")
         assert out_a[0] == out_b[0] == 200
 
-    def test_large_error_gets_boosted_correction(self):
+    def test_large_error_gets_boosted_correction(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=True,
@@ -141,7 +142,7 @@ class TestFairDistribution:
         assert out_a[0] > 250
         assert out_b[0] < 150
 
-    def test_error_boost_disabled_when_threshold_zero(self):
+    def test_error_boost_disabled_when_threshold_zero(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=True,
@@ -158,7 +159,7 @@ class TestFairDistribution:
         assert out_a[0] == 260
         assert out_b[0] == 140
 
-    def test_small_offset_gets_small_adjustment(self):
+    def test_small_offset_gets_small_adjustment(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=True,
@@ -172,7 +173,7 @@ class TestFairDistribution:
         assert 98 < out_a[0] < 102
         assert 98 < out_b[0] < 102
 
-    def test_error_reduce_disabled_when_threshold_zero(self):
+    def test_error_reduce_disabled_when_threshold_zero(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=True,
@@ -188,7 +189,7 @@ class TestFairDistribution:
         out_a = device._compute_smooth_target([200, 0, 0], "a")
         assert out_a[0] == 103
 
-    def test_balance_deadband_skips_small_correction(self):
+    def test_balance_deadband_skips_small_correction(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=True,
@@ -202,7 +203,7 @@ class TestFairDistribution:
         out_a = device._compute_smooth_target([200, 0, 0], "a")
         assert out_a[0] == 100
 
-    def test_max_correction_per_step_caps_correction(self):
+    def test_max_correction_per_step_caps_correction(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=True,
@@ -216,7 +217,7 @@ class TestFairDistribution:
         out_a = device._compute_smooth_target([400, 0, 0], "a")
         assert 200 < out_a[0] <= 250
 
-    def test_max_target_step_caps_target_vs_actual(self):
+    def test_max_target_step_caps_target_vs_actual(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=True,
@@ -234,7 +235,7 @@ class TestFairDistribution:
 class TestSaturationDetection:
     """Tests for saturation detection (full/empty battery)."""
 
-    def test_saturated_consumer_gets_reduced_share(self):
+    def test_saturated_consumer_gets_reduced_share(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=True,
@@ -251,7 +252,7 @@ class TestSaturationDetection:
         assert out_a[0] < out_b[0]
         assert out_b[0] > 200
 
-    def test_saturation_ema_smooths_in(self):
+    def test_saturation_ema_smooths_in(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=False,
@@ -269,7 +270,7 @@ class TestSaturationDetection:
         out2 = device._compute_smooth_target([400, 0, 0], "a")
         assert out2[0] < out1[0]
 
-    def test_saturation_ema_smooths_out_when_recovering(self):
+    def test_saturation_ema_smooths_out_when_recovering(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=False,
@@ -288,7 +289,7 @@ class TestSaturationDetection:
         out2 = device._compute_smooth_target([400, 0, 0], "a")
         assert out2[0] > out1[0]
 
-    def test_saturation_ignores_low_target(self):
+    def test_saturation_ignores_low_target(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=False,
@@ -303,7 +304,7 @@ class TestSaturationDetection:
         out = device._compute_smooth_target([20, 0, 0], "a")
         assert out[0] == 10
 
-    def test_saturation_off_no_reduction(self):
+    def test_saturation_off_no_reduction(self) -> None:
         device = _ct002(
             active_control=True,
             fair_distribution=False,
@@ -317,7 +318,7 @@ class TestSaturationDetection:
         out_b = device._compute_smooth_target([400, 0, 0], "b")
         assert out_a[0] == out_b[0] == 200
 
-    def test_saturation_opposite_sign_meaningful_output_not_saturated(self):
+    def test_saturation_opposite_sign_meaningful_output_not_saturated(self) -> None:
         """Meaningful output in the wrong direction can be normal ramp-down."""
         device = _ct002(
             active_control=True,
@@ -336,7 +337,7 @@ class TestSaturationDetection:
         assert out[0] == 200
         assert device._balancer._get_consumer("a").saturation_score == 0.0
 
-    def test_partial_output_not_saturated(self):
+    def test_partial_output_not_saturated(self) -> None:
         """A battery producing meaningful output below target is NOT saturated.
 
         This is the key behavioral distinction: only near-zero output counts as
@@ -358,7 +359,7 @@ class TestSaturationDetection:
         # actual=50 is well above min_target_for_saturation=20, so no saturation.
         assert device._balancer._get_consumer("a").saturation_score == 0.0
 
-    def test_saturation_boundary_at_threshold(self):
+    def test_saturation_boundary_at_threshold(self) -> None:
         """Output exactly at min_target_for_saturation is not saturated;
         output just below it is."""
         device = _ct002(
@@ -386,7 +387,7 @@ class TestSaturationDetection:
 class TestCleanup:
     """Tests that saturation state is cleaned up with consumers."""
 
-    def test_cleanup_removes_saturation_state(self):
+    def test_cleanup_removes_saturation_state(self) -> None:
         device = _ct002(saturation_detection=True, consumer_ttl=0.01)
         device._update_consumer_report("a", "A", 0)
         device._balancer._get_consumer("a").last_target = 100
@@ -395,7 +396,7 @@ class TestCleanup:
         device._cleanup_consumers()
         assert "a" not in device._balancer._consumers
 
-    def test_cleanup_removes_efficiency_state(self):
+    def test_cleanup_removes_efficiency_state(self) -> None:
         device = _ct002(min_efficient_power=150, consumer_ttl=0.01)
         device._update_consumer_report("a", "A", 0)
         device._balancer._deprioritized.add("a")
@@ -411,7 +412,7 @@ class TestCleanup:
 class TestEfficiencyOptimization:
     """Tests for efficiency optimization (low-demand power concentration)."""
 
-    def test_disabled_by_default(self):
+    def test_disabled_by_default(self) -> None:
         """With min_efficient_power=0, output is identical to current behavior."""
         device = _ct002(
             active_control=True,
@@ -423,7 +424,7 @@ class TestEfficiencyOptimization:
         out = device._compute_smooth_target([400, 0, 0], "a")
         assert out[0] == 200
 
-    def test_low_demand_concentrates_on_one_consumer(self):
+    def test_low_demand_concentrates_on_one_consumer(self) -> None:
         """200W with 2 consumers and threshold=150 → one gets ~200W, other ~0W."""
         device = _ct002(
             active_control=True,
@@ -438,7 +439,7 @@ class TestEfficiencyOptimization:
         # One should get ~200W, the other ~0W
         assert (out_a[0] > 150 and out_b[0] < 10) or (out_b[0] > 150 and out_a[0] < 10)
 
-    def test_high_demand_activates_all_consumers(self):
+    def test_high_demand_activates_all_consumers(self) -> None:
         """600W with 2 consumers and threshold=150 → both get ~300W."""
         device = _ct002(
             active_control=True,
@@ -452,7 +453,7 @@ class TestEfficiencyOptimization:
         assert out_a[0] == 300
         assert out_b[0] == 300
 
-    def test_hysteresis_prevents_oscillation(self):
+    def test_hysteresis_prevents_oscillation(self) -> None:
         """At steady 250W with threshold=150, system should stay at 1 active
         (not oscillate between 1 and 2)."""
         device = _ct002(
@@ -471,7 +472,7 @@ class TestEfficiencyOptimization:
         device._compute_smooth_target([251, 0, 0], "b")
         assert len(device._balancer._deprioritized) == 1
 
-    def test_exits_limiting_at_higher_threshold(self):
+    def test_exits_limiting_at_higher_threshold(self) -> None:
         """Hysteresis requires higher per-consumer demand to exit limiting."""
         device = _ct002(
             active_control=True,
@@ -496,7 +497,7 @@ class TestEfficiencyOptimization:
         device._compute_smooth_target([370, 0, 0], "b")
         assert len(device._balancer._deprioritized) == 0
 
-    def test_priority_rotation(self):
+    def test_priority_rotation(self) -> None:
         """After rotation interval, the deprioritized consumer changes."""
         device = _ct002(
             active_control=True,
@@ -521,7 +522,7 @@ class TestEfficiencyOptimization:
         assert len(second_deprioritized) == 1
         assert first_deprioritized != second_deprioritized
 
-    def test_single_consumer_always_active(self):
+    def test_single_consumer_always_active(self) -> None:
         """With only 1 consumer, it's always active regardless of threshold."""
         device = _ct002(
             active_control=True,
@@ -533,7 +534,7 @@ class TestEfficiencyOptimization:
         assert out[0] == 50
         assert len(device._balancer._deprioritized) == 0
 
-    def test_three_consumers_demand_supports_two(self):
+    def test_three_consumers_demand_supports_two(self) -> None:
         """350W with 3 consumers and threshold=150 → 2 active, 1 deprioritized."""
         device = _ct002(
             active_control=True,
@@ -548,7 +549,7 @@ class TestEfficiencyOptimization:
         device._compute_smooth_target([350, 0, 0], "c")
         assert len(device._balancer._deprioritized) == 1
 
-    def test_negative_target_concentrates(self):
+    def test_negative_target_concentrates(self) -> None:
         """Charging (negative target) should also concentrate on fewer batteries."""
         device = _ct002(
             active_control=True,
@@ -569,7 +570,7 @@ class TestEfficiencyOptimization:
         assert total > 150
         assert min(abs(out_a[0]), abs(out_b[0])) < 10
 
-    def test_cache_consistency_across_consumers(self):
+    def test_cache_consistency_across_consumers(self) -> None:
         """Same sample should produce consistent deprioritized set."""
         device = _ct002(
             active_control=True,
@@ -584,7 +585,7 @@ class TestEfficiencyOptimization:
         deprioritized_after_b = set(device._balancer._deprioritized)
         assert deprioritized_after_a == deprioritized_after_b
 
-    def test_works_with_fair_distribution_off(self):
+    def test_works_with_fair_distribution_off(self) -> None:
         """Efficiency optimization should work even with fair_distribution=False."""
         device = _ct002(
             active_control=True,
@@ -603,7 +604,7 @@ class TestEfficiencyOptimization:
 class TestEfficiencyFade:
     """Tests for smooth fade transitions during efficiency optimization."""
 
-    def test_fade_gradual_deprioritize(self):
+    def test_fade_gradual_deprioritize(self) -> None:
         """With default alpha, deprioritized consumer should fade gradually."""
         device = _ct002(
             active_control=True,
@@ -620,7 +621,7 @@ class TestEfficiencyFade:
         fade_w = device._balancer._consumers[deprioritized_cid].fade_weight
         assert 0 < fade_w < 1.0, f"Expected intermediate fade, got {fade_w}"
 
-    def test_fade_blend_drives_consumer_down(self):
+    def test_fade_blend_drives_consumer_down(self) -> None:
         """During fade-down, the blend formula should produce negative targets
         to actively drive the consumer toward zero, not just reduce its share."""
         device = _ct002(
@@ -663,7 +664,7 @@ class TestEfficiencyFade:
             f"got {out[0]}. fade_w={fade_w}"
         )
 
-    def test_fade_gradual_activate(self):
+    def test_fade_gradual_activate(self) -> None:
         """When demand rises, reactivated consumer fades in gradually."""
         device = _ct002(
             active_control=True,
@@ -694,7 +695,7 @@ class TestEfficiencyFade:
         fade_w = device._balancer._consumers[deprioritized_cid].fade_weight
         assert 0 < fade_w < 1.0, f"Expected gradual activate, got {fade_w}"
 
-    def test_fade_converges(self):
+    def test_fade_converges(self) -> None:
         """After enough calls, fade weight snaps to target."""
         device = _ct002(
             active_control=True,
@@ -710,7 +711,7 @@ class TestEfficiencyFade:
         deprioritized_cid = next(iter(device._balancer._deprioritized))
         assert device._balancer._consumers[deprioritized_cid].fade_weight == 0.0
 
-    def test_fade_instant_with_alpha_one(self):
+    def test_fade_instant_with_alpha_one(self) -> None:
         """With alpha=1.0, fade is instant (matches old behavior)."""
         device = _ct002(
             active_control=True,
@@ -725,7 +726,7 @@ class TestEfficiencyFade:
         # One should be at ~200W, the other at ~0W — same as old behavior.
         assert (out_a[0] > 150 and out_b[0] < 10) or (out_b[0] > 150 and out_a[0] < 10)
 
-    def test_fade_rotation_during_fade(self):
+    def test_fade_rotation_during_fade(self) -> None:
         """Rotation fires even while a consumer is mid-fade."""
         device = _ct002(
             active_control=True,
@@ -747,7 +748,7 @@ class TestEfficiencyFade:
         # Rotation should fire — fade handles overlapping transitions.
         assert device._balancer._deprioritized != first_deprioritized
 
-    def test_fade_consumer_disconnect_mid_fade(self):
+    def test_fade_consumer_disconnect_mid_fade(self) -> None:
         """Consumer with active fade gets pruned by cleanup."""
         device = _ct002(
             min_efficient_power=150,
@@ -759,7 +760,7 @@ class TestEfficiencyFade:
         device._cleanup_consumers()
         assert "a" not in device._balancer._consumers
 
-    def test_fade_new_consumer_during_fade(self):
+    def test_fade_new_consumer_during_fade(self) -> None:
         """New consumer starts its fade from 1.0, not from 0.0."""
         device = _ct002(
             active_control=True,
@@ -782,7 +783,7 @@ class TestEfficiencyFade:
         # New consumer "c" should be at 1.0 (never deprioritized).
         assert device._balancer._get_consumer("c").fade_weight == 1.0
 
-    def test_fade_demand_reversal(self):
+    def test_fade_demand_reversal(self) -> None:
         """Deprioritization reverses mid-fade; EMA reverses direction."""
         device = _ct002(
             active_control=True,
@@ -812,7 +813,7 @@ class TestEfficiencyFade:
 class TestEfficiencySaturationSwap:
     """Tests for saturation-aware forced rotation in efficiency optimization."""
 
-    def test_efficiency_force_rotation_on_saturation(self):
+    def test_efficiency_force_rotation_on_saturation(self) -> None:
         """Active consumer with saturation above threshold gets swapped out."""
         device = _ct002(
             active_control=True,
@@ -837,7 +838,7 @@ class TestEfficiencySaturationSwap:
         # Active consumer should now be deprioritized (swapped)
         assert active_cid in device._balancer._deprioritized
 
-    def test_efficiency_no_force_rotation_below_threshold(self):
+    def test_efficiency_no_force_rotation_below_threshold(self) -> None:
         """Saturation below threshold does not trigger a swap."""
         device = _ct002(
             active_control=True,
@@ -863,7 +864,7 @@ class TestEfficiencySaturationSwap:
         # No swap should have occurred
         assert device._balancer._deprioritized == first_deprioritized
 
-    def test_efficiency_no_force_rotation_all_saturated(self):
+    def test_efficiency_no_force_rotation_all_saturated(self) -> None:
         """When all consumers are saturated, no swap occurs (no healthy replacement)."""
         device = _ct002(
             active_control=True,
@@ -886,7 +887,7 @@ class TestEfficiencySaturationSwap:
         # No swap — deprioritized set unchanged
         assert device._balancer._deprioritized == first_deprioritized
 
-    def test_efficiency_force_rotation_resets_timer(self):
+    def test_efficiency_force_rotation_resets_timer(self) -> None:
         """Forced swap resets the rotation timer."""
         device = _ct002(
             active_control=True,
@@ -909,7 +910,7 @@ class TestEfficiencySaturationSwap:
         # Rotation timer should have been updated from sentinel
         assert device._balancer._last_rotation > 0
 
-    def test_efficiency_force_rotation_disabled_when_zero(self):
+    def test_efficiency_force_rotation_disabled_when_zero(self) -> None:
         """Threshold=0.0 disables forced swap even with high saturation."""
         device = _ct002(
             active_control=True,
@@ -930,7 +931,7 @@ class TestEfficiencySaturationSwap:
         device._compute_smooth_target([200, 0, 0], "b")
         assert device._balancer._deprioritized == first_deprioritized
 
-    def test_efficiency_saturation_decay(self):
+    def test_efficiency_saturation_decay(self) -> None:
         """Saturation decays multiplicatively when target < min_target."""
         device = _ct002(
             active_control=True,
@@ -946,7 +947,7 @@ class TestEfficiencySaturationSwap:
         expected = 0.5 * 0.9
         assert abs(device._balancer._consumers["a"].saturation_score - expected) < 1e-6
 
-    def test_efficiency_saturation_decay_floor(self):
+    def test_efficiency_saturation_decay_floor(self) -> None:
         """Saturation entry is removed when it decays below 0.001."""
         device = _ct002(
             active_control=True,
@@ -961,7 +962,7 @@ class TestEfficiencySaturationSwap:
         # 0.001 * 0.5 = 0.0005 < 0.001 → entry should be removed
         assert device._balancer._get_consumer("a").saturation_score == 0.0
 
-    def test_efficiency_force_swap_during_active_fade(self):
+    def test_efficiency_force_swap_during_active_fade(self) -> None:
         """Forced swap during an active fade converges correctly."""
         device = _ct002(
             active_control=True,
@@ -991,7 +992,7 @@ class TestEfficiencySaturationSwap:
             device._compute_smooth_target([200, 0, 0], "a")
             device._compute_smooth_target([200, 0, 0], "b")
 
-    def test_efficiency_force_rotation_cache_invalidation(self):
+    def test_efficiency_force_rotation_cache_invalidation(self) -> None:
         """After forced swap, next consumer call returns post-swap result."""
         device = _ct002(
             active_control=True,
@@ -1017,7 +1018,7 @@ class TestEfficiencySaturationSwap:
         assert active_cid in device._balancer._deprioritized
         assert depr_cid not in device._balancer._deprioritized
 
-    def test_efficiency_force_rotation_three_consumers(self):
+    def test_efficiency_force_rotation_three_consumers(self) -> None:
         """With 3 consumers and 2 active slots, only the saturated one swaps."""
         device = _ct002(
             active_control=True,
@@ -1050,7 +1051,7 @@ class TestEfficiencySaturationSwap:
         # Still exactly 1 deprioritized
         assert len(device._balancer._deprioritized) == 1
 
-    def test_efficiency_activation_resets_stale_saturation(self):
+    def test_efficiency_activation_resets_stale_saturation(self) -> None:
         """Activation clears residual saturation when a consumer becomes active."""
         device = _ct002(
             active_control=True,
@@ -1076,7 +1077,7 @@ class TestEfficiencySaturationSwap:
         # Its saturation should have been reset on activation
         assert device._balancer._get_consumer(depr_cid).saturation_score == 0.0
 
-    def test_efficiency_rampdown_does_not_poison_replacement_battery(self):
+    def test_efficiency_rampdown_does_not_poison_replacement_battery(self) -> None:
         """A healthy battery ramping down must remain eligible for takeover."""
         device = _ct002(
             active_control=True,
@@ -1099,7 +1100,7 @@ class TestEfficiencySaturationSwap:
 
         assert device._balancer._get_consumer("b").saturation_score == 0.0
 
-    def test_efficiency_force_rotation_on_saturation_charging(self):
+    def test_efficiency_force_rotation_on_saturation_charging(self) -> None:
         """Forced swap also works for charging (negative target / solar excess)."""
         device = _ct002(
             active_control=True,
@@ -1123,7 +1124,7 @@ class TestEfficiencySaturationSwap:
         # Active consumer should now be deprioritized (swapped)
         assert active_cid in device._balancer._deprioritized
 
-    def test_rotation_grace_period_prevents_immediate_swap_back(self):
+    def test_rotation_grace_period_prevents_immediate_swap_back(self) -> None:
         """After timed rotation promotes a consumer, saturation updates are
         skipped during the grace period so the battery has time to ramp up."""
         device = _ct002(
@@ -1172,7 +1173,7 @@ class TestEfficiencySaturationSwap:
         # Its saturation should be zero (updates skipped during grace)
         assert device._balancer._get_consumer(first_depr).saturation_score == 0.0
 
-    def test_rotation_grace_period_expires(self):
+    def test_rotation_grace_period_expires(self) -> None:
         """Probe timeout restores the previous active battery."""
         device = _ct002(
             active_control=True,
@@ -1213,7 +1214,7 @@ class TestEfficiencySaturationSwap:
         assert rejected_out[0] == 0.0
         assert restored_out[0] > 0.0
 
-    def test_probe_backup_uses_delta_not_absolute_output(self):
+    def test_probe_backup_uses_delta_not_absolute_output(self) -> None:
         """Initial probe command should ramp up instead of jumping to absolute output."""
         device = _ct002(
             active_control=True,
@@ -1236,7 +1237,7 @@ class TestEfficiencySaturationSwap:
         assert out_a[0] == 0
         assert out_b[0] == 5
 
-    def test_probe_backup_ignores_probe_output_and_follows_demand(self):
+    def test_probe_backup_ignores_probe_output_and_follows_demand(self) -> None:
         """Backup should keep following live demand during probe."""
         device = _ct002(
             active_control=True,
@@ -1259,7 +1260,7 @@ class TestEfficiencySaturationSwap:
         assert out_a[0] == 0
         assert out_b[0] == 0
 
-    def test_probe_backup_backs_off_after_first_qualifying_sample(self):
+    def test_probe_backup_backs_off_after_first_qualifying_sample(self) -> None:
         """Once the probe has one qualifying sample, backup should subtract actual probe output."""
         device = _ct002(
             active_control=True,
@@ -1288,7 +1289,7 @@ class TestEfficiencySaturationSwap:
 class TestInactiveConsumers:
     """Tests for the active/pause flag (set_consumer_active)."""
 
-    def test_inactive_consumer_drives_to_zero_on_phase(self):
+    def test_inactive_consumer_drives_to_zero_on_phase(self) -> None:
         """An inactive consumer with non-zero reported power should get
         target = -reported_power on its phase, not just [0,0,0]."""
         device = _ct002(active_control=True, fair_distribution=False)
@@ -1300,7 +1301,7 @@ class TestInactiveConsumers:
         # Phase B → index 1, target should be -250 to steer output to zero
         assert result == [0.0, -250.0, 0.0]
 
-    def test_inactive_consumer_already_at_zero_returns_zeros(self):
+    def test_inactive_consumer_already_at_zero_returns_zeros(self) -> None:
         """An inactive consumer reporting 0W should get [0,0,0]."""
         device = _ct002(active_control=True, fair_distribution=False)
         device._update_consumer_report("bat1", "A", 0)
@@ -1309,7 +1310,7 @@ class TestInactiveConsumers:
         result = device._compute_smooth_target([400, 0, 0], "bat1")
         assert result == [0, 0, 0]
 
-    def test_inactive_consumer_excluded_from_fair_distribution(self):
+    def test_inactive_consumer_excluded_from_fair_distribution(self) -> None:
         """Fair share should only count active consumers."""
         device = _ct002(active_control=True, fair_distribution=False)
         device._update_consumer_report("bat1", "A", 0)
@@ -1320,7 +1321,7 @@ class TestInactiveConsumers:
         result = device._compute_smooth_target([400, 0, 0], "bat2")
         assert result[0] == 400
 
-    def test_inactive_consumer_excluded_from_efficiency_rotation(self):
+    def test_inactive_consumer_excluded_from_efficiency_rotation(self) -> None:
         """Inactive consumers should not appear in the efficiency priority list."""
         device = _ct002(
             active_control=True,
@@ -1338,7 +1339,7 @@ class TestInactiveConsumers:
         assert "bat1" in device._balancer._priority
         assert "bat3" in device._balancer._priority
 
-    def test_reactivated_consumer_rejoins_distribution(self):
+    def test_reactivated_consumer_rejoins_distribution(self) -> None:
         """After re-activating, consumer should participate normally."""
         device = _ct002(active_control=True, fair_distribution=False)
         device._update_consumer_report("bat1", "A", 0)
@@ -1354,7 +1355,7 @@ class TestInactiveConsumers:
         result = device._compute_smooth_target([400, 0, 0], "bat1")
         assert result[0] == 200  # now split between two
 
-    def test_set_consumer_active_toggle(self):
+    def test_set_consumer_active_toggle(self) -> None:
         device = _ct002()
         assert device.is_consumer_active("x")
         device.set_consumer_active("x", False)
@@ -1362,7 +1363,7 @@ class TestInactiveConsumers:
         device.set_consumer_active("x", True)
         assert device.is_consumer_active("x")
 
-    def test_reactivation_clears_stale_state(self):
+    def test_reactivation_clears_stale_state(self) -> None:
         """Re-enabling a consumer should clear saturation and last_target."""
         device = _ct002(active_control=True)
         device._balancer._get_consumer("bat1").saturation_score = 0.8
@@ -1375,7 +1376,7 @@ class TestInactiveConsumers:
         assert device._balancer._get_consumer("bat1").saturation_score == 0.0
         assert device._balancer._get_consumer("bat1").last_target is None
 
-    def test_last_target_set_to_zero_for_inactive(self):
+    def test_last_target_set_to_zero_for_inactive(self) -> None:
         """Inactive consumer's last_target should be recorded as 0."""
         device = _ct002(active_control=True)
         device._update_consumer_report("bat1", "A", 100)
@@ -1387,10 +1388,10 @@ class TestInactiveConsumers:
 class TestActiveControlToggle:
     """Tests for the device-level active-control switch (set_active_control)."""
 
-    def test_default_on(self):
+    def test_default_on(self) -> None:
         assert _ct002().active_control is True
 
-    def test_disable_falls_back_to_relay(self):
+    def test_disable_falls_back_to_relay(self) -> None:
         """With active control off, _compute_smooth_target returns the raw
         grid values untouched (relay mode) instead of a balancer split."""
         device = _ct002(active_control=True, fair_distribution=False)
@@ -1401,7 +1402,7 @@ class TestActiveControlToggle:
         assert device.active_control is False
         assert device._compute_smooth_target([400, 0, 0], "a") == [400, 0, 0]
 
-    def test_toggle_back_on_resumes_split(self):
+    def test_toggle_back_on_resumes_split(self) -> None:
         device = _ct002(active_control=False, fair_distribution=False)
         device._update_consumer_report("a", "A", 100)
         device._update_consumer_report("b", "A", 100)

--- a/tests/test_ct002_mac_policy.py
+++ b/tests/test_ct002_mac_policy.py
@@ -8,7 +8,7 @@ def make_request(ct_mac):
     return build_payload(fields)
 
 
-async def test_ct002_accepts_any_when_no_mac():
+async def test_ct002_accepts_any_when_no_mac() -> None:
     device = CT002(ct_mac="")
     transport = MagicMock()
     await device._handle_request(
@@ -17,7 +17,7 @@ async def test_ct002_accepts_any_when_no_mac():
     transport.sendto.assert_called_once()
 
 
-async def test_ct002_configured_mac_rejects_mismatch():
+async def test_ct002_configured_mac_rejects_mismatch() -> None:
     device = CT002(ct_mac="AABBCCDDEEFF")
     transport = MagicMock()
     await device._handle_request(
@@ -26,7 +26,7 @@ async def test_ct002_configured_mac_rejects_mismatch():
     transport.sendto.assert_not_called()
 
 
-async def test_ct002_configured_mac_accepts_match():
+async def test_ct002_configured_mac_accepts_match() -> None:
     device = CT002(ct_mac="AABBCCDDEEFF")
     transport = MagicMock()
     await device._handle_request(

--- a/tests/test_ct002_protocol.py
+++ b/tests/test_ct002_protocol.py
@@ -1,6 +1,8 @@
 import logging
 from unittest.mock import MagicMock
 
+import pytest
+
 from astrameter.ct002 import CT002, CT002Request, ReportingConsumerRow
 from astrameter.ct002.balancer import BalancerConfig
 from astrameter.ct002.protocol import (
@@ -14,7 +16,7 @@ from astrameter.ct002.protocol import (
 )
 
 
-def test_parse_request_roundtrip():
+def test_parse_request_roundtrip() -> None:
     fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "5", "7"]
     payload = build_payload(fields)
     parsed, error = parse_request(payload)
@@ -22,7 +24,7 @@ def test_parse_request_roundtrip():
     assert parsed == fields
 
 
-def test_parse_request_checksum_error():
+def test_parse_request_checksum_error() -> None:
     fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "0", "0"]
     payload = bytearray(build_payload(fields))
     payload[-1] = ord("0") if payload[-1] != ord("0") else ord("1")
@@ -31,7 +33,7 @@ def test_parse_request_checksum_error():
     assert "Checksum" in error
 
 
-def test_parse_request_checksum_space_tolerance():
+def test_parse_request_checksum_space_tolerance() -> None:
     fields = ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "0", "0"]
     payload = bytearray(build_payload(fields))
     payload[-2] = ord(" ")
@@ -40,7 +42,7 @@ def test_parse_request_checksum_space_tolerance():
     assert parsed == fields
 
 
-def test_build_payload_length_and_checksum():
+def test_build_payload_length_and_checksum() -> None:
     fields = ["HMG-50", "AABBCCDDEEFF", "HME-3", "112233445566", "0", "0"]
     payload = build_payload(fields)
     assert payload[0] == SOH
@@ -56,7 +58,7 @@ def test_build_payload_length_and_checksum():
     assert payload[-2:] == expected
 
 
-def test_checksum_matches_helper():
+def test_checksum_matches_helper() -> None:
     payload = bytearray([SOH, STX, 0x30, 0x30, ETX])
     checksum = calculate_checksum(payload)
     assert isinstance(checksum, int)
@@ -64,7 +66,7 @@ def test_checksum_matches_helper():
     assert checksum == expected
 
 
-def test_ct002_response_field_count_stable():
+def test_ct002_response_field_count_stable() -> None:
     device = CT002()
     request = CT002Request.from_fields(
         ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "0", "0"]
@@ -128,7 +130,7 @@ def _set_instruction(
     device._consumers[consumer_id].last_instructed_power = float(instructed)
 
 
-def test_ct002_relays_sum_of_charge_instructions_by_phase():
+def test_ct002_relays_sum_of_charge_instructions_by_phase() -> None:
     device = CT002()
     request = CT002Request.from_fields(
         ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "B", "-100"]
@@ -159,7 +161,7 @@ def test_ct002_relays_sum_of_charge_instructions_by_phase():
     assert response_for_b[16] == "-240"  # B_chrg_power
 
 
-def test_ct002_relay_reports_battery_count_per_phase():
+def test_ct002_relay_reports_battery_count_per_phase() -> None:
     """Relay mode forwards the real per-phase battery count as *_chrg_nb.
 
     Each battery divides the forwarded aggregate by this count to take its
@@ -186,7 +188,7 @@ def test_ct002_relay_reports_battery_count_per_phase():
     assert response[10] == "0"  # C_chrg_nb: none
 
 
-def test_ct002_active_control_reports_count_one_per_phase():
+def test_ct002_active_control_reports_count_one_per_phase() -> None:
     """Active control distributes a per-consumer target, so *_chrg_nb stays 1."""
     device = CT002(active_control=True)
     request = CT002Request.from_fields(
@@ -206,7 +208,7 @@ def test_ct002_active_control_reports_count_one_per_phase():
     assert response[10] == "0"  # C_chrg_nb: inactive phase
 
 
-def test_ct002_excludes_non_participating_from_aggregation():
+def test_ct002_excludes_non_participating_from_aggregation() -> None:
     """A consumer that sent participate=0 is left out of the relay aggregates."""
     device = CT002(active_control=False)
     request = CT002Request.from_fields(
@@ -229,7 +231,7 @@ def test_ct002_excludes_non_participating_from_aggregation():
     assert response[15] == "-180"  # A_chrg_power excludes the opted-out -120
 
 
-async def test_ct002_handle_request_respects_participate_field():
+async def test_ct002_handle_request_respects_participate_field() -> None:
     """The optional 7th request field marks a consumer non-participating."""
     transport = MagicMock()
 
@@ -257,7 +259,7 @@ async def test_ct002_handle_request_respects_participate_field():
     assert next(iter(default._consumers.values())).participates is True
 
 
-def test_ct002_splits_positive_instructions_into_dchrg_fields():
+def test_ct002_splits_positive_instructions_into_dchrg_fields() -> None:
     device = CT002()
     request = CT002Request.from_fields(
         ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "B", "100"]
@@ -280,7 +282,7 @@ def test_ct002_splits_positive_instructions_into_dchrg_fields():
     assert response[9] == "1"  # B_chrg_nb
 
 
-def test_ct002_splits_mixed_sign_instructions_per_storage_before_aggregation():
+def test_ct002_splits_mixed_sign_instructions_per_storage_before_aggregation() -> None:
     device = CT002()
     request = CT002Request.from_fields(
         ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "A", "0"]
@@ -301,7 +303,7 @@ def test_ct002_splits_mixed_sign_instructions_per_storage_before_aggregation():
     assert response[8] == "1"  # A_chrg_nb active flag
 
 
-def test_ct002_pv_passthrough_does_not_appear_as_dchrg():
+def test_ct002_pv_passthrough_does_not_appear_as_dchrg() -> None:
     """Regression for #376: positive *report* but negative *net instruction*
     must not populate *_dchrg_power (otherwise other batteries idle)."""
     device = CT002()
@@ -324,7 +326,7 @@ def test_ct002_pv_passthrough_does_not_appear_as_dchrg():
     assert response[15] == "-500"  # A_chrg_power reflects the net instruction
 
 
-def test_ct002_discharging_battery_with_small_correction_keeps_dchrg_signal():
+def test_ct002_discharging_battery_with_small_correction_keeps_dchrg_signal() -> None:
     """Net-power semantics: a battery discharging at +500 W that we just
     corrected down by 100 must still register as discharging (+400 W),
     not flip into the charge bucket on the strength of the delta alone."""
@@ -370,7 +372,7 @@ async def _drive_request(
     await device._handle_request(request, ("1.1.1.1", 12345), transport)
 
 
-async def test_handle_request_records_net_instructed_power_not_delta():
+async def test_handle_request_records_net_instructed_power_not_delta() -> None:
     """Regression for the delta-vs-net mistake.
 
     Venus discharging at +500 W, we correct down by 100 W.  The simulator
@@ -391,7 +393,7 @@ async def test_handle_request_records_net_instructed_power_not_delta():
     )
 
 
-async def test_combined_mode_records_net_from_summed_grid_field():
+async def test_combined_mode_records_net_from_summed_grid_field() -> None:
     """A combined-mode (phase 'D') battery reads the *summed* grid field
     (field 7), so its net instructed power is the reported output plus the
     whole target — not just the phase-A slot.  Feeding a target spread across
@@ -408,7 +410,7 @@ async def test_combined_mode_records_net_from_summed_grid_field():
     assert consumer.last_instructed_power == 800.0
 
 
-async def test_event_listener_fires_for_combined_mode_not_inspection():
+async def test_event_listener_fires_for_combined_mode_not_inspection() -> None:
     """HA discovery/state is driven by the consumer event listener, which must
     fire for a combined-mode ('D') battery — a valid, steered phase — but stay
     silent for a true inspection ('0') poll (still discovering its phase)."""
@@ -423,7 +425,7 @@ async def test_event_listener_fires_for_combined_mode_not_inspection():
     assert "bbccddeeffaa" not in fired  # inspection → suppressed
 
 
-async def test_handle_request_pv_passthrough_net_target_and_relay_buckets():
+async def test_handle_request_pv_passthrough_net_target_and_relay_buckets() -> None:
     """Venus scenario from issue #376 driven in relay mode: reports +500
     (passthrough), the relayed grid delta is -500 → the *expected* net target
     is 0 (``last_instructed_power``).  But relay buckets must forward the
@@ -445,7 +447,7 @@ async def test_handle_request_pv_passthrough_net_target_and_relay_buckets():
     assert by_phase["A"].chrg_power == 0
 
 
-async def test_relay_buckets_aggregate_reported_power_not_reported_plus_grid():
+async def test_relay_buckets_aggregate_reported_power_not_reported_plus_grid() -> None:
     """Issue #457: relay-mode buckets must equal the per-phase sum of
     *reported* battery powers, not reported+grid (the battery's *next*
     expected net), matching real CT captures."""
@@ -472,7 +474,7 @@ async def test_relay_buckets_aggregate_reported_power_not_reported_plus_grid():
     assert response[15] == "-100"  # A_chrg_power
 
 
-async def test_handle_request_skips_instruction_update_in_inspection_mode():
+async def test_handle_request_skips_instruction_update_in_inspection_mode() -> None:
     """No instruction is being given in inspection mode — we send raw
     meter readings as information so the battery can identify its phase,
     and the battery runs its phase-discovery routine rather than our
@@ -533,11 +535,11 @@ async def _seed_good_reading(device: CT002, battery_mac: str) -> None:
     await _drive_and_capture(device, battery_mac, "A", 0, before_send=good)
 
 
-async def _raise_stale(_addr, _request, _consumer_id):
+async def _raise_stale(_addr, _request, _consumer_id) -> None:
     raise ValueError("powermeter unavailable (test)")
 
 
-async def test_handle_request_holds_with_zero_delta_when_before_send_fails():
+async def test_handle_request_holds_with_zero_delta_when_before_send_fails() -> None:
     """Issue #403: when the powermeter is unavailable (before_send raises),
     the response must be a zero adjustment so the battery holds — not a delta
     re-derived from the stale cached reading (which would wind it up)."""
@@ -561,7 +563,7 @@ async def test_handle_request_holds_with_zero_delta_when_before_send_fails():
     assert device._consumers["aabbccddeeff"].last_instructed_power == 250.0
 
 
-async def test_handle_request_inspection_mode_holds_when_before_send_fails():
+async def test_handle_request_inspection_mode_holds_when_before_send_fails() -> None:
     """A phase self-diagnosis poll (inspection marker) while the meter is down
     must not be fed the frozen per-phase reading — feeding stale data is what
     corrupts the Venus phase detection in #403."""
@@ -575,7 +577,7 @@ async def test_handle_request_inspection_mode_holds_when_before_send_fails():
     assert fields[4:7] == ["0", "0", "0"], fields[4:7]
 
 
-async def test_handle_request_uses_cache_when_before_send_returns_none():
+async def test_handle_request_uses_cache_when_before_send_returns_none() -> None:
     """A before_send returning None (e.g. no powermeter matches this client)
     is NOT a failure: the cached reading is still served. Guards that the hold
     path keys on the raised exception, not on a None return."""
@@ -594,7 +596,7 @@ async def test_handle_request_uses_cache_when_before_send_returns_none():
     assert fields[4] == "500", fields[4]
 
 
-def test_ct002_info_idx_increments_and_wraps():
+def test_ct002_info_idx_increments_and_wraps() -> None:
     device = CT002()
     request = CT002Request.from_fields(
         ["HMG-50", "AABBCCDDEEFF", "HME-4", "112233445566", "A", "0"]
@@ -614,7 +616,9 @@ def test_ct002_info_idx_increments_and_wraps():
     assert after_wrap[13] == "0"
 
 
-def test_ct002_logs_phase_detection_and_change(caplog):
+def test_ct002_logs_phase_detection_and_change(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     device = CT002()
 
     with caplog.at_level(logging.INFO):
@@ -631,7 +635,7 @@ def test_ct002_logs_phase_detection_and_change(caplog):
 # ── x / ABC bucket routing (issue #460) ─────────────────────────────────────
 
 
-async def test_inspection_reporter_counts_in_x_bucket_not_a():
+async def test_inspection_reporter_counts_in_x_bucket_not_a() -> None:
     """An inspection ('0') reporter must populate the x bucket — not inflate
     phase A's count/aggregate (which would skew the relay share split)."""
     device = CT002(ct_mac="112233445566", active_control=False)
@@ -660,7 +664,7 @@ async def test_inspection_reporter_counts_in_x_bucket_not_a():
     assert response[15] == "0"  # A_chrg_power
 
 
-async def test_combined_phase_d_reporter_lands_in_abc_bucket():
+async def test_combined_phase_d_reporter_lands_in_abc_bucket() -> None:
     """A combined-mode (phase 'D') reporter must populate the ABC bucket and
     ABC_chrg_nb instead of being folded into phase A."""
     device = CT002(ct_mac="112233445566", active_control=False)
@@ -688,7 +692,7 @@ async def test_combined_phase_d_reporter_lands_in_abc_bucket():
     assert response[8] == "0"  # A_chrg_nb
 
 
-def test_active_control_abc_bucket_uses_instructed_power():
+def test_active_control_abc_bucket_uses_instructed_power() -> None:
     """Under active control a combined-mode (phase 'D') battery is steered like
     any A/B/C battery, so its ABC bucket aggregates the *instructed* net power
     (issue #376), not the raw reported passthrough.  A true inspection ('0')
@@ -711,7 +715,7 @@ def test_active_control_abc_bucket_uses_instructed_power():
     assert by_phase["x"].chrg_power == -200  # reported (never instructed)
 
 
-def test_active_control_combined_mode_response_reports_count_one():
+def test_active_control_combined_mode_response_reports_count_one() -> None:
     """Under active control the ABC (combined 'D') count field must be 1 so a
     combined battery applies its individual target as-is instead of dividing by
     N — mirroring the per-phase active-control count (issue #459)."""
@@ -728,7 +732,7 @@ def test_active_control_combined_mode_response_reports_count_one():
     assert response[18] == "-400"  # ABC_chrg_power = instructed net
 
 
-def test_relay_mode_combined_count_is_real_battery_count():
+def test_relay_mode_combined_count_is_real_battery_count() -> None:
     """Relay mode forwards the real combined-battery count so each battery takes
     its 1/N share — the contrast with active control's count of 1."""
     device = CT002(active_control=False)
@@ -743,7 +747,9 @@ def test_relay_mode_combined_count_is_real_battery_count():
     assert response[11] == "2"  # ABC count = real battery count in relay mode
 
 
-def test_ct002_logs_phase_detection_for_combined_mode(caplog):
+def test_ct002_logs_phase_detection_for_combined_mode(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     device = CT002()
 
     with caplog.at_level(logging.INFO):
@@ -771,7 +777,7 @@ class _StepClock:
         self.now += seconds
 
 
-def test_adaptive_ttl_evicts_after_two_missed_poll_cycles():
+def test_adaptive_ttl_evicts_after_two_missed_poll_cycles() -> None:
     """Default (consumer_ttl=None): a consumer expires after missing ~2 of
     its own poll cycles, like the real CT."""
     clock = _StepClock()
@@ -790,7 +796,7 @@ def test_adaptive_ttl_evicts_after_two_missed_poll_cycles():
     assert "a" not in device._consumers
 
 
-def test_adaptive_ttl_uses_fallback_while_cadence_unknown():
+def test_adaptive_ttl_uses_fallback_while_cadence_unknown() -> None:
     """A consumer that has polled only once has no cadence yet; it survives
     the fallback window and is evicted after it."""
     clock = _StepClock()
@@ -806,7 +812,7 @@ def test_adaptive_ttl_uses_fallback_while_cadence_unknown():
     assert "a" not in device._consumers
 
 
-def test_adaptive_ttl_floor_protects_fast_pollers():
+def test_adaptive_ttl_floor_protects_fast_pollers() -> None:
     """A battery polling every second isn't evicted by a 2-3 s hiccup: the
     adaptive TTL is floored (network-jitter tolerance)."""
     clock = _StepClock()
@@ -824,7 +830,7 @@ def test_adaptive_ttl_floor_protects_fast_pollers():
     assert "a" not in device._consumers
 
 
-def test_fixed_consumer_ttl_overrides_adaptive_eviction():
+def test_fixed_consumer_ttl_overrides_adaptive_eviction() -> None:
     """An explicit CONSUMER_TTL keeps the old fixed-window behavior."""
     clock = _StepClock()
     device = CT002(consumer_ttl=120, clock=clock)
@@ -841,7 +847,7 @@ def test_fixed_consumer_ttl_overrides_adaptive_eviction():
     assert "a" not in device._consumers
 
 
-def test_stale_consumer_drops_out_of_aggregation_before_cleanup_runs():
+def test_stale_consumer_drops_out_of_aggregation_before_cleanup_runs() -> None:
     """The real CT evicts per response cycle, so the relay count/aggregate
     must shrink as soon as a battery goes silent — without waiting for the
     periodic cleanup task to remove the entry."""

--- a/tests/test_ct002_protocol_parity.py
+++ b/tests/test_ct002_protocol_parity.py
@@ -36,7 +36,7 @@ def _load_vectors():
     _load_vectors(),
     ids=[v["description"][:60] for v in _load_vectors()],
 )
-def test_build_payload_matches_canonical_wire(vec):
+def test_build_payload_matches_canonical_wire(vec) -> None:
     expected = bytes.fromhex(vec["wire_hex"])
     actual = bytes(build_payload(vec["fields"]))
     assert actual == expected, (
@@ -50,14 +50,14 @@ def test_build_payload_matches_canonical_wire(vec):
     _load_vectors(),
     ids=[v["description"][:60] for v in _load_vectors()],
 )
-def test_parse_request_round_trips(vec):
+def test_parse_request_round_trips(vec) -> None:
     wire = bytes.fromhex(vec["wire_hex"])
     fields, error = parse_request(wire)
     assert error is None, f"parse_request rejected canonical bytes: {error}"
     assert fields == vec["fields"]
 
 
-def test_parse_request_tolerates_checksum_space_high_nibble():
+def test_parse_request_tolerates_checksum_space_high_nibble() -> None:
     # Find the vector that exercises this decode-only mutation.
     vectors = [v for v in _load_vectors() if "decode_only_mutations" in v]
     assert vectors, "Expected at least one vector flagged for space-tolerance"

--- a/tests/test_ct_settings_wiring.py
+++ b/tests/test_ct_settings_wiring.py
@@ -117,14 +117,14 @@ def distinct_settings() -> CtSettings:
     return replace(CtSettings(), **values)
 
 
-def test_destination_map_covers_every_ct_setting():
+def test_destination_map_covers_every_ct_setting() -> None:
     """A new CT setting must declare where it lands before this test passes."""
     covered = set(DESTINATIONS) | set(NOT_ON_THE_EMULATOR)
     declared = {field.name for field in fields(CtSettings)}
     assert covered == declared
 
 
-def test_every_ct_setting_reaches_its_destination():
+def test_every_ct_setting_reaches_its_destination() -> None:
     ct = distinct_settings()
     ct002 = _build_ct002(ct, "HME-4", "device-1", ct.debug_status, None)
 
@@ -136,20 +136,20 @@ def test_every_ct_setting_reaches_its_destination():
     assert not mismatches, f"settings that did not arrive: {mismatches}"
 
 
-def test_ct_type_and_device_id_are_passed_through():
+def test_ct_type_and_device_id_are_passed_through() -> None:
     ct002 = _build_ct002(CtSettings(), "HME-3", "device-9", False, None)
     assert ct002.ct_type == "HME-3"
     assert ct002._device_id == "device-9"
 
 
-def test_debug_status_is_passed_separately_from_the_setting():
+def test_debug_status_is_passed_separately_from_the_setting() -> None:
     """The DEBUG_STATUS env escape hatch can turn it on for either backend."""
     ct002 = _build_ct002(CtSettings(debug_status=False), "HME-4", "dev", True, None)
     assert ct002.debug_status is True
 
 
 @pytest.mark.parametrize("name", boolean_fields())
-def test_each_boolean_setting_reaches_only_its_own_destination(name):
+def test_each_boolean_setting_reaches_only_its_own_destination(name) -> None:
     """Flags cannot be told apart by value, so flip exactly one at a time.
 
     Two swapped flags with the same default would survive the sweep above;

--- a/tests/test_e2e_probe_lockup.py
+++ b/tests/test_e2e_probe_lockup.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import contextlib
 import socket
+from collections.abc import Iterator
 
 import _ct002_e2e_backend as be
 import pytest
@@ -41,7 +42,7 @@ pytestmark = pytest.mark.esphome_e2e
 # stale-meter (``before_send``) and harness-lifecycle tests are Python-only
 # and skip on esphome (see the per-test guards).
 @pytest.fixture(params=["python", "esphome"], autouse=True)
-def _emulator_backend(request):
+def _emulator_backend(request: pytest.FixtureRequest) -> Iterator[None]:
     if request.param == "esphome" and not be.have_esphome():
         pytest.skip("esphome CLI not on PATH; install with `uv tool install esphome`")
     be.ACTIVE_BACKEND = request.param
@@ -464,7 +465,7 @@ class TestProbeLockup:
 
     async def test_powermeter_stale_error_is_handled_gracefully(
         self,
-        caplog,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """The fixed path: when the powermeter proactively raises
         ``ValueError`` on detected staleness (as the HomeWizard /

--- a/tests/test_efficiency_e2e.py
+++ b/tests/test_efficiency_e2e.py
@@ -13,6 +13,9 @@ probe deadlines) is fully reproducible.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from typing import Any
+
 import _ct002_e2e_backend as be
 import pytest
 from _ct002_e2e_backend import (
@@ -35,7 +38,7 @@ pytestmark = pytest.mark.esphome_e2e
 # Every test runs once per emulator backend. The python backend always runs;
 # esphome skips without the CLI. See tests/_ct002_e2e_backend.py.
 @pytest.fixture(params=["python", "esphome"], autouse=True)
-def _emulator_backend(request):
+def _emulator_backend(request: pytest.FixtureRequest) -> Iterator[None]:
     if request.param == "esphome" and not be.have_esphome():
         pytest.skip("esphome CLI not on PATH; install with `uv tool install esphome`")
     be.ACTIVE_BACKEND = request.param
@@ -70,8 +73,8 @@ class _SimHarness:
         startup_delays: list[float] | None = None,
         min_power_threshold: float = 5.0,
         min_power_thresholds: list[float] | None = None,
-        **ct_kwargs,
-    ):
+        **ct_kwargs: Any,
+    ) -> None:
         self.backend = be.ACTIVE_BACKEND
         self._esphome = EsphomeSim() if self.backend == "esphome" else None
         free_udp, http_port = find_free_ports(2)
@@ -176,7 +179,7 @@ class _SimHarness:
 
         self._scheduler = PollScheduler(self.batteries, self.clock, self._step_battery)
 
-    async def start(self):
+    async def start(self) -> None:
         await self.powermeter.start()
         if self.backend == "python":
             await self.ct002.start()
@@ -187,7 +190,7 @@ class _SimHarness:
                 self._esphome.set_cfg(key, val)
             self._esphome.set_clock(self.clock())
 
-    async def stop(self):
+    async def stop(self) -> None:
         if self.backend == "python":
             await self.ct002.stop()
         else:
@@ -258,7 +261,7 @@ class _SimHarness:
 class TestEfficiencyE2E:
     """End-to-end tests for efficiency optimization with simulated batteries."""
 
-    async def test_low_demand_concentrates_power(self):
+    async def test_low_demand_concentrates_power(self) -> None:
         """At 200W with 2 batteries and threshold=150, only 1 battery should be active."""
         h = _SimHarness(
             num_batteries=2,
@@ -277,7 +280,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_high_demand_uses_all_batteries(self):
+    async def test_high_demand_uses_all_batteries(self) -> None:
         """At 600W with 2 batteries and threshold=150, both should be active."""
         h = _SimHarness(
             num_batteries=2,
@@ -290,7 +293,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_demand_increase_activates_second_battery(self):
+    async def test_demand_increase_activates_second_battery(self) -> None:
         """When demand rises from low to high, second battery activates."""
         h = _SimHarness(
             num_batteries=2,
@@ -308,7 +311,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_disabled_feature_uses_all_batteries(self):
+    async def test_disabled_feature_uses_all_batteries(self) -> None:
         """With min_efficient_power=0 (default), both batteries share load equally."""
         h = _SimHarness(
             num_batteries=2,
@@ -321,7 +324,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_priority_rotation_switches_active_battery(self):
+    async def test_priority_rotation_switches_active_battery(self) -> None:
         """After rotation interval, the other battery joins via probe."""
         h = _SimHarness(
             num_batteries=2,
@@ -360,7 +363,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_probe_keeps_grid_near_zero_during_slow_rotation(self):
+    async def test_probe_keeps_grid_near_zero_during_slow_rotation(self) -> None:
         """During a slow probe, the previous battery keeps covering demand."""
         h = _SimHarness(
             num_batteries=2,
@@ -415,7 +418,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_probe_handles_mixed_poll_intervals(self):
+    async def test_probe_handles_mixed_poll_intervals(self) -> None:
         """Residual backup coverage tolerates probe lag from slower polling."""
         h = _SimHarness(
             num_batteries=2,
@@ -513,7 +516,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_probe_acceptance_avoids_large_export_spike(self):
+    async def test_probe_acceptance_avoids_large_export_spike(self) -> None:
         """Successful probe handoff should not temporarily double total output."""
         h = _SimHarness(
             num_batteries=2,
@@ -578,7 +581,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_probe_respects_80w_inverter_floor(self):
+    async def test_probe_respects_80w_inverter_floor(self) -> None:
         """Probe should use a meaningful command when batteries ignore tiny targets."""
         h = _SimHarness(
             num_batteries=2,
@@ -619,7 +622,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_probe_rejection_keeps_backup_covering_demand(self):
+    async def test_probe_rejection_keeps_backup_covering_demand(self) -> None:
         """Rejected probe should not create a noticeable demand gap."""
         h = _SimHarness(
             num_batteries=2,
@@ -665,7 +668,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_grid_converges_near_zero(self):
+    async def test_grid_converges_near_zero(self) -> None:
         """With efficiency optimization, grid import/export should converge near zero."""
         h = _SimHarness(
             num_batteries=2,
@@ -685,7 +688,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_three_batteries_partial_activation(self):
+    async def test_three_batteries_partial_activation(self) -> None:
         """With 3 batteries and 350W demand (threshold=150), 2 should be active."""
         h = _SimHarness(
             num_batteries=3,
@@ -698,7 +701,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_smooth_transition_no_overshoot(self):
+    async def test_smooth_transition_no_overshoot(self) -> None:
         """During demand increase, no single battery should overshoot excessively."""
         h = _SimHarness(
             num_batteries=2,
@@ -736,7 +739,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_saturated_battery_triggers_rotation(self):
+    async def test_saturated_battery_triggers_rotation(self) -> None:
         """When the active battery is saturated, it gets swapped out quickly."""
         h = _SimHarness(
             num_batteries=2,
@@ -765,7 +768,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_initially_empty_battery_swaps_without_timed_rotation(self):
+    async def test_initially_empty_battery_swaps_without_timed_rotation(self) -> None:
         """An empty prioritized battery should be swapped out before timed rotation."""
         h = _SimHarness(
             num_batteries=2,
@@ -793,7 +796,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_saturation_recovery_after_swap(self):
+    async def test_saturation_recovery_after_swap(self) -> None:
         """After forced swap, original battery recovers when constraint is lifted."""
         h = _SimHarness(
             num_batteries=2,
@@ -843,7 +846,7 @@ class TestEfficiencyE2E:
         finally:
             await h.stop()
 
-    async def test_load_sign_reversal_does_not_cause_false_saturation(self):
+    async def test_load_sign_reversal_does_not_cause_false_saturation(self) -> None:
         """When load flips sign (discharge->charge), active battery must not
         be falsely detected as saturated while it ramps to the new direction.
 

--- a/tests/test_issue376_pv_passthrough.py
+++ b/tests/test_issue376_pv_passthrough.py
@@ -37,7 +37,7 @@ pytestmark = pytest.mark.esphome_e2e
 
 
 @pytest.fixture(params=["python", "esphome"], autouse=True)
-def _emulator_backend(request):
+def _emulator_backend(request: pytest.FixtureRequest):
     if request.param == "esphome" and not be.have_esphome():
         pytest.skip("esphome CLI not on PATH; install with `uv tool install esphome`")
     be.ACTIVE_BACKEND = request.param

--- a/tests/test_main_config.py
+++ b/tests/test_main_config.py
@@ -1,4 +1,7 @@
 import argparse
+from pathlib import Path
+
+import pytest
 
 from astrameter import main as main_module
 from astrameter.config.addon import AddonAppConfig
@@ -10,7 +13,7 @@ class NoSupervisor:
 
     base_url = "http://supervisor"
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.lookups = 0
 
     def mqtt_service(self):
@@ -22,7 +25,7 @@ class NoSupervisor:
         return ""
 
 
-def test_marstek_password_with_percent_is_read_verbatim(tmp_path):
+def test_marstek_password_with_percent_is_read_verbatim(tmp_path: Path) -> None:
     """No interpolation: a literal '%' in a credential survives."""
     path = tmp_path / "config.ini"
     path.write_text(
@@ -37,7 +40,7 @@ def test_marstek_password_with_percent_is_read_verbatim(tmp_path):
     assert marstek.password == "abc%def/123"
 
 
-def test_load_config_reads_the_config_file_by_default(tmp_path):
+def test_load_config_reads_the_config_file_by_default(tmp_path: Path) -> None:
     path = tmp_path / "config.ini"
     path.write_text("[GENERAL]\nDEVICE_TYPE = ct002\n", encoding="utf-8")
 
@@ -50,7 +53,7 @@ def test_load_config_reads_the_config_file_by_default(tmp_path):
     assert config.path == str(path)
 
 
-def test_load_config_takes_the_addon_options(monkeypatch):
+def test_load_config_takes_the_addon_options(monkeypatch: pytest.MonkeyPatch) -> None:
     """--addon skips the file entirely: the add-on options are the config."""
     monkeypatch.setattr(
         main_module.addon, "SupervisorClient", lambda *a, **k: NoSupervisor()
@@ -68,7 +71,9 @@ def test_load_config_takes_the_addon_options(monkeypatch):
     assert config.path is None
 
 
-def test_load_config_rereads_the_addon_options_on_restart(monkeypatch):
+def test_load_config_rereads_the_addon_options_on_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A restart re-reads the options, picking up changes made meanwhile."""
     monkeypatch.setattr(
         main_module.addon, "SupervisorClient", lambda *a, **k: NoSupervisor()
@@ -83,7 +88,9 @@ def test_load_config_rereads_the_addon_options_on_restart(monkeypatch):
     assert config.general().device_types == ["ct003"]
 
 
-def test_load_config_resolves_the_supervisor_lookups_up_front(monkeypatch):
+def test_load_config_resolves_the_supervisor_lookups_up_front(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Both startup and the restart branch load through here, so the blocking
     Supervisor lookups can never be left to the running event loop."""
     supervisor = NoSupervisor()
@@ -101,7 +108,7 @@ def test_load_config_resolves_the_supervisor_lookups_up_front(monkeypatch):
     assert supervisor.lookups == 2
 
 
-def test_cli_throttle_override_reaches_the_power_sources(tmp_path):
+def test_cli_throttle_override_reaches_the_power_sources(tmp_path: Path) -> None:
     path = tmp_path / "config.ini"
     path.write_text("[GENERAL]\nTHROTTLE_INTERVAL = 1\n", encoding="utf-8")
     config = IniAppConfig.from_file(str(path))

--- a/tests/test_marstek_api.py
+++ b/tests/test_marstek_api.py
@@ -11,12 +11,12 @@ from astrameter.marstek_api import (
 )
 
 
-def test_desired_type_mapping():
+def test_desired_type_mapping() -> None:
     assert _desired_type("ct002") == "HME-4"
     assert _desired_type("ct003") == "HME-3"
 
 
-def test_find_existing_managed_device_matches_prefix_and_type():
+def test_find_existing_managed_device_matches_prefix_and_type() -> None:
     devices = [
         {"devid": "02b250aaaaaa", "mac": "02b250aaaaaa", "type": "HME-4"},
         {"devid": "ffffffffffff", "mac": "ffffffffffff", "type": "HME-3"},
@@ -27,7 +27,7 @@ def test_find_existing_managed_device_matches_prefix_and_type():
     assert found["devid"] == "02b250aaaaaa"
 
 
-def test_find_existing_managed_device_ignores_wrong_type():
+def test_find_existing_managed_device_ignores_wrong_type() -> None:
     devices = [
         {"devid": "02b250aaaaaa", "mac": "02b250aaaaaa", "type": "HME-3"},
     ]
@@ -36,7 +36,7 @@ def test_find_existing_managed_device_ignores_wrong_type():
     assert found is None
 
 
-def test_generate_new_id_uses_prefix_and_avoids_collisions():
+def test_generate_new_id_uses_prefix_and_avoids_collisions() -> None:
     devices = [
         {"devid": "02b250aaaaaa", "mac": "02b250aaaaaa"},
         {"devid": "02b250bbbbbb", "mac": "02b250bbbbbb"},
@@ -48,9 +48,9 @@ def test_generate_new_id_uses_prefix_and_avoids_collisions():
     assert new_id not in {"02b250aaaaaa", "02b250bbbbbb"}
 
 
-def test_translate_marstek_message_password_error_chinese():
+def test_translate_marstek_message_password_error_chinese() -> None:
     assert _translate_marstek_message("4", "密码错误") == "password incorrect"
 
 
-def test_translate_marstek_message_passthrough_unknown():
+def test_translate_marstek_message_passthrough_unknown() -> None:
     assert _translate_marstek_message("999", "some backend text") == "some backend text"

--- a/tests/test_steering_eval.py
+++ b/tests/test_steering_eval.py
@@ -69,14 +69,14 @@ def _one_battery_scenario(spec: BatterySpec, duration_s: float) -> Scenario:
     )
 
 
-def test_grid_cost_asymmetric_tariff():
+def test_grid_cost_asymmetric_tariff() -> None:
     # 1 kWh imported costs the retail tariff; 1 kWh exported earns the (lower)
     # feed-in tariff as a credit (negative cost).
     assert _grid_cost_ct(1000.0, 0.0) == pytest.approx(RETAIL_CT_PER_KWH)
     assert _grid_cost_ct(0.0, 1000.0) == pytest.approx(-FEEDIN_CT_PER_KWH)
 
 
-def test_oracle_zero_cost_when_battery_covers_load():
+def test_oracle_zero_cost_when_battery_covers_load() -> None:
     # A steady 500 W deficit for an hour against a battery with ample energy and
     # power: the perfect-foresight battery supplies all of it, so the optimal
     # grid exchange — and its cost — is zero.
@@ -87,7 +87,7 @@ def test_oracle_zero_cost_when_battery_covers_load():
     assert cost == pytest.approx(0.0, abs=1e-6)
 
 
-def test_oracle_floor_when_battery_too_small():
+def test_oracle_floor_when_battery_too_small() -> None:
     # Only 100 Wh of stored energy but the load asks 500 W for an hour (500 Wh).
     # The oracle supplies its 100 Wh and the remaining ~400 Wh must import — a
     # physically irreducible floor no controller can beat.
@@ -100,7 +100,7 @@ def test_oracle_floor_when_battery_too_small():
     assert cost == pytest.approx(RETAIL_CT_PER_KWH * 400.0 / 1000.0, rel=0.02)
 
 
-def test_oracle_credits_dc_input_solar():
+def test_oracle_credits_dc_input_solar() -> None:
     # 500 W deficit for an hour, the battery starts EMPTY but receives 500 W of
     # solar straight into its DC side (B2500-style). A DC-blind oracle would
     # import the whole 500 Wh; the DC-aware oracle passes the solar through to
@@ -150,7 +150,7 @@ def _tiny_scenario() -> Scenario:
     )
 
 
-def test_run_scenario_produces_metrics():
+def test_run_scenario_produces_metrics() -> None:
     res = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
     assert res["scenario"] == "tiny"
     assert res["samples"] > 200
@@ -180,13 +180,13 @@ def test_run_scenario_produces_metrics():
     assert res["settle_mean_s"] < res["duration_h"] * 3600
 
 
-def test_run_scenario_is_deterministic():
+def test_run_scenario_is_deterministic() -> None:
     a = asyncio.run(run_scenario(_tiny_scenario(), seed=7))
     b = asyncio.run(run_scenario(_tiny_scenario(), seed=7))
     assert a == b
 
 
-def test_overrides_reach_the_balancer():
+def test_overrides_reach_the_balancer() -> None:
     # An absurd deadband makes the balance-correction path inert; the run
     # must still complete and produce metrics (knob plumbed through CT002).
     res = asyncio.run(
@@ -195,7 +195,7 @@ def test_overrides_reach_the_balancer():
     assert res["samples"] > 200
 
 
-def test_scenario_registry_shape():
+def test_scenario_registry_shape() -> None:
     scenarios = build_scenarios()
     # Multi-battery scenarios exist in both balancer modes.
     assert "two_venus/fair" in scenarios
@@ -273,7 +273,7 @@ def test_scenario_registry_shape():
         assert sc.duration_s > 0 and sc.batteries
 
 
-def test_markdown_compare_renders():
+def test_markdown_compare_renders() -> None:
     res = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
     base = dict(res, overshoot_max_w=res["overshoot_max_w"] + 100.0)
     md = render_markdown_compare([base], [res])
@@ -296,7 +296,7 @@ def test_markdown_compare_renders():
     assert "steering-eval-report.html" in md_with_report
 
 
-def test_compare_tolerates_base_missing_a_new_metric():
+def test_compare_tolerates_base_missing_a_new_metric() -> None:
     """A base produced before a metric existed (this PR adds grid_p2p_w) must
     not break the comparison — CI runs base (old code) vs head (new code), so
     the base rows lack newly added keys. Both renderers must degrade to '—'."""
@@ -309,7 +309,7 @@ def test_compare_tolerates_base_missing_a_new_metric():
     assert "grid_p2p_w" in h
 
 
-def test_html_report_is_self_contained_and_interactive():
+def test_html_report_is_self_contained_and_interactive() -> None:
     res = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
     base = dict(res, overshoot_max_w=res["overshoot_max_w"] + 100.0)
     h = render_html_report([base], [res])
@@ -330,7 +330,7 @@ def test_html_report_is_self_contained_and_interactive():
     assert 'class="better"' in h or 'class="worse"' in h
 
 
-def test_html_report_escapes_script_breakout_in_chart_data():
+def test_html_report_escapes_script_breakout_in_chart_data() -> None:
     res = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
     # A label that would close the inline <script> if embedded verbatim.
     res = dict(res, battery_labels=["</script><b>x"])
@@ -341,7 +341,7 @@ def test_html_report_escapes_script_breakout_in_chart_data():
     assert "\\u003c/script>" in h
 
 
-def test_html_report_handles_missing_baseline():
+def test_html_report_handles_missing_baseline() -> None:
     res = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
     h = render_html_report(None, [res])
     # Head-only still renders the grid (head series) and per-battery charts.
@@ -349,13 +349,13 @@ def test_html_report_handles_missing_baseline():
     assert 'id="batt0"' in h
 
 
-def test_grid_trace_is_downsampled_to_fixed_length():
+def test_grid_trace_is_downsampled_to_fixed_length() -> None:
     res = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
     assert len(res["grid_trace"]) == GRAPH_POINTS
     assert all(isinstance(v, float) for v in res["grid_trace"])
 
 
-def test_battery_traces_one_per_battery_fixed_length():
+def test_battery_traces_one_per_battery_fixed_length() -> None:
     res = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
     # One label and one fixed-length downsampled trace per battery.
     assert res["battery_labels"] == ["B1 HMG-50"]
@@ -364,7 +364,7 @@ def test_battery_traces_one_per_battery_fixed_length():
     assert all(isinstance(v, float) for v in res["battery_traces"][0])
 
 
-def test_consumption_trace_matches_grid_plus_battery_output():
+def test_consumption_trace_matches_grid_plus_battery_output() -> None:
     res = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
     cons = res["consumption_trace"]
     assert len(cons) == GRAPH_POINTS
@@ -383,7 +383,7 @@ def _two_results() -> list[dict]:
     return [a, b]
 
 
-def test_aggregate_is_per_metric_mean_across_scenarios():
+def test_aggregate_is_per_metric_mean_across_scenarios() -> None:
     results = _two_results()
     agg = _aggregate(results)
     assert agg["scenario"] == "AGGREGATE"
@@ -395,7 +395,7 @@ def test_aggregate_is_per_metric_mean_across_scenarios():
         assert agg[key] == round(expected, _metric_ndp(key)), key
 
 
-def test_cost_keys_keep_two_decimals_through_aggregation():
+def test_cost_keys_keep_two_decimals_through_aggregation() -> None:
     # Regret clusters at fractions of a cent, so the aggregate/seed-merge must
     # keep 2 dp for *_ct keys (1 dp would quantize the guardrail's 5% test into
     # noise). A sub-0.1 ct mean must survive, not round to 0.0.
@@ -415,7 +415,7 @@ def test_cost_keys_keep_two_decimals_through_aggregation():
     assert _metric_ndp("grid_rms_w") == 1 and _metric_ndp("cost_regret_ct") == 2
 
 
-def test_aggregate_omits_metrics_absent_from_every_result():
+def test_aggregate_omits_metrics_absent_from_every_result() -> None:
     res = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
     old = {k: v for k, v in res.items() if k != "grid_p2p_w"}
     # A base produced before grid_p2p_w existed contributes no value for it, so
@@ -424,7 +424,7 @@ def test_aggregate_omits_metrics_absent_from_every_result():
     assert "grid_p2p_w" in _aggregate([res])
 
 
-def test_overall_summary_reports_direction():
+def test_overall_summary_reports_direction() -> None:
     base_agg = {"settle_mean_s": 10.0, "overshoot_max_w": 100.0}
     better = {"settle_mean_s": 8.0, "overshoot_max_w": 90.0}
     worse = {"settle_mean_s": 12.0, "overshoot_max_w": 110.0}
@@ -433,7 +433,7 @@ def test_overall_summary_reports_direction():
     assert "(worse)" in _overall_summary(base_agg, worse)
 
 
-def test_weighted_overall_import_outweighs_export():
+def test_weighted_overall_import_outweighs_export() -> None:
     # Same-sized relative move on import vs export: import is weighted ~4x, so
     # an import improvement must move the weighted score more than an equal
     # export improvement, and an import regression dominates an export gain.
@@ -448,13 +448,13 @@ def test_weighted_overall_import_outweighs_export():
     assert _weighted_overall(base, mixed) > 0
 
 
-def test_weighted_overall_none_when_nothing_comparable():
+def test_weighted_overall_none_when_nothing_comparable() -> None:
     assert _weighted_overall({}, {}) is None
     # A base metric of 0 has no defined relative change → excluded.
     assert _weighted_overall({"overshoot_max_w": 0.0}, {"overshoot_max_w": 5.0}) is None
 
 
-def test_guardrail_regression_is_flagged():
+def test_guardrail_regression_is_flagged() -> None:
     base = {"overshoot_max_w": 100.0, "band_crossings_per_h": 50.0, "grid_p2p_w": 40.0}
     # overshoot_max up 30% (past the 5% tolerance), the rest flat.
     head = {"overshoot_max_w": 130.0, "band_crossings_per_h": 50.0, "grid_p2p_w": 40.0}
@@ -466,7 +466,7 @@ def test_guardrail_regression_is_flagged():
     assert _guardrail_regressions(base, {**base, "overshoot_max_w": 103.0}) == []
 
 
-def test_guardrail_includes_import_not_export():
+def test_guardrail_includes_import_not_export() -> None:
     # Avoidable grid import is the retail-tariff money metric, free to fix
     # (discharge): a regression past the tolerance is a do-no-harm breach even
     # when the dynamics are flat.
@@ -485,7 +485,7 @@ def test_guardrail_includes_import_not_export():
     )
 
 
-def test_guardrail_flags_regression_from_zero_base():
+def test_guardrail_flags_regression_from_zero_base() -> None:
     # The worst do-no-harm breach: a metric going from nothing to something
     # (zero overshoot becoming a real sign flip, or a perfectly self-consuming
     # controller starting to import). A relative change against 0 is undefined,
@@ -502,14 +502,14 @@ def test_guardrail_flags_regression_from_zero_base():
     )
 
 
-def test_priority_summary_clean_when_no_guardrail_regresses():
+def test_priority_summary_clean_when_no_guardrail_regresses() -> None:
     base = {"avoidable_import_wh": 100.0, "overshoot_max_w": 100.0}
     head = {"avoidable_import_wh": 80.0, "overshoot_max_w": 80.0}
     summary = _priority_summary(base, head)
     assert "✅" in summary and "(better)" in summary
 
 
-def test_markdown_compare_leads_with_priority_verdict():
+def test_markdown_compare_leads_with_priority_verdict() -> None:
     results = _two_results()
     base = [dict(r, overshoot_max_w=r["overshoot_max_w"] + 50.0) for r in results]
     md = render_markdown_compare(base, results)
@@ -517,7 +517,7 @@ def test_markdown_compare_leads_with_priority_verdict():
     assert "priority-weighted" in md
 
 
-def test_overall_summary_denominator_counts_only_compared_metrics():
+def test_overall_summary_denominator_counts_only_compared_metrics() -> None:
     # Base carries only 2 of the reported metrics (e.g. an older base from
     # before others existed); the verdict's denominator must be the metrics
     # actually compared, not the full list.
@@ -526,7 +526,7 @@ def test_overall_summary_denominator_counts_only_compared_metrics():
     assert "across 2 metrics" in _overall_summary(base, head)
 
 
-def test_compare_aggregates_uses_only_shared_scenarios():
+def test_compare_aggregates_uses_only_shared_scenarios() -> None:
     def mk(name: str, settle: float) -> dict:
         return {"scenario": name, "seed": 1, "settle_mean_s": settle}
 
@@ -543,7 +543,7 @@ def test_compare_aggregates_uses_only_shared_scenarios():
     assert _compare_aggregates(None, head) == (None, _aggregate(head))
 
 
-def test_render_text_adds_aggregate_only_for_multiple_scenarios():
+def test_render_text_adds_aggregate_only_for_multiple_scenarios() -> None:
     multi = render_text(_two_results())
     assert "AGGREGATE (mean across 2 scenarios)" in multi
     # A single scenario would just echo its own numbers, so no aggregate.
@@ -551,7 +551,7 @@ def test_render_text_adds_aggregate_only_for_multiple_scenarios():
     assert "AGGREGATE" not in single
 
 
-def test_markdown_compare_leads_with_aggregate_rollup():
+def test_markdown_compare_leads_with_aggregate_rollup() -> None:
     results = _two_results()
     base = [dict(r, overshoot_max_w=r["overshoot_max_w"] + 50.0) for r in results]
     md = render_markdown_compare(base, results)
@@ -562,7 +562,7 @@ def test_markdown_compare_leads_with_aggregate_rollup():
     assert md.index("Aggregate — mean across") < md.index("<details>")
 
 
-def test_html_report_renders_aggregate_section():
+def test_html_report_renders_aggregate_section() -> None:
     results = _two_results()
     base = [dict(r, overshoot_max_w=r["overshoot_max_w"] + 50.0) for r in results]
     h = render_html_report(base, results)
@@ -570,7 +570,7 @@ def test_html_report_renders_aggregate_section():
     assert "improved" in h  # the one-line verdict is rendered
 
 
-def test_merge_seeds_averages_metrics_and_traces():
+def test_merge_seeds_averages_metrics_and_traces() -> None:
     r1 = {
         "scenario": "x",
         "seed": 1,
@@ -600,18 +600,18 @@ def test_merge_seeds_averages_metrics_and_traces():
     assert merged["battery_labels"] == ["B1 HMG-50"]
 
 
-def test_merge_seeds_single_seed_is_passthrough():
+def test_merge_seeds_single_seed_is_passthrough() -> None:
     r = {"scenario": "x", "seed": 1, "settle_mean_s": 10.0}
     # One seed: nothing to average, the original row (with its seed) is returned.
     assert _merge_seeds([r]) is r
 
 
-def test_seed_label_reads_single_or_averaged():
+def test_seed_label_reads_single_or_averaged() -> None:
     assert _seed_label({"seed": 3}) == "seed 3"
     assert _seed_label({"n_seeds": 4, "seeds": [1, 2, 3, 4]}) == "mean of 4 seeds"
 
 
-def test_markdown_compare_notes_seed_averaging():
+def test_markdown_compare_notes_seed_averaging() -> None:
     res = asyncio.run(run_scenario(_tiny_scenario(), seed=3))
     head = [dict(res, n_seeds=3, seeds=[1, 2, 3])]
     md = render_markdown_compare([res], head)
@@ -620,7 +620,7 @@ def test_markdown_compare_notes_seed_averaging():
     assert "mean of 3 seeds" in md
 
 
-def test_run_all_runs_seeds_in_parallel_and_merges():
+def test_run_all_runs_seeds_in_parallel_and_merges() -> None:
     # End-to-end through the process pool: one real (short) scenario over two
     # seeds collapses to a single seed-averaged row.
     results = _run_all(["single_venus_washer"], [1, 2], {})
@@ -633,7 +633,7 @@ def test_run_all_runs_seeds_in_parallel_and_merges():
         assert key in r
 
 
-def test_metric_glossary_covers_every_reported_metric():
+def test_metric_glossary_covers_every_reported_metric() -> None:
     glossary_keys = [key for key, _ in _METRIC_GLOSSARY]
     assert glossary_keys == _REPORT_METRICS
 
@@ -659,7 +659,7 @@ def test_metric_glossary_covers_every_reported_metric():
         "single_venus_pv",
     ],
 )
-def test_full_scenario_definitions_build(name):
+def test_full_scenario_definitions_build(name) -> None:
     import random
 
     sc = build_scenarios()[name]
@@ -667,7 +667,7 @@ def test_full_scenario_definitions_build(name):
     assert events and all(e.at >= 0 for e in events)
 
 
-def test_washer_scenario_reproduces_sustained_oscillation():
+def test_washer_scenario_reproduces_sustained_oscillation() -> None:
     """The washing-machine scenario (issue #473) reproduces the field signature:
     a drum-tumble rhythm over a latency-delayed meter, so the loop hunts
     continuously instead of holding zero. It is scored on the sustained-
@@ -685,7 +685,7 @@ def test_washer_scenario_reproduces_sustained_oscillation():
         assert res[key] >= 0, key
 
 
-def test_noisy_scenario_has_no_labeled_events_but_scores_aggregates():
+def test_noisy_scenario_has_no_labeled_events_but_scores_aggregates() -> None:
     """The pretty-noisy house baseline has no scripted load steps (so the
     step-response metrics read 0), and the loud baseline noise drives the loop:
     it is scored on the sustained-oscillation aggregates, all of which stay
@@ -701,7 +701,7 @@ def test_noisy_scenario_has_no_labeled_events_but_scores_aggregates():
         assert res[key] >= 0, key
 
 
-def test_trace_scenario_replays_real_load_and_scores_aggregates():
+def test_trace_scenario_replays_real_load_and_scores_aggregates() -> None:
     """The real-trace scenario drives the base load from a recorded household
     trace (no scripted load steps, so the step-response metrics read 0) and is
     scored on the sustained-oscillation/energy aggregates, all populated and
@@ -721,7 +721,7 @@ def test_trace_scenario_replays_real_load_and_scores_aggregates():
     assert res["consumption_trace"] != res2["consumption_trace"]
 
 
-def test_trace_eff_variant_concentrates_unlike_fair():
+def test_trace_eff_variant_concentrates_unlike_fair() -> None:
     """The two-Venus trace /eff variant raises min_efficient_power so efficiency
     optimization actually engages on a real load: during a calm stretch it
     concentrates onto one Venus and idles the second (which only cuts in on
@@ -750,7 +750,7 @@ def test_trace_eff_variant_concentrates_unlike_fair():
     assert min_battery_idle_fraction(eff) > 0.5
 
 
-def test_pv_net_load_scenario_charges_from_real_solar():
+def test_pv_net_load_scenario_charges_from_real_solar() -> None:
     """The real-PV net-load scenario drives PV + load together from a recorded
     Cyprus prosumer (partly-cloudy day). Net export charges the battery (SoC
     rises from its 0.4 start) and the loop tracks the real solar variability
@@ -767,7 +767,7 @@ def test_pv_net_load_scenario_charges_from_real_solar():
     assert min(res["battery_traces"][0]) < -20
 
 
-def test_phase_imbalance_nulls_each_phase_independently():
+def test_phase_imbalance_nulls_each_phase_independently() -> None:
     """With one Venus per phase and asymmetric per-phase loads, the active-
     control loop distributes a target to each unit so every phase is nulled —
     not just the aggregate. Each battery discharges to cover its own phase, and
@@ -783,7 +783,7 @@ def test_phase_imbalance_nulls_each_phase_independently():
     assert all(m > 100 for m in means)
 
 
-def test_soc_saturation_scenarios_hit_the_edges():
+def test_soc_saturation_scenarios_hit_the_edges() -> None:
     """The drain/fill scenarios actually push the pack into empty/full
     saturation, exercising the handoff to the grid. Once saturated the battery
     can't help, so the *avoidable* energy is a small fraction of the total grid
@@ -801,7 +801,7 @@ def test_soc_saturation_scenarios_hit_the_edges():
     assert fill["avoidable_export_wh"] < 0.3 * fill["export_wh"]
 
 
-def test_slow_meter_variant_tracks_worse_than_default():
+def test_slow_meter_variant_tracks_worse_than_default() -> None:
     """A slow meter (fresh reading only every ~10 s) makes the loop act on
     badly stale data, so it mistracks far more than the same scenario on the
     realistic ~1 s default meter. The slow variant exists to cover meters that
@@ -815,7 +815,7 @@ def test_slow_meter_variant_tracks_worse_than_default():
     assert slow["grid_p2p_w"] > 2 * fast["grid_p2p_w"]
 
 
-def test_meter_latency_drives_sustained_oscillation():
+def test_meter_latency_drives_sustained_oscillation() -> None:
     """Acting on a delayed meter reading turns a settling loop into one that
     hunts: the washing-machine scenario's grid swing (grid_p2p_w) is markedly
     larger with its meter latency than with the delay removed. This guards the
@@ -870,7 +870,7 @@ class TestRampPacingRegression:
             build_events=events,
         )
 
-    def test_paced_overshoot_bounded(self):
+    def test_paced_overshoot_bounded(self) -> None:
         # Isolate ramp pacing: disable the adaptive grid-state predictor (on by
         # default), which independently bounds the windup this test attributes
         # to pacing — leaving it on would make the unpaced run look bounded too.

--- a/tests/test_version_info.py
+++ b/tests/test_version_info.py
@@ -1,11 +1,13 @@
+import pytest
+
 import astrameter.version_info as version_info
 
 
-def test_get_git_commit_sha_empty(monkeypatch):
+def test_get_git_commit_sha_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GIT_COMMIT_SHA", raising=False)
     assert version_info.get_git_commit_sha() == ""
 
 
-def test_get_git_commit_sha_strips(monkeypatch):
+def test_get_git_commit_sha_strips(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GIT_COMMIT_SHA", "  abc123  ")
     assert version_info.get_git_commit_sha() == "abc123"


### PR DESCRIPTION
## Why

Several places had grown a private copy of something that already existed, or
carried plumbing that repeated once per route. Separately, a large share of the
codebase was unannotated — and mypy skips an unannotated function's body
entirely, so those parts were not being checked at all. Annotating them is what
turned up most of the defects below.

No behavior change is intended beyond the three noted at the end.

## Changes

### One error path for the web server (`0555d87`)

Each route carried its own copy of the plumbing: a `try` around
`request.json()`, a `(client, error)` tuple unpacked into `if error: return
error`, and a `str(exc)` translated to a status code at every call into
Supervisor. Handlers now raise `ApiError` and `_add()` turns it into the
response — the same place that already wrapped every `POST` in the
content-type guard. Twelve function-local imports move to the top of the file.

`web_guard`'s response helpers were private names imported from another module;
they are now `json_response` / `error_response` / `forbidden`.

### One WebSocket loop for the two meters that need it (`0555d87`)

Home Assistant and HomeWizard had each grown a connect / read / reconnect loop,
alike down to the close-frame tuple and the bare `sleep(5)`. Both inherit
`WebSocketPowermeter` (new `powermeter/ws_client.py`), which owns the session,
the reader task and the backoff; each subclass says only where to dial, what a
text frame means, and what to forget on a drop.

`WebSocket` there is a Protocol — the four members the read loop and handlers
actually use — so a test can drive them with canned frames.
`WebSocketConnect` is a separate alias for what `session.ws_connect()` returns.

### Shelly poll handler, and the meter it reads from (`6d4ddde`)

`Shelly._handle_request` was ~100 lines nested six deep, ending in a catch-all
that logged "Error processing message" for anything the identical catch-all one
frame up would have logged with the address. Decoding, meter selection and the
response shape are three small functions; the handler is guard clauses. Its
arguments were `(transport, data, addr)` while its own caller passed
`(data, addr, transport)` — both match CT002 now.

`Shelly` declared its sources as a positional `(meter, filter, flag)` triple, so
`main` cast a `list[ConfiguredPowermeter]` to reach it; it takes the named tuple.
Picking the source that answers a client and waiting out one push before reading
it was written twice, down to the same 2-second cap and the same log sentence —
both emulators call the new `meter_pool` for it.

### Duplicated helpers in the config loader (`6d4ddde`)

The Home Assistant factory had a private copy of `one_or_many`; the Shelly
factory a five-branch chain raising a bare `Exception`; the MQTT factory a
hand-rolled "plural key wins". Each uses the one helper that already did the
job, and an unknown Shelly `TYPE` raises `ValueError` naming what it accepts.
`validate_config` built a parser from imports the module already had.

### Annotations, and what they found (`0c93529`, `38b7214`, `47987c0`)

Every function in `src/` is annotated, so `check_untyped_defs`,
`disallow_untyped_defs` and `disallow_incomplete_defs` are now on for
everything. (Scoping them to non-test code turned out not to be expressible:
tests live in the same packages, and a mypy module pattern matches whole dotted
components, never a `_test` suffix inside one.)

Defects this surfaced, none of which the tests could have caught:

- `_call_before_send` documents that it returns `(result, failed)` but was
  declared as returning the result alone.
- `_resolve_target` walked one variable between `list[int]`,
  `list[float] | None` and back through a branch reassigning it twice.
- `consumer_ttl` arrived as a `float` while the settings that fill it and the
  snapshot that reports it both call it an `int` — as does the firmware's
  `uint32_t`.
- `parse_request` returned `(fields | None, error | None)`, a pair whose halves
  are never independent; it returns the union the caller can narrow, matching
  how `protocol.cpp` reads its `std::optional`. Its checksum mismatch put raw
  `bytes` through an f-string, so it read `expected b'2f', got b'ff'`.
- Two identical `FakePowermeter` stubs, neither a `Powermeter`: one shared
  fixture that subclasses it, so a wrapper growing a requirement fails there.
- `_FakeWs` had no `close()`, which the read watchdog calls on it.
- ~30 factory tests read `meter.ip` off a declared `Powermeter` — they assumed
  which class the factory returns without asserting it. They assert it now.
- Two tests asserted nothing at all: one wrapped five constructors in a
  `try/except` swallowing anything without "Connection" in the message.

Where a signature said more than the code needs, it now says what it needs:
`DatagramSink` (the UDP handlers only call `sendto`) and `PowermeterWrapper` in
place of matching on `type(x).__name__`.

### Logging (`6d4ddde`, `9bc0bf7`)

`MqttPowermeter._run` nested eight deep — the reconnect loop wrapped the
connection, which wrapped the message loop, which wrapped the per-index parse.
The simulator TUI parsed server-sent events inline, four levels below the
`async with` holding the response open. Both are flat. All f-string log calls
are `%`-style: they were formatting their arguments whether or not the level
was enabled.

## Behavior changes

Three, all deliberate:

- A stopped Home Assistant meter no longer reports itself online. It picks up
  the `_connected` reset on `stop()` that HomeWizard already had and documented.
- A Supervisor failure on `POST /api/config-mode` answers `502` rather than
  `400`, matching the sibling route. The dashboard only reads the message.
- An unknown Shelly `TYPE` raises `ValueError`, not bare `Exception`.

## Verification

`uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest`
— clean; mypy passes with the three flags above enabled.

Beyond that, the optional suites CI runs, obtained rather than skipped:

- 1578 Python tests, 8 skipped (was 40 — `esphome`, `mosquitto` and `textual`
  installed locally).
- 99 cross-backend parity tests (`tests/components/ct002/`).
- 146 C++ host gtests, built per the `check-ct002-parity` sandbox notes.

No CT002 ↔ ESPHome shared behavior changed, so nothing was owed to the C++ side.

## Checklist

- [x] Base branch is `develop`, not `main`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest` passes
- [x] Python ↔ ESPHome parity held (no shared CT002 behavior changes; host gtests run)
- [x] No user-visible changes requiring `CHANGELOG.md` — refactor, tooling and tests only

https://claude.ai/code/session_01MprqHXqPgjAXwWAwWFEevx