### PR TITLE
Invalidate unavailable ESPHome native power readings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** an unavailable ESPHome native power sensor continuing to report its old reading as healthy while connected, leaving batteries steering against stale grid power until the sensor recovered.
+- **Fixed** an unavailable ESPHome native power sensor continuing to report its old reading as healthy while connected, leaving batteries steering against stale grid power until the sensor recovered ([#645](https://github.com/tomquist/astrameter/pull/645)).
 
 - **Fixed** a Home Assistant power source refusing to start, or reading as permanently unavailable, when its entity list had a stray or trailing comma (`POWER_INPUT_ALIAS = sensor.import,`). Blank entries are now ignored ([#640](https://github.com/tomquist/astrameter/pull/640)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Fixed** an unavailable ESPHome native power sensor continuing to report its old reading as healthy while connected, leaving batteries steering against stale grid power until the sensor recovered.
+
 - **Fixed** a Home Assistant power source refusing to start, or reading as permanently unavailable, when its entity list had a stray or trailing comma (`POWER_INPUT_ALIAS = sensor.import,`). Blank entries are now ignored ([#640](https://github.com/tomquist/astrameter/pull/640)).
 
 - **Fixed** a B2500 written off as unable to deliver after being handed a share too small to switch it on, which made every later share smaller still — leaving it at 0 W indefinitely while the house imported ([#624](https://github.com/tomquist/astrameter/issues/624), [#629](https://github.com/tomquist/astrameter/pull/629)).

--- a/src/astrameter/powermeter/esphome_native.py
+++ b/src/astrameter/powermeter/esphome_native.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import math
 
 import aioesphomeapi
 from aioesphomeapi import EntityInfo, EntityState, SensorState
@@ -47,7 +48,8 @@ class ESPHomeNative(PushPowermeter):
         #: watts — what installs relied on before units were read.
         self._unit: str | None = None
         self.is_connected: bool = False
-        # Stays set across messages; only a (re)connect clears it.
+        # Set while the latest sensor state is valid; cleared on unavailability
+        # and disconnect so a connected API cannot make stale data look healthy.
         self._any_message_event = asyncio.Event()
         logger.debug(
             "ESPHome native: %s:%s as %s, object id %s",
@@ -167,12 +169,13 @@ class ESPHomeNative(PushPowermeter):
             logger.error("ESPHome native: subscribed entity %s is not a sensor", state)
             return
 
-        # When the upstream sensor goes unavailable, aioesphomeapi delivers a
-        # SensorState with missing_state=True and often NaN. Feeding that into
-        # active control would corrupt the grid reading, so drop the update and
-        # keep the last known-good value.
-        if state.missing_state or state.state != state.state:
-            logger.debug("Ignoring unavailable/NaN sensor state")
+        # An explicit unavailable state invalidates the old measurement even
+        # while the API connection stays alive. Wake pending readers too: they
+        # must see the outage instead of waiting and reusing the old value.
+        if state.missing_state or not math.isfinite(state.state):
+            self._any_message_event.clear()
+            self._message_event.set()
+            logger.debug("ESPHome native sensor is unavailable")
             return
 
         self.last_value = state.state
@@ -204,7 +207,11 @@ class ESPHomeNative(PushPowermeter):
         return scale
 
     def stream_online(self) -> bool | None:
-        return self.is_connected
+        return (
+            self.is_connected
+            and self._any_message_event.is_set()
+            and (self._unit is None or self._unit in POWER_UNIT_SCALE)
+        )
 
     async def wait_for_message(self, timeout: float = 5) -> None:
         await self._wait(self._any_message_event, timeout)

--- a/src/astrameter/powermeter/esphome_native_test.py
+++ b/src/astrameter/powermeter/esphome_native_test.py
@@ -1,3 +1,4 @@
+import asyncio
 import math
 
 import pytest
@@ -72,19 +73,62 @@ async def test_change_callback_ignores_before_subscribe() -> None:
     assert await pm.get_powermeter_watts() == []
 
 
-async def test_change_callback_drops_missing_state() -> None:
+@pytest.mark.parametrize(
+    ("value", "missing"),
+    [
+        (100.0, True),
+        (math.nan, True),
+        (math.nan, False),
+        (math.inf, False),
+        (-math.inf, False),
+    ],
+)
+async def test_unavailable_state_invalidates_cached_reading_and_recovers(
+    value: float, missing: bool
+) -> None:
+    """An alive API must not hide an unavailable power sensor behind old watts."""
+    pm = _subscribed_pm(unit="kW")
+    pm.change_callback(_state(1.2))
+    assert await pm.get_powermeter_watts() == [1200.0]
+    assert pm.stream_online() is True
+    pm.change_callback(_state(value, missing_state=missing))
+    assert await pm.get_powermeter_watts() == []
+    assert pm.stream_online() is False
+    pm.change_callback(_state(0.4))
+    assert await pm.get_powermeter_watts() == [400.0]
+    assert pm.stream_online() is True
+
+
+async def test_unavailable_update_wakes_pending_reader() -> None:
+    """The normal wait-for-next-message path must observe the outage promptly."""
     pm = _subscribed_pm()
-    pm.change_callback(_state(100.0))
+    pm.change_callback(_state(1200.0))
+    waiter = asyncio.create_task(pm.wait_for_next_message(timeout=1))
+    await asyncio.sleep(0)
     pm.change_callback(_state(math.nan, missing_state=True))
-    # The unavailable update is dropped; the last good value is kept.
-    assert await pm.get_powermeter_watts() == [100.0]
+    await asyncio.wait_for(waiter, timeout=0.2)
+    assert await pm.get_powermeter_watts() == []
 
 
-async def test_change_callback_drops_nan_without_missing_flag() -> None:
+async def test_timeout_cannot_resurrect_unavailable_reading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even a reader arriving after the outage must not serve the old cache."""
+    from astrameter import meter_pool
+    from astrameter.config.config_loader import ClientFilter
+    from astrameter.config.settings import ConfiguredPowermeter
+    from astrameter.powermeter.wrappers.health import HealthTrackingPowermeter
+
     pm = _subscribed_pm()
-    pm.change_callback(_state(100.0))
-    pm.change_callback(_state(math.nan))
-    assert await pm.get_powermeter_watts() == [100.0]
+    health = HealthTrackingPowermeter(pm)
+    pm.change_callback(_state(1200.0))
+    await health.get_powermeter_watts()
+    pm.change_callback(_state(math.nan, missing_state=True))
+    monkeypatch.setattr(meter_pool, "FRESH_MESSAGE_TIMEOUT_S", 0.01)
+    configured = ConfiguredPowermeter(health, ClientFilter([]), True)
+    assert await meter_pool.read_fresh(configured) == []
+    assert health.status_snapshot().online is False
+    assert health.status_snapshot().last_read_ok is False
 
 
 async def test_wait_for_message_returns_after_message() -> None:
@@ -121,11 +165,11 @@ async def test_disconnect_clears_value() -> None:
     assert pm.entity_info is None
 
 
-async def test_stream_online_reflects_connection() -> None:
+async def test_stream_online_requires_valid_sensor_state() -> None:
     pm = _make_pm()
     assert pm.stream_online() is False
     pm.is_connected = True
-    assert pm.stream_online() is True
+    assert pm.stream_online() is False
 
 
 async def test_connect_error_resets_state() -> None:


### PR DESCRIPTION
## Why

An ESPHome native sensor could report unavailable while its API connection remained alive, yet AstraMeter continued returning its last power reading and marked it healthy. The normal wait-for-next-message timeout also served that stale value to the control loop.

This clears reading validity on missing, NaN, or infinite states, wakes pending readers, and reports the source offline until a valid measurement arrives. Valid readings resume automatically, with the declared unit conversion preserved.

## Validation

- Ruff formatting/checks and mypy pass.
- Local pytest: 1,600 passed, 107 skipped (optional ESPHome/CMake/MQTT integration prerequisites were not on the suite PATH).
- Regression coverage: invalid state variants, recovery, pending-reader wakeup, and the normal timeout/health path.
- Python source adapter only; no shared CT002 behavior or dashboard assets changed.
- One user-facing changelog bullet under `Next`.

No physical ESPHome device was used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed unavailable ESPHome power sensors continuing to report their last healthy reading.
  - Battery steering now stops relying on stale grid-power data when a sensor becomes unavailable or reports an invalid value.
  - Power monitoring is correctly marked offline during sensor outages and resumes after recovery.
  - Pending readings now update promptly when sensor availability changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->