### PR TITLE
Restore the MQTT mirror guard and HomeWizard's cached TLS context, and correct #639's annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Fixed** a Home Assistant power source refusing to start, or reading as permanently unavailable, when its entity list had a stray or trailing comma (`POWER_INPUT_ALIAS = sensor.import,`). Blank entries are now ignored.
+
 - **Fixed** a B2500 written off as unable to deliver after being handed a share too small to switch it on, which made every later share smaller still — leaving it at 0 W indefinitely while the house imported ([#624](https://github.com/tomquist/astrameter/issues/624), [#629](https://github.com/tomquist/astrameter/pull/629)).
 
 - **Fixed** B2500 batteries sitting at 0 W under active control while the whole house load was imported: the command they were sent could never exceed what the battery needs to start, and a battery that never starts was never sent more ([#600](https://github.com/tomquist/astrameter/issues/600), [#614](https://github.com/tomquist/astrameter/pull/614), [#631](https://github.com/tomquist/astrameter/pull/631)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** a Home Assistant power source refusing to start, or reading as permanently unavailable, when its entity list had a stray or trailing comma (`POWER_INPUT_ALIAS = sensor.import,`). Blank entries are now ignored.
+- **Fixed** a Home Assistant power source refusing to start, or reading as permanently unavailable, when its entity list had a stray or trailing comma (`POWER_INPUT_ALIAS = sensor.import,`). Blank entries are now ignored ([#640](https://github.com/tomquist/astrameter/pull/640)).
 
 - **Fixed** a B2500 written off as unable to deliver after being handed a share too small to switch it on, which made every later share smaller still — leaving it at 0 W indefinitely while the house imported ([#624](https://github.com/tomquist/astrameter/issues/624), [#629](https://github.com/tomquist/astrameter/pull/629)).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ known-first-party = ["astrameter"]
 [tool.mypy]
 python_version = "3.10"
 warn_unused_configs = true
+warn_unused_ignores = true
 warn_return_any = false
 ignore_missing_imports = true
 explicit_package_bases = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,11 @@ check_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_defs = true
 disable_error_code = ["import-untyped"]
+
+[[tool.mypy.overrides]]
+# Whether these suppressions are needed depends on whether the optional `sim`
+# extra is installed: with textual present they silence a real signature
+# mismatch, without it the call is untyped and they read as unused. CI lints
+# with `dev` only, so the module is exempt rather than wrong in one of the two.
+module = "astrameter.simulator.tui"
+warn_unused_ignores = false

--- a/src/astrameter/config/addon_test.py
+++ b/src/astrameter/config/addon_test.py
@@ -11,6 +11,7 @@ from astrameter.config.ini_config import IniAppConfig
 from astrameter.config.settings import CtSettings, GeneralSettings
 from astrameter.powermeter import HomeAssistant, ThrottledPowermeter
 from astrameter.powermeter.wrappers.base import PowermeterWrapper
+from astrameter.powermeter.wrappers.health import HealthTrackingPowermeter
 
 
 class FakeSupervisor(addon.SupervisorClient):
@@ -165,7 +166,7 @@ def test_marstek_needs_the_opt_in_and_credentials() -> None:
 def test_single_power_entity_is_read_directly() -> None:
     cfg = config(BASE_OPTIONS)
     meter = cfg.powermeters(cfg.general())[0][0]
-    assert isinstance(meter, PowermeterWrapper)
+    assert isinstance(meter, HealthTrackingPowermeter)
     source = meter.wrapped_powermeter
     assert isinstance(source, HomeAssistant)
     assert source.power_calculate is False
@@ -177,7 +178,7 @@ def test_single_power_entity_is_read_directly() -> None:
 def _inner_source(cfg: addon.AddonAppConfig) -> HomeAssistant:
     """The Home Assistant source under the health wrapper the loader adds."""
     meter = cfg.powermeters(cfg.general())[0][0]
-    assert isinstance(meter, PowermeterWrapper)
+    assert isinstance(meter, HealthTrackingPowermeter)
     source = meter.wrapped_powermeter
     assert isinstance(source, HomeAssistant)
     return source
@@ -246,7 +247,7 @@ def test_command_line_throttle_override_reaches_the_power_source() -> None:
     general = cfg.general()
     general = replace(general, signal=replace(general.signal, throttle_interval=9))
     meter = cfg.powermeters(general)[0][0]
-    assert isinstance(meter, PowermeterWrapper)
+    assert isinstance(meter, HealthTrackingPowermeter)
     throttled = meter.wrapped_powermeter
     assert isinstance(throttled, ThrottledPowermeter)
     assert throttled.throttle_interval == 9

--- a/src/astrameter/config/config_loader.py
+++ b/src/astrameter/config/config_loader.py
@@ -659,7 +659,7 @@ def create_homeassistant_powermeter(
     else:
         _static_token = config.get(section, "ACCESSTOKEN", fallback="")
 
-        def token_getter() -> str:  # type: ignore[no-redef]
+        def token_getter() -> str:
             return _static_token
 
     return HomeAssistant(

--- a/src/astrameter/config/config_loader_test.py
+++ b/src/astrameter/config/config_loader_test.py
@@ -52,7 +52,7 @@ from astrameter.powermeter import (
     TibberPulse,
     TransformedPowermeter,
 )
-from astrameter.powermeter.wrappers.base import PowermeterWrapper
+from astrameter.powermeter.wrappers.health import HealthTrackingPowermeter
 
 
 def test_client_filter() -> None:
@@ -753,7 +753,7 @@ def test_read_all_configs_with_power_transform() -> None:
     powermeters = read_all_powermeter_configs(config)
     assert len(powermeters) == 1
     pm, _, _ = powermeters[0]
-    assert isinstance(pm, PowermeterWrapper)
+    assert isinstance(pm, HealthTrackingPowermeter)
     pm = pm.wrapped_powermeter  # unwrap outermost HealthTrackingPowermeter
     assert isinstance(pm, TransformedPowermeter)
     assert pm.offsets == [-50.0]
@@ -772,7 +772,7 @@ def test_read_all_configs_with_per_phase_transform() -> None:
     powermeters = read_all_powermeter_configs(config)
     assert len(powermeters) == 1
     pm, _, _ = powermeters[0]
-    assert isinstance(pm, PowermeterWrapper)
+    assert isinstance(pm, HealthTrackingPowermeter)
     pm = pm.wrapped_powermeter  # unwrap outermost HealthTrackingPowermeter
     assert isinstance(pm, TransformedPowermeter)
     assert pm.offsets == [-10.0, -20.0, -30.0]
@@ -790,7 +790,7 @@ def test_read_all_configs_offset_only() -> None:
     powermeters = read_all_powermeter_configs(config)
     assert len(powermeters) == 1
     pm, _, _ = powermeters[0]
-    assert isinstance(pm, PowermeterWrapper)
+    assert isinstance(pm, HealthTrackingPowermeter)
     pm = pm.wrapped_powermeter  # unwrap outermost HealthTrackingPowermeter
     assert isinstance(pm, TransformedPowermeter)
     assert pm.offsets == [10.0]
@@ -808,7 +808,7 @@ def test_read_all_configs_zero_multiplier_accepted() -> None:
     powermeters = read_all_powermeter_configs(config)
     assert len(powermeters) == 1
     pm, _, _ = powermeters[0]
-    assert isinstance(pm, PowermeterWrapper)
+    assert isinstance(pm, HealthTrackingPowermeter)
     pm = pm.wrapped_powermeter  # unwrap outermost HealthTrackingPowermeter
     assert isinstance(pm, TransformedPowermeter)
     assert pm.multipliers == [0.0]
@@ -824,7 +824,7 @@ def test_read_all_configs_wraps_with_health_tracking_named_by_section() -> None:
     powermeters = read_all_powermeter_configs(config)
     assert len(powermeters) == 1
     pm, _, _ = powermeters[0]
-    assert isinstance(pm, PowermeterWrapper)
+    assert isinstance(pm, HealthTrackingPowermeter)
     assert pm.name == "SCRIPT_1"
 
 
@@ -838,7 +838,7 @@ def test_read_all_configs_no_transform_when_not_configured() -> None:
     powermeters = read_all_powermeter_configs(config)
     assert len(powermeters) == 1
     pm, _, _ = powermeters[0]
-    assert isinstance(pm, PowermeterWrapper)
+    assert isinstance(pm, HealthTrackingPowermeter)
     pm = pm.wrapped_powermeter  # unwrap outermost HealthTrackingPowermeter
     assert not isinstance(pm, TransformedPowermeter)
 

--- a/src/astrameter/config/ini_config_test.py
+++ b/src/astrameter/config/ini_config_test.py
@@ -5,7 +5,7 @@ from astrameter.config.config_loader import new_config_parser
 from astrameter.config.ini_config import IniAppConfig, render_ini
 from astrameter.config.settings import CtSettings, GeneralSettings
 from astrameter.powermeter import ThrottledPowermeter
-from astrameter.powermeter.wrappers.base import PowermeterWrapper
+from astrameter.powermeter.wrappers.health import HealthTrackingPowermeter
 
 
 def config(text: str) -> IniAppConfig:
@@ -148,7 +148,7 @@ IP = 192.168.1.10
 """
     )
     meter, _, _ = cfg.powermeters(cfg.general())[0]
-    assert isinstance(meter, PowermeterWrapper)
+    assert isinstance(meter, HealthTrackingPowermeter)
     assert isinstance(meter.wrapped_powermeter, ThrottledPowermeter)
 
 

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -698,7 +698,7 @@ class CT002:
         self,
         consumer_id: str,
         phase: str,
-        power: object,
+        power: int,
         device_type: str = "",
         *,
         source_ip: str | None = None,

--- a/src/astrameter/ct002/protocol.py
+++ b/src/astrameter/ct002/protocol.py
@@ -44,14 +44,14 @@ def calculate_checksum(data_bytes: bytes | bytearray) -> int:
     return xor
 
 
-def parse_int(value: object, default: int = 0) -> int:
+def parse_int(value: str | float, default: int = 0) -> int:
     """The integer *value* denotes, or *default* when it denotes none.
 
-    Takes ``object`` because it reads both wire strings and already-parsed
-    numbers; the ``TypeError`` below is what covers everything else.
+    Reads both the wire's strings and already-parsed numbers, which is the
+    whole domain its callers have.
     """
     try:
-        return int(value)  # type: ignore[call-overload]
+        return int(value)
     except (TypeError, ValueError):
         return default
 

--- a/src/astrameter/main.py
+++ b/src/astrameter/main.py
@@ -120,7 +120,7 @@ def _build_ct002(
     ct_type: str,
     device_id: str,
     debug_status: bool,
-    reset_fn: Callable[[], None],
+    reset_fn: Callable[[], None] | None,
 ) -> CT002:
     """Create the emulator a :class:`CtSettings` describes."""
     return CT002(

--- a/src/astrameter/powermeter/homewizard.py
+++ b/src/astrameter/powermeter/homewizard.py
@@ -56,6 +56,7 @@ class HomeWizardPowermeter(WebSocketPowermeter):
         self.token = token
         self.serial = serial
         self._verify_ssl = verify_ssl
+        self._ssl_context: ssl.SSLContext | None = None
         self._max_measurement_age_seconds = max(0.0, max_measurement_age_seconds)
         self._clock = clock or time.monotonic
         self.values: list[float] | None = None
@@ -98,9 +99,13 @@ class HomeWizardPowermeter(WebSocketPowermeter):
         await super().start()
 
     def _connect(self, session: aiohttp.ClientSession) -> WebSocketConnect:
+        if self._ssl_context is None:
+            # Built once and kept: _connect runs on every reconnect, and
+            # building the context reads the bundled CA off disk.
+            self._ssl_context = self._build_ssl_context()
         return session.ws_connect(
             f"wss://{self.ip}/api/ws",
-            ssl=self._build_ssl_context(),
+            ssl=self._ssl_context,
             server_hostname=f"appliance/p1dongle/{self.serial}",
             heartbeat=WS_HEARTBEAT_SECONDS,
         )

--- a/src/astrameter/powermeter/homewizard_test.py
+++ b/src/astrameter/powermeter/homewizard_test.py
@@ -492,6 +492,12 @@ async def test_close_message_exits_iteration() -> None:
 
     await pm._read(ws)
 
+    # The frame before the CLOSE was acted on — this is the only test that
+    # drives the shared read loop, so without it a dropped TEXT dispatch in
+    # WebSocketPowermeter._read would go unnoticed.
+    ws.send_json.assert_awaited_once_with({"type": "subscribe", "data": "measurement"})
+    assert pm._connected is True
+    # ...and the one after it was not.
     assert pm.values is None
 
 

--- a/src/astrameter/powermeter/modbus_test.py
+++ b/src/astrameter/powermeter/modbus_test.py
@@ -261,7 +261,7 @@ async def modbus_udp_server() -> AsyncIterator[int]:
     server = ModbusUdpServer(context, address=("127.0.0.1", 0))
     await server.listen()
     # UDP uses a datagram transport (no listening socket list like TCP).
-    port = server.transport.get_extra_info("sockname")[1]  # type: ignore[union-attr]
+    port = server.transport.get_extra_info("sockname")[1]
     yield port
     await server.shutdown()
 

--- a/src/astrameter/powermeter/ws_client.py
+++ b/src/astrameter/powermeter/ws_client.py
@@ -47,6 +47,8 @@ class WebSocket(Protocol):
     a test can drive the same handlers with a few canned frames.
     """
 
+    # Not AsyncIterator[WSMessage]: aiohttp's own __aiter__ returns the
+    # response object, which does not satisfy that.
     def __aiter__(self) -> AsyncIterator[Any]: ...
 
     async def send_json(self, data: Any) -> None: ...
@@ -57,7 +59,11 @@ class WebSocket(Protocol):
 #: What ``session.ws_connect(...)`` hands back, unawaited. A concrete aiohttp
 #: type rather than the protocol above: only the handlers need to accept a
 #: stand-in, and the connection itself is always the real thing.
-WebSocketConnect = AbstractAsyncContextManager[aiohttp.ClientWebSocketResponse[bool]]
+#:
+#: The aiohttp half is a forward reference so it is never evaluated at import
+#: time — only ``AbstractAsyncContextManager`` is subscripted here, and every
+#: power source reaches this module.
+WebSocketConnect = AbstractAsyncContextManager["aiohttp.ClientWebSocketResponse[bool]"]
 
 
 async def cancel(task: asyncio.Task | None) -> None:

--- a/src/astrameter/udp_server.py
+++ b/src/astrameter/udp_server.py
@@ -20,13 +20,13 @@ class DatagramSink(Protocol):
     def sendto(self, data: bytes, addr: tuple) -> None: ...
 
 
-Handler = Callable[[bytes, tuple, asyncio.DatagramTransport], Coroutine[Any, Any, None]]
+Handler = Callable[[bytes, tuple, DatagramSink], Coroutine[Any, Any, None]]
 
 
 class _HandlerProtocol(asyncio.DatagramProtocol):
     def __init__(self, handler: Handler) -> None:
         self._handler = handler
-        self._transport: asyncio.DatagramTransport | None = None
+        self._transport: DatagramSink | None = None
         # asyncio keeps only a weak reference to a running task, so a handler
         # nobody holds can be collected mid-poll; the set is that reference.
         self._tasks: set[asyncio.Task] = set()
@@ -35,7 +35,8 @@ class _HandlerProtocol(asyncio.DatagramProtocol):
         # Widened by the base class, and narrowed rather than checked: the
         # concrete datagram transports do not inherit `DatagramTransport`, so
         # an isinstance test here refuses the very object asyncio hands over.
-        self._transport = cast("asyncio.DatagramTransport", transport)
+        # Narrowed to what a handler uses, which it genuinely does have.
+        self._transport = cast("DatagramSink", transport)
 
     def datagram_received(self, data: bytes, addr: tuple) -> None:
         assert self._transport is not None

--- a/src/astrameter/web_config_test.py
+++ b/src/astrameter/web_config_test.py
@@ -63,7 +63,7 @@ def test_validate_section_name_with_bracket() -> None:
 
 def test_validate_section_not_dict() -> None:
     with pytest.raises(ValueError, match="must map to an object"):
-        _validate_config_payload({"S": "bad"}, ["S"])  # type: ignore[dict-item]
+        _validate_config_payload({"S": "bad"}, ["S"])
 
 
 def test_validate_empty_key() -> None:

--- a/src/astrameter/web_server.py
+++ b/src/astrameter/web_server.py
@@ -16,7 +16,7 @@ import shutil
 import signal
 import tempfile
 import threading
-from collections.abc import Awaitable, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import web
@@ -450,14 +450,22 @@ class WebServer:
         entry = self.status.devices.get(device_id)
         return entry.device if entry else None
 
-    async def _mirror_to_mqtt(self, kind: str, publish: Awaitable[None]) -> None:
+    async def _mirror_to_mqtt(
+        self, kind: str, publish: Callable[[], Awaitable[None]]
+    ) -> None:
         """Mirror a control write to the retained MQTT command topic.
 
         Without it the broker's redelivery on the next reconnect reverts what
         the user just set.
+
+        Takes a factory rather than a coroutine so the call is *built* inside
+        the guard too. The write itself has already landed by the time we get
+        here, so nothing about mirroring it — including an insights object that
+        turns out not to offer the method — may turn a successful write into a
+        failed request.
         """
         try:
-            await publish
+            await publish()
         except Exception:
             logger.exception("Failed to mirror %s write to MQTT", kind)
 
@@ -511,7 +519,9 @@ class WebServer:
             # percentage as a fraction.
             await self._mirror_to_mqtt(
                 "control",
-                insights.publish_consumer_command(device_id, consumer_id, field, value),
+                lambda: insights.publish_consumer_command(
+                    device_id, consumer_id, field, value
+                ),
             )
         return self._applied()
 
@@ -543,7 +553,8 @@ class WebServer:
         insights = self._insights()
         if insights is not None:
             await self._mirror_to_mqtt(
-                "device", insights.publish_device_command(device_id, {field: value})
+                "device",
+                lambda: insights.publish_device_command(device_id, {field: value}),
             )
         return self._applied()
 

--- a/src/astrameter/web_server.py
+++ b/src/astrameter/web_server.py
@@ -126,10 +126,10 @@ async def _body(request: web.Request) -> dict[str, Any]:
     return body
 
 
-def _required(body: dict[str, Any], *keys: str) -> list[Any]:
-    """The values of *keys*, refusing the request when one is missing."""
+def _required(body: dict[str, Any], key: str) -> Any:
+    """The value of *key*, refusing the request when it is missing."""
     try:
-        return [body[key] for key in keys]
+        return body[key]
     except KeyError as exc:
         raise ApiError(f"Invalid request: {exc}", status=400) from exc
 
@@ -486,9 +486,10 @@ class WebServer:
         if not self._may_write(request):
             return forbidden()
         body = await _body(request)
-        device_id, consumer_id, field, value = _required(
-            body, "device_id", "consumer_id", "field", "value"
-        )
+        device_id = _required(body, "device_id")
+        consumer_id = _required(body, "consumer_id")
+        field = _required(body, "field")
+        value = _required(body, "value")
 
         device = self._device(device_id)
         control = CONSUMER_CONTROLS_BY_FIELD.get(field)
@@ -530,7 +531,8 @@ class WebServer:
         if not self._may_write(request):
             return forbidden()
         body = await _body(request)
-        (device_id, field) = _required(body, "device_id", "field")
+        device_id = _required(body, "device_id")
+        field = _required(body, "field")
         value = body.get("value", True)
 
         device = self._device(device_id)
@@ -644,7 +646,7 @@ class WebServer:
         """
         client = self._supervisor(request)
         body = await _body(request)
-        (options,) = _required(body, "options")
+        options = _required(body, "options")
         if not isinstance(options, dict):
             raise ApiError("Invalid request: 'options' must be an object", status=400)
 
@@ -734,7 +736,7 @@ class WebServer:
         """
         client = self._supervisor(request)
         body = await _body(request)
-        (target,) = _required(body, "mode")
+        target = _required(body, "mode")
 
         if target == "file":
             filename = (body.get("filename") or "astrameter.ini").strip()

--- a/tests/test_addon_e2e.py
+++ b/tests/test_addon_e2e.py
@@ -18,7 +18,7 @@ import contextlib
 import json
 import socket
 import threading
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -180,15 +180,19 @@ async def running_addon(options: dict, supervisor: FakeSupervisor, udp_port: int
             await task
 
 
-@pytest.fixture
-def addon_options(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> Callable[..., dict]:
-    """A realistic /data/options.json, read the way the add-on reads it."""
-    monkeypatch.setenv("SUPERVISOR_TOKEN", SUPERVISOR_TOKEN)
-    udp_port = find_free_ports(1)[0]
+class AddonOptions:
+    """Writes a /data/options.json, and carries the UDP port it reserved.
 
-    def write(**overrides: Any) -> dict:
+    An object rather than a function with an attribute bolted on: the port is
+    as much a part of what the fixture hands out as the writer is, and the
+    tests read both.
+    """
+
+    def __init__(self, tmp_path: Path, udp_port: int) -> None:
+        self._tmp_path = tmp_path
+        self.udp_port = udp_port
+
+    def __call__(self, **overrides: Any) -> dict:
         options = {
             "power_input_alias": GRID_SENSOR,
             "power_output_alias": "",
@@ -200,12 +204,16 @@ def addon_options(
             "log_level": "info",
             **overrides,
         }
-        path = tmp_path / "options.json"
+        path = self._tmp_path / "options.json"
         path.write_text(json.dumps(options), encoding="utf-8")
         return load_options(str(path))
 
-    write.udp_port = udp_port  # type: ignore[attr-defined]
-    return write
+
+@pytest.fixture
+def addon_options(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AddonOptions:
+    """A realistic /data/options.json, read the way the add-on reads it."""
+    monkeypatch.setenv("SUPERVISOR_TOKEN", SUPERVISOR_TOKEN)
+    return AddonOptions(tmp_path, find_free_ports(1)[0])
 
 
 @pytest.fixture
@@ -220,7 +228,7 @@ def supervisor() -> Iterator[FakeSupervisor]:
 
 @pytest.mark.timeout(60)
 async def test_addon_serves_the_home_assistant_reading_over_udp(
-    addon_options: Callable[..., dict], supervisor: FakeSupervisor
+    addon_options: AddonOptions, supervisor: FakeSupervisor
 ) -> None:
     options = addon_options()
 
@@ -238,7 +246,7 @@ async def test_addon_serves_the_home_assistant_reading_over_udp(
 
 @pytest.mark.timeout(60)
 async def test_add_on_options_reach_the_running_emulator(
-    addon_options: Callable[..., dict], supervisor: FakeSupervisor
+    addon_options: AddonOptions, supervisor: FakeSupervisor
 ) -> None:
     """A tuning option set in the add-on UI changes what the battery is told."""
     options = addon_options(power_offset="100", ct_mac="AABBCCDDEE01")


### PR DESCRIPTION
## Why

CodeRabbit skipped [#639](https://github.com/tomquist/AstraMeter/pull/639) — 122 files over its
100-file limit, and no review credits — so it merged without an automated
pass. This is that pass, done instead by three reviewers reading the merged
diff along separate axes (production behavior, test strength, typing
soundness), with every finding re-verified before it was acted on.

Two real regressions, three tests that asserted less than they read as
asserting, four annotations that described the checker rather than the code,
and one user-visible fix that #639 made by accident and did not declare.

## Behavior restored

**A control write could be reported as failed after it had already landed.**
`_mirror_to_mqtt` promised that mirroring a write to the retained MQTT
command topic could never fail the write itself. #639 built the publish
coroutine at the call site, *outside* the guard, so an insights service
missing the method raised after `control.apply()` had succeeded and the
dashboard was told the write failed. It takes a factory again, so building
the call is inside the guard along with awaiting it.

**HomeWizard re-read its CA off disk every five seconds while disconnected.**
The old loop built the TLS context once above `while True`; the extracted
`_connect()` runs per dial. Beyond the I/O, an unreadable CA file turned a
task that used to die once into an endless error-log loop. Built once and
kept.

## Tests that were not asserting what they claimed

- `test_close_message_exits_iteration` checked only that the frame *after* a
  CLOSE was ignored, never that the frame before it was handled. As the only
  caller of the shared read loop, it passed with the entire TEXT dispatch
  removed from `WebSocketPowermeter._read` — verified, then verified again
  that it now fails without it.
- A scripted narrowing in #639 had relaxed `HealthTrackingPowermeter` to
  `PowermeterWrapper` in tests whose names and comments name the specific
  wrapper. The genuinely generic stack-walking loop keeps the base class; the
  rest say what they mean.
- `addon_options` was typed as a plain callable while carrying the UDP port
  it reserved as an attribute that four call sites read. It is an object that
  has both, and the `# type: ignore` hiding the mismatch is gone.

## Annotations that were not true

| | was | is |
|---|---|---|
| `_build_ct002` | `reset_fn: Callable[[], None]` | `\| None` — which `CT002.__init__` takes and every test caller passes |
| `_update_consumer_report` | `power: object` | `int` — what `CT002Request.power` already is |
| `parse_int` | `object` + `# type: ignore[call-overload]` | `str \| float`, its real domain, with no suppression |
| `_required` | `-> list[Any]`, unpacked into 1/2/4 names | one value per call — unpacking an unknown length was a `ValueError` mypy accepted |

Two more where a name existed but did no work:

- `udp_server` introduced `DatagramSink` to say what a handler needs of a
  transport, then cast to `asyncio.DatagramTransport` anyway — the very type
  the comment above the cast explains the object does *not* have. It casts to
  the protocol it does satisfy, and `Handler` names that too.
- `WebSocketConnect` subscripted an aiohttp class at import time, which
  `from __future__ import annotations` does not defer. Every power source
  reaches that module, so an aiohttp without the type parameter would take
  the whole meter stack down rather than the two WebSocket sources. The
  aiohttp half is a forward reference; only the stdlib context manager is
  subscripted. Confirmed still correct under mypy and at runtime.

`warn_unused_ignores` is on, which found three suppressions whose errors no
longer occur. Now that every function is annotated it can keep finding them.

The one module it cannot judge is `astrameter.simulator.tui`, so that module
is exempt. Whether its two suppressions are needed depends on whether the
optional `sim` extra is installed: with `textual` present they silence a real
signature mismatch, without it the call is untyped and they read as unused.
CI lints with `dev` only, so the module would be wrong in one of the two
environments either way. Reproduced both ways
(`uv sync --python 3.11 --extra dev`) before settling on the exemption.

## Changelog

#639 replaced the Home Assistant factory's private `parse_entities` with the
shared helper, which drops blank entries where the private copy kept them. A
reviewer showed the difference is reachable: an entity list with a trailing
comma (`POWER_INPUT_ALIAS = sensor.import,`) yielded a blank entity that
either failed every read or tripped the input/output length check at
construction — a config that could not start. Strictly a repair, with no
reverse case, but user-visible, so it gets a line.

## Deliberately not changed

- `POST /api/config-mode` answering `502` rather than `400` on a Supervisor
  failure — declared in #639 and consistent with its sibling route.
- Shelly's single-phase MQTT event value now being `350.0` rather than `350`;
  the three-phase branch already floated, and both parse identically.
- An undecodable datagram on the Shelly port logging at DEBUG rather than
  ERROR — that port takes anything on the LAN, and CT002's equivalent decoder
  already logs at DEBUG.
- `StatusRegistry.insights` staying `Any`. Typing it is the root fix for the
  mirror bug above, but `status_test.py` deliberately assigns a bare
  `object()` to it, so that is a separate decision rather than a drive-by.

## Verification

`uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest` — clean.

- 1578 Python tests, 8 skipped.
- 99 cross-backend parity tests (`tests/components/ct002/`).
- 146 C++ host gtests, rebuilt and run.

CI is green on `ae78731`: lint, `validate` on 3.10–3.13, all 14 ESPHome
compile targets, both host CT002 suites, dashboard e2e, web and
addon-container. The steering evaluation reports 0 improved / 0 regressed /
15 unchanged across 33 scenarios — `cost_regret_ct` flat at 0.76 — which is
the expected result for a change that deliberately leaves `LoadBalancer`
alone.

No CT002 ↔ ESPHome shared behavior changed. `parse_int`'s annotation change
is Python-side only; the mirror's `parse_int_strict` is string-only by
design and is unaffected.

## Checklist

- [x] Base branch is `develop`, not `main`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest` passes
- [x] Python ↔ ESPHome parity held (no shared CT002 behavior changes; host gtests run)
- [x] `CHANGELOG.md` updated — one bullet, for the trailing-comma fix, linked to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MprqHXqPgjAXwWAwWFEevx

---
_Generated by [Claude Code](https://claude.ai/code/session_01MprqHXqPgjAXwWAwWFEevx)_


## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Home Assistant power sources failing to start or appearing permanently unavailable when entity lists contain trailing or extra commas.
  - Prevented successful web configuration updates from being reported as failed when optional publishing is unavailable.
  - Improved WebSocket message handling so authorization and measurement messages are processed in the correct order.

- **Performance**
  - Reduced repeated SSL certificate loading when reconnecting to HomeWizard devices.

- **Maintenance**
  - Improved type checking and test coverage across device integrations and configuration handling.
