### PR TITLE
Fix efficiency window weight rotation to scale only with one active slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** a battery's **Efficiency Window Weight** not sharing the low-demand rotation as set: anything below 100 % was skipped after a single poll instead of running proportionally less than its peers ([#647](https://github.com/tomquist/astrameter/issues/647)).
+- **Fixed** a battery set to a lower **Efficiency Window Weight** than its peers barely taking a turn in the low-demand rotation, and one that could not keep up being handed the slot straight back ([#647](https://github.com/tomquist/astrameter/issues/647)).
 
 - **Fixed** an unavailable ESPHome native power sensor continuing to report its old reading as healthy while connected, leaving batteries steering against stale grid power until the sensor recovered ([#645](https://github.com/tomquist/astrameter/pull/645)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** a battery set to a lower **Efficiency Window Weight** than its peers barely taking a turn in the low-demand rotation, instead of running proportionally less than them ([#647](https://github.com/tomquist/astrameter/issues/647)). Set it to `0 %` for a battery you want held back whenever the others can cover.
+- **Fixed** a battery set to a lower **Efficiency Window Weight** than its peers barely taking a turn in the low-demand rotation, instead of running proportionally less than them ([#647](https://github.com/tomquist/astrameter/issues/647), [#648](https://github.com/tomquist/astrameter/pull/648)). Set it to `0 %` for a battery you want held back whenever the others can cover.
 
 - **Fixed** an unavailable ESPHome native power sensor continuing to report its old reading as healthy while connected, leaving batteries steering against stale grid power until the sensor recovered ([#645](https://github.com/tomquist/astrameter/pull/645)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** a battery set to a lower **Efficiency Window Weight** than its peers barely taking a turn in the low-demand rotation, and one that could not keep up being handed the slot straight back ([#647](https://github.com/tomquist/astrameter/issues/647)).
+- **Fixed** a battery set to a lower **Efficiency Window Weight** than its peers barely taking a turn in the low-demand rotation, instead of running proportionally less than them ([#647](https://github.com/tomquist/astrameter/issues/647)).
 
 - **Fixed** an unavailable ESPHome native power sensor continuing to report its old reading as healthy while connected, leaving batteries steering against stale grid power until the sensor recovered ([#645](https://github.com/tomquist/astrameter/pull/645)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** a battery set to a lower **Efficiency Window Weight** than its peers barely taking a turn in the low-demand rotation, instead of running proportionally less than them ([#647](https://github.com/tomquist/astrameter/issues/647)).
+- **Fixed** a battery set to a lower **Efficiency Window Weight** than its peers barely taking a turn in the low-demand rotation, instead of running proportionally less than them ([#647](https://github.com/tomquist/astrameter/issues/647)). The weight applies while low demand runs one battery at a time; set it to `0 %` to hold a battery back whenever the others can cover.
 
 - **Fixed** an unavailable ESPHome native power sensor continuing to report its old reading as healthy while connected, leaving batteries steering against stale grid power until the sensor recovered ([#645](https://github.com/tomquist/astrameter/pull/645)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Fixed** a battery's **Efficiency Window Weight** not sharing the low-demand rotation as set: anything below 100 % was skipped after a single poll instead of running proportionally less than its peers ([#647](https://github.com/tomquist/astrameter/issues/647)).
+
 - **Fixed** an unavailable ESPHome native power sensor continuing to report its old reading as healthy while connected, leaving batteries steering against stale grid power until the sensor recovered ([#645](https://github.com/tomquist/astrameter/pull/645)).
 
 - **Fixed** a Home Assistant power source refusing to start, or reading as permanently unavailable, when its entity list had a stray or trailing comma (`POWER_INPUT_ALIAS = sensor.import,`). Blank entries are now ignored ([#640](https://github.com/tomquist/astrameter/pull/640)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** a battery set to a lower **Efficiency Window Weight** than its peers barely taking a turn in the low-demand rotation, instead of running proportionally less than them ([#647](https://github.com/tomquist/astrameter/issues/647)). The weight applies while low demand runs one battery at a time; set it to `0 %` to hold a battery back whenever the others can cover.
+- **Fixed** a battery set to a lower **Efficiency Window Weight** than its peers barely taking a turn in the low-demand rotation, instead of running proportionally less than them ([#647](https://github.com/tomquist/astrameter/issues/647)). Set it to `0 %` for a battery you want held back whenever the others can cover.
 
 - **Fixed** an unavailable ESPHome native power sensor continuing to report its old reading as healthy while connected, leaving batteries steering against stale grid power until the sensor recovered ([#645](https://github.com/tomquist/astrameter/pull/645)).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -215,7 +215,9 @@ share as a 15 kWh one and saturates first. Three settings work together to fix t
   active time each battery holds. When demand is low and only one battery runs at a
   time, a larger battery should hold a proportionally bigger slice of the rotation
   window — e.g. `75` % and `25` % for the same 3:1 capacity ratio — so it handles
-  more of the cumulative energy over time.
+  more of the cumulative energy over time. It biases the battery holding the
+  rotating slot, so once demand is high enough for several to run at once their
+  shares even out again and **Distribution Weight** is the setting that matters.
 
 See [CT002 / CT003 steering](ct002.md) for details on all three settings.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -215,9 +215,11 @@ share as a 15 kWh one and saturates first. Three settings work together to fix t
   active time each battery holds. When demand is low and only one battery runs at a
   time, a larger battery should hold a proportionally bigger slice of the rotation
   window — e.g. `75` % and `25` % for the same 3:1 capacity ratio — so it handles
-  more of the cumulative energy over time. It biases the battery holding the
-  rotating slot, so once demand is high enough for several to run at once their
-  shares even out again and **Distribution Weight** is the setting that matters.
+  more of the cumulative energy over time. It is a clean control only while
+  demand is low enough to run one battery at a time: it sets how long each one
+  holds the single rotating slot. Once demand runs several at once the active
+  shares stop tracking the weights, and **Distribution Weight** is what governs
+  how the load divides between them.
 
 See [CT002 / CT003 steering](ct002.md) for details on all three settings.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -216,10 +216,15 @@ share as a 15 kWh one and saturates first. Three settings work together to fix t
   time, a larger battery should hold a proportionally bigger slice of the rotation
   window — e.g. `75` % and `25` % for the same 3:1 capacity ratio — so it handles
   more of the cumulative energy over time. It is a clean control only while
-  demand is low enough to run one battery at a time: it sets how long each one
-  holds the single rotating slot. Once demand runs several at once the active
-  shares stop tracking the weights, and **Distribution Weight** is what governs
-  how the load divides between them.
+  demand is low enough to run **one** battery at a time: it sets how long each
+  one holds the single rotating slot. Once demand runs several batteries at once
+  but not all of them, a battery is active for its own turn *and* its
+  predecessor's, so the shares stop tracking the weights — and unequal weights
+  then spread *equally* weighted batteries unevenly too. Three batteries at
+  `100`/`100`/`25` % with two running at a time measure 28 / 44 / 28 %, so the
+  two you weighted the same wear about 60 % apart. Leave the weights equal
+  unless low demand really does run one battery at a time, and use
+  **Distribution Weight** to divide load between batteries that run together.
 
 See [CT002 / CT003 steering](ct002.md) for details on all three settings.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -220,9 +220,7 @@ share as a 15 kWh one and saturates first. Three settings work together to fix t
   each battery holds the single rotating slot. Once demand runs several at once
   every turn is a full interval again, so only `0` % still has an effect (it
   parks a battery whenever the others can cover) — use **Distribution Weight**
-  to divide load between batteries that run together. Very small weights also
-  fall a little short of their ratio, since each handover costs the balancer a
-  moment to settle.
+  to divide load between batteries that run together.
 
 See [CT002 / CT003 steering](ct002.md) for details on all three settings.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -218,11 +218,11 @@ share as a 15 kWh one and saturates first. Three settings work together to fix t
   more of the cumulative energy over time. It applies only while demand is low
   enough to run **one** battery at a time, which is what it describes: how long
   each battery holds the single rotating slot. Once demand runs several at once
-  the rotation goes back to even turns for everyone and the weights stop
-  mattering — use **Distribution Weight** to divide load between batteries that
-  run together. Very small weights also flatten out, because a battery cannot
-  hand its slot on faster than the balancer settles after each swap: `10` %
-  against `100` % measures about 8:1 rather than 10:1.
+  every turn is a full interval again, so only `0` % still has an effect (it
+  parks a battery whenever the others can cover) — use **Distribution Weight**
+  to divide load between batteries that run together. Very small weights also
+  fall a little short of their ratio, since each handover costs the balancer a
+  moment to settle.
 
 See [CT002 / CT003 steering](ct002.md) for details on all three settings.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -215,16 +215,14 @@ share as a 15 kWh one and saturates first. Three settings work together to fix t
   active time each battery holds. When demand is low and only one battery runs at a
   time, a larger battery should hold a proportionally bigger slice of the rotation
   window — e.g. `75` % and `25` % for the same 3:1 capacity ratio — so it handles
-  more of the cumulative energy over time. It is a clean control only while
-  demand is low enough to run **one** battery at a time: it sets how long each
-  one holds the single rotating slot. Once demand runs several batteries at once
-  but not all of them, a battery is active for its own turn *and* its
-  predecessor's, so the shares stop tracking the weights — and unequal weights
-  then spread *equally* weighted batteries unevenly too. Three batteries at
-  `100`/`100`/`25` % with two running at a time measure 28 / 44 / 28 %, so the
-  two you weighted the same wear about 60 % apart. Leave the weights equal
-  unless low demand really does run one battery at a time, and use
-  **Distribution Weight** to divide load between batteries that run together.
+  more of the cumulative energy over time. It applies only while demand is low
+  enough to run **one** battery at a time, which is what it describes: how long
+  each battery holds the single rotating slot. Once demand runs several at once
+  the rotation goes back to even turns for everyone and the weights stop
+  mattering — use **Distribution Weight** to divide load between batteries that
+  run together. Very small weights also flatten out, because a battery cannot
+  hand its slot on faster than the balancer settles after each swap: `10` %
+  against `100` % measures about 8:1 rather than 10:1.
 
 See [CT002 / CT003 steering](ct002.md) for details on all three settings.
 

--- a/docs/mqtt-insights.md
+++ b/docs/mqtt-insights.md
@@ -332,8 +332,8 @@ controls are available to any MQTT client:
   proportionally less, since a battery holds each turn for that fraction of
   [EFFICIENCY_ROTATION_INTERVAL](ct002.md#battery-efficiency-optimization). Two
   batteries you want to take turns in a 1:2 ratio can be set to `50 %` and
-  `100 %`: with the default 15-minute interval that is roughly 7 minutes against
-  15. Separate from **Distribution Weight** (which biases the split among active
+  `100 %`: with the default 15-minute interval that is 7.5 minutes against 15.
+  Separate from **Distribution Weight** (which biases the split among active
   batteries).
 - **Min DC Output** — minimum discharge in watts to keep this battery's inverter
   from switching off at 0 W and falling asleep (see

--- a/docs/mqtt-insights.md
+++ b/docs/mqtt-insights.md
@@ -328,9 +328,12 @@ controls are available to any MQTT client:
 - **Efficiency Window Weight** — how much of the **efficiency rotation** each
   battery takes when demand is low and the balancer runs only some batteries to
   keep them efficient. `100 %` is neutral; `0 %` skips a battery (parked while
-  limiting, but still used when all batteries are needed); in between gives it less
-  active time. Separate from **Distribution Weight** (which biases the split among
-  active batteries).
+  limiting, but still used when all batteries are needed); in between gives it
+  proportionally less, since a battery holds each turn for that fraction of
+  `EFFICIENCY_ROTATION_INTERVAL`. Two batteries you want to take turns in a 1:2
+  ratio can be set to `50 %` and `100 %`: with the default 15-minute interval that
+  is roughly 7 minutes against 15. Separate from **Distribution Weight** (which
+  biases the split among active batteries).
 - **Min DC Output** — minimum discharge in watts to keep this battery's inverter
   from switching off at 0 W and falling asleep (see
   [MIN_DC_OUTPUT](ct002.md#dc-battery-keep-alive)). Only shown for DC batteries

--- a/docs/mqtt-insights.md
+++ b/docs/mqtt-insights.md
@@ -335,9 +335,7 @@ controls are available to any MQTT client:
   `100 %`: with the default 15-minute interval that is 7.5 minutes against 15.
   This applies while demand runs one battery at a time; once several run at once
   every turn is a full interval again (only `0 %` still parks a battery), and
-  **Distribution Weight** is what splits the load among them. Very small weights
-  fall a little short of their ratio, because each handover costs the balancer a
-  moment to settle.
+  **Distribution Weight** is what splits the load among them.
 - **Min DC Output** — minimum discharge in watts to keep this battery's inverter
   from switching off at 0 W and falling asleep (see
   [MIN_DC_OUTPUT](ct002.md#dc-battery-keep-alive)). Only shown for DC batteries

--- a/docs/mqtt-insights.md
+++ b/docs/mqtt-insights.md
@@ -330,10 +330,11 @@ controls are available to any MQTT client:
   keep them efficient. `100 %` is neutral; `0 %` skips a battery (parked while
   limiting, but still used when all batteries are needed); in between gives it
   proportionally less, since a battery holds each turn for that fraction of
-  `EFFICIENCY_ROTATION_INTERVAL`. Two batteries you want to take turns in a 1:2
-  ratio can be set to `50 %` and `100 %`: with the default 15-minute interval that
-  is roughly 7 minutes against 15. Separate from **Distribution Weight** (which
-  biases the split among active batteries).
+  [EFFICIENCY_ROTATION_INTERVAL](ct002.md#battery-efficiency-optimization). Two
+  batteries you want to take turns in a 1:2 ratio can be set to `50 %` and
+  `100 %`: with the default 15-minute interval that is roughly 7 minutes against
+  15. Separate from **Distribution Weight** (which biases the split among active
+  batteries).
 - **Min DC Output** — minimum discharge in watts to keep this battery's inverter
   from switching off at 0 W and falling asleep (see
   [MIN_DC_OUTPUT](ct002.md#dc-battery-keep-alive)). Only shown for DC batteries

--- a/docs/mqtt-insights.md
+++ b/docs/mqtt-insights.md
@@ -334,10 +334,10 @@ controls are available to any MQTT client:
   batteries you want to take turns in a 1:2 ratio can be set to `50 %` and
   `100 %`: with the default 15-minute interval that is 7.5 minutes against 15.
   This applies while demand runs one battery at a time; once several run at once
-  every turn is a full interval again, and **Distribution Weight** is what splits
-  the load among them. Very small weights flatten out — `10 %` against `100 %`
-  lands nearer 8:1 than 10:1 — because each handover costs a little settling
-  time.
+  every turn is a full interval again (only `0 %` still parks a battery), and
+  **Distribution Weight** is what splits the load among them. Very small weights
+  fall a little short of their ratio, because each handover costs the balancer a
+  moment to settle.
 - **Min DC Output** — minimum discharge in watts to keep this battery's inverter
   from switching off at 0 W and falling asleep (see
   [MIN_DC_OUTPUT](ct002.md#dc-battery-keep-alive)). Only shown for DC batteries

--- a/docs/mqtt-insights.md
+++ b/docs/mqtt-insights.md
@@ -333,8 +333,11 @@ controls are available to any MQTT client:
   [EFFICIENCY_ROTATION_INTERVAL](ct002.md#battery-efficiency-optimization). Two
   batteries you want to take turns in a 1:2 ratio can be set to `50 %` and
   `100 %`: with the default 15-minute interval that is 7.5 minutes against 15.
-  Separate from **Distribution Weight** (which biases the split among active
-  batteries).
+  This applies while demand runs one battery at a time; once several run at once
+  every turn is a full interval again, and **Distribution Weight** is what splits
+  the load among them. Very small weights flatten out — `10 %` against `100 %`
+  lands nearer 8:1 than 10:1 — because each handover costs a little settling
+  time.
 - **Min DC Output** — minimum discharge in watts to keep this battery's inverter
   from switching off at 0 W and falling asleep (see
   [MIN_DC_OUTPUT](ct002.md#dc-battery-keep-alive)). Only shown for DC batteries

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -1783,8 +1783,8 @@ void LoadBalancer::sync_pool_(const ReportMap &reports, double grace) {
   // weight here would make it a permanent rank: the heaviest battery would
   // retake the head on the poll after every rotation, saturation swap and
   // forced rotation, and a lighter one would never hold its slot for the window
-  // rotate_priority_head_ scales for it (issue #647). Past the fill, the order
-  // is the rotation's to own.
+  // the head-rotation block in compute_efficiency_deprioritized_ scales for it
+  // (issue #647). Past the fill, the order is the rotation's to own.
   std::unordered_set<std::string> current;
   for (const auto &r : reports) current.insert(r.first);
   this->priority_.erase(std::remove_if(this->priority_.begin(), this->priority_.end(),

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -928,6 +928,8 @@ void LoadBalancer::reset_consumer(const std::string &consumer_id) {
 }
 
 void LoadBalancer::force_rotation(const std::unordered_set<std::string> &current_pool) {
+  // Unlike sync_pool_, this is handed ids without reports, so it cannot read
+  // weights: the members it appends stay in id order rather than heaviest-first.
   std::vector<std::string> new_priority;
   for (const auto &cid : this->priority_) {
     if (current_pool.find(cid) != current_pool.end()) new_priority.push_back(cid);
@@ -1665,8 +1667,7 @@ std::unordered_map<std::string, float> LoadBalancer::compute_efficiency_depriori
   const bool probe_active = this->probe_state_.has_value();
 
   // The active head holds its slot for efficiency_rotation_interval scaled by
-  // its efficiency window weight, so a lower-weight battery rotates out sooner
-  // (weight 0 -> threshold 0 -> rotates out on the next tick).
+  // its efficiency window weight, so a lower-weight battery rotates out sooner.
   //
   // The weight only scales the window while a *single* battery holds the
   // rotating slot, which is the case it describes. With several slots active a
@@ -1796,8 +1797,6 @@ void LoadBalancer::sync_pool_(const ReportMap &reports, double grace) {
   // deliberately), and a lighter one would never hold its slot for the window
   // the head-rotation block in compute_efficiency_deprioritized_ scales for it
   // (issue #647). Past the fill, the order is the rotation's to own.
-  // (force_rotation is handed ids without reports, so the arrivals it appends
-  // stay in id order.)
   std::unordered_set<std::string> current;
   for (const auto &r : reports) current.insert(r.first);
   this->priority_.erase(std::remove_if(this->priority_.begin(), this->priority_.end(),

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -1774,11 +1774,17 @@ std::unordered_map<std::string, float> LoadBalancer::compute_efficiency_depriori
 }
 
 void LoadBalancer::sync_pool_(const ReportMap &reports, double grace) {
-  // Drop departed consumers, append new arrivals (in id order, each with a
-  // settling grace), then sink low/zero efficiency-window-weight batteries to
-  // the back so they fall into the deprioritized tail first while limiting. A
-  // *stable* descending sort preserves the fair-wear rotation cycle within each
-  // weight tier.
+  // Drop departed consumers, then append new arrivals - heaviest efficiency
+  // window first, ties by id - each with a settling grace, so a fresh pool
+  // starts limiting from the battery with the most active time to give.
+  //
+  // Only a *zero*-weight battery is sunk to the back, and on every sync, so
+  // parking one takes effect as soon as its weight is set. Ordering the rest by
+  // weight here would make it a permanent rank: the heaviest battery would
+  // retake the head on the poll after every rotation, saturation swap and
+  // forced rotation, and a lighter one would never hold its slot for the window
+  // rotate_priority_head_ scales for it (issue #647). Past the fill, the order
+  // is the rotation's to own.
   std::unordered_set<std::string> current;
   for (const auto &r : reports) current.insert(r.first);
   this->priority_.erase(std::remove_if(this->priority_.begin(), this->priority_.end(),
@@ -1789,20 +1795,28 @@ void LoadBalancer::sync_pool_(const ReportMap &reports, double grace) {
     if (current.count(d)) new_dep.insert(d);
   this->deprioritized_ = std::move(new_dep);
 
-  std::vector<std::string> sorted_current(current.begin(), current.end());
-  std::sort(sorted_current.begin(), sorted_current.end());
-  for (const auto &cid : sorted_current) {
+  std::vector<std::string> arrivals;
+  for (const auto &cid : current) {
     if (std::find(this->priority_.begin(), this->priority_.end(), cid) ==
-        this->priority_.end()) {
-      this->priority_.push_back(cid);
-      this->set_consumer_grace_(cid, grace);
-    }
+        this->priority_.end())
+      arrivals.push_back(cid);
+  }
+  std::sort(arrivals.begin(), arrivals.end(),
+            [&](const std::string &a, const std::string &b) {
+              const float wa = efficiency_window_weight_of(reports, a);
+              const float wb = efficiency_window_weight_of(reports, b);
+              if (wa != wb) return wa > wb;
+              return a < b;
+            });
+  for (const auto &cid : arrivals) {
+    this->priority_.push_back(cid);
+    this->set_consumer_grace_(cid, grace);
   }
 
   std::stable_sort(this->priority_.begin(), this->priority_.end(),
                    [&](const std::string &a, const std::string &b) {
-                     return efficiency_window_weight_of(reports, a) >
-                            efficiency_window_weight_of(reports, b);
+                     return (efficiency_window_weight_of(reports, a) <= 0.0f) <
+                            (efficiency_window_weight_of(reports, b) <= 0.0f);
                    });
 }
 

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -1677,10 +1677,14 @@ std::unordered_map<std::string, float> LoadBalancer::compute_efficiency_depriori
   // one slot every turn is a full interval. Parking is unaffected either way: a
   // 0 weight is sunk to the tail by sync_pool_, not by this window.
   if (!probe_active && !probe_resolved && !this->priority_.empty()) {
+    // A zero weight at the head falls back to a full window too: parking is
+    // sync_pool_'s job, so the head is only ever 0 when every battery is
+    // parked, and a 0 threshold would then hand the slot on at every poll the
+    // probe machinery leaves free.
+    const float configured =
+        efficiency_window_weight_of(reports, this->priority_.front());
     const float head_weight =
-        prev_slots <= 1
-            ? efficiency_window_weight_of(reports, this->priority_.front())
-            : 1.0f;
+        (prev_slots <= 1 && configured > 0.0f) ? configured : 1.0f;
     if ((now - this->last_rotation_) >=
         cfg.efficiency_rotation_interval * head_weight) {
       this->last_rotation_ = now;

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -1791,8 +1791,9 @@ void LoadBalancer::sync_pool_(const ReportMap &reports, double grace) {
   // Only a *zero*-weight battery is sunk to the back, and on every sync, so
   // parking one takes effect as soon as its weight is set. Ordering the rest by
   // weight here would make it a permanent rank: the heaviest battery would
-  // retake the head on the poll after every rotation, saturation swap and
-  // forced rotation, and a lighter one would never hold its slot for the window
+  // retake the head on the poll after every rotation, saturation swap, forced
+  // rotation and probe rejection (each of which rewrites the order
+  // deliberately), and a lighter one would never hold its slot for the window
   // the head-rotation block in compute_efficiency_deprioritized_ scales for it
   // (issue #647). Past the fill, the order is the rotation's to own.
   // (force_rotation is handed ids without reports, so the arrivals it appends

--- a/esphome/components/ct002/balancer.cpp
+++ b/esphome/components/ct002/balancer.cpp
@@ -1667,9 +1667,19 @@ std::unordered_map<std::string, float> LoadBalancer::compute_efficiency_depriori
   // The active head holds its slot for efficiency_rotation_interval scaled by
   // its efficiency window weight, so a lower-weight battery rotates out sooner
   // (weight 0 -> threshold 0 -> rotates out on the next tick).
+  //
+  // The weight only scales the window while a *single* battery holds the
+  // rotating slot, which is the case it describes. With several slots active a
+  // battery is active for its own turn and its predecessors', so weighting the
+  // head's turn spreads equally weighted batteries unevenly instead (three at
+  // 1.0/1.0/0.25 with two slots measured 28/44/28 % of the active time). Above
+  // one slot every turn is a full interval. Parking is unaffected either way: a
+  // 0 weight is sunk to the tail by sync_pool_, not by this window.
   if (!probe_active && !probe_resolved && !this->priority_.empty()) {
     const float head_weight =
-        efficiency_window_weight_of(reports, this->priority_.front());
+        prev_slots <= 1
+            ? efficiency_window_weight_of(reports, this->priority_.front())
+            : 1.0f;
     if ((now - this->last_rotation_) >=
         cfg.efficiency_rotation_interval * head_weight) {
       this->last_rotation_ = now;
@@ -1785,6 +1795,8 @@ void LoadBalancer::sync_pool_(const ReportMap &reports, double grace) {
   // forced rotation, and a lighter one would never hold its slot for the window
   // the head-rotation block in compute_efficiency_deprioritized_ scales for it
   // (issue #647). Past the fill, the order is the rotation's to own.
+  // (force_rotation is handed ids without reports, so the arrivals it appends
+  // stay in id order.)
   std::unordered_set<std::string> current;
   for (const auto &r : reports) current.insert(r.first);
   this->priority_.erase(std::remove_if(this->priority_.begin(), this->priority_.end(),

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -2596,17 +2596,21 @@ class LoadBalancer:
         Parking a battery is unaffected either way: a 0 weight is sunk to the
         tail by :meth:`_sync_pool`, not by this window.
 
+        A zero weight at the head falls back to a full window too.  Parking is
+        :meth:`_sync_pool`'s job, so the head is only ever a 0 when *every*
+        battery is parked — and then there is no preference left to express,
+        while a 0 threshold would hand the slot on at every poll the probe
+        machinery leaves free (measured at roughly every 46 s against the
+        900 s interval).
+
         *active_slots* is the count the previous poll settled on, so the first
         poll after a pool narrows to one slot still gets a full window; the
         threshold is re-checked every poll, so it corrects on the next one.
         """
         if not self._priority:
             return
-        head_weight = (
-            _report_of(reports, self._priority[0]).efficiency_window_weight
-            if active_slots <= 1
-            else 1.0
-        )
+        configured = _report_of(reports, self._priority[0]).efficiency_window_weight
+        head_weight = configured if active_slots <= 1 and configured > 0.0 else 1.0
         if now - self._last_rotation < self._cfg.efficiency_rotation_interval * (
             head_weight
         ):

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -2402,21 +2402,31 @@ class LoadBalancer:
     def _sync_pool(self, reports: Reports, grace: float) -> None:
         """Reconcile the rotation order with the reporting pool.
 
-        Drops departed consumers, appends new arrivals (in id order, each with a
-        settling grace), then sinks low-weight batteries to the back so they fall
-        into the deprioritized tail first while limiting; the *stable* sort
-        preserves the fair-wear rotation cycle within each weight tier.
+        Drops departed consumers, then appends new arrivals — heaviest
+        efficiency window first, ties by id — each with a settling grace, so a
+        fresh pool starts limiting from the battery with the most active time
+        to give.
+
+        Only a *zero*-weight battery is sunk to the back, and on every sync, so
+        parking one takes effect as soon as its weight is set.  Ordering the
+        rest by weight here would make it a permanent rank: the heaviest
+        battery would retake the head on the poll after every rotation,
+        saturation swap and forced rotation, and a lighter one would never hold
+        its slot for the window :meth:`_rotate_priority_head` scales for it
+        (issue #647).  Past the fill, the order is the rotation's to own.
         """
         current = set(reports)
         self._priority = [c for c in self._priority if c in current]
         self._deprioritized.intersection_update(current)
-        for cid in sorted(current):
-            if cid not in self._priority:
-                self._priority.append(cid)
-                self._set_consumer_grace(cid, grace)
+        arrivals = sorted(
+            (c for c in current if c not in self._priority),
+            key=lambda cid: (-_report_of(reports, cid).efficiency_window_weight, cid),
+        )
+        for cid in arrivals:
+            self._priority.append(cid)
+            self._set_consumer_grace(cid, grace)
         self._priority.sort(
-            key=lambda cid: _report_of(reports, cid).efficiency_window_weight,
-            reverse=True,
+            key=lambda cid: _report_of(reports, cid).efficiency_window_weight <= 0.0
         )
 
     def _demand_estimate(self, reports: Reports, grid_total: float) -> float:

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -1501,7 +1501,13 @@ class LoadBalancer:
     # ------------------------------------------------------------------
 
     def force_rotation(self, current_pool: set[str]) -> None:
-        """Manually rotate priority order."""
+        """Manually rotate priority order.
+
+        Unlike :meth:`_sync_pool`, this is handed ids without reports, so it
+        cannot read weights: the members it appends stay in id order rather than
+        heaviest-first.  Only the fill differs — the rotation it forces is what
+        the caller asked for either way.
+        """
         self._priority = [cid for cid in self._priority if cid in current_pool]
         for cid in sorted(current_pool):
             if cid not in self._priority:
@@ -2407,8 +2413,7 @@ class LoadBalancer:
         Drops departed consumers, then appends new arrivals — heaviest
         efficiency window first, ties by id — each with a settling grace, so a
         fresh pool starts limiting from the battery with the most active time
-        to give.  (:meth:`force_rotation` is handed ids without reports, so the
-        arrivals it appends stay in id order.)
+        to give.
 
         Only a *zero*-weight battery is sunk to the back, and on every sync, so
         parking one takes effect as soon as its weight is set.  Ordering the
@@ -2578,7 +2583,7 @@ class LoadBalancer:
 
         The head holds its slot for ``efficiency_rotation_interval`` scaled by
         its efficiency window weight, so a lower-weight battery rotates out
-        sooner — weight 0 means a threshold of 0, i.e. out on the next tick.
+        sooner.
 
         The weight only scales the window while a *single* battery holds the
         rotating slot, which is the case it describes: "this battery takes that
@@ -2590,6 +2595,10 @@ class LoadBalancer:
         rotates the pool evenly and leaves fair wear to mean what it says.
         Parking a battery is unaffected either way: a 0 weight is sunk to the
         tail by :meth:`_sync_pool`, not by this window.
+
+        *active_slots* is the count the previous poll settled on, so the first
+        poll after a pool narrows to one slot still gets a full window; the
+        threshold is re-checked every poll, so it corrects on the next one.
         """
         if not self._priority:
             return

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -2412,7 +2412,8 @@ class LoadBalancer:
         parking one takes effect as soon as its weight is set.  Ordering the
         rest by weight here would make it a permanent rank: the heaviest
         battery would retake the head on the poll after every rotation,
-        saturation swap and forced rotation, and a lighter one would never hold
+        saturation swap, forced rotation and probe rejection (each of which
+        rewrites the order deliberately), and a lighter one would never hold
         its slot for the window :meth:`_rotate_priority_head` scales for it
         (issue #647).  Past the fill, the order is the rotation's to own.
         """
@@ -2506,7 +2507,7 @@ class LoadBalancer:
         # Both checks run BEFORE the cache lookup, because either can make the
         # cached active set stale.
         if not probing:
-            self._rotate_priority_head(reports, now)
+            self._rotate_priority_head(reports, now, prev_slots)
             if self._active_slot_saturated(prev_slots):
                 self._invalidate_efficiency_cache()
 
@@ -2568,16 +2569,33 @@ class LoadBalancer:
         self._cache_result = result
         return result
 
-    def _rotate_priority_head(self, reports: Reports, now: float) -> None:
+    def _rotate_priority_head(
+        self, reports: Reports, now: float, active_slots: int
+    ) -> None:
         """Send the longest-serving active battery to the back of the queue.
 
         The head holds its slot for ``efficiency_rotation_interval`` scaled by
         its efficiency window weight, so a lower-weight battery rotates out
         sooner — weight 0 means a threshold of 0, i.e. out on the next tick.
+
+        The weight only scales the window while a *single* battery holds the
+        rotating slot, which is the case it describes: "this battery takes that
+        fraction of the active time".  With several slots active a battery is
+        active for its own turn *and* its predecessors', so weighting the head's
+        turn spreads *equally* weighted batteries unevenly instead — three at
+        1.0 / 1.0 / 0.25 with two slots measured 28 / 44 / 28 % of the active
+        time.  Above one slot every turn is therefore a full interval, which
+        rotates the pool evenly and leaves fair wear to mean what it says.
+        Parking a battery is unaffected either way: a 0 weight is sunk to the
+        tail by :meth:`_sync_pool`, not by this window.
         """
         if not self._priority:
             return
-        head_weight = _report_of(reports, self._priority[0]).efficiency_window_weight
+        head_weight = (
+            _report_of(reports, self._priority[0]).efficiency_window_weight
+            if active_slots <= 1
+            else 1.0
+        )
         if now - self._last_rotation < self._cfg.efficiency_rotation_interval * (
             head_weight
         ):

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -67,8 +67,10 @@ class ConsumerReport:
     """Fair-share weight. ``0.0`` parks the battery; the setter bounds it to [0, 10]."""
 
     efficiency_window_weight: float = 1.0
-    """Fraction of ``efficiency_rotation_interval`` an active slot is held for,
-    clamped to [0, 1]. ``0.0`` rotates out on the next tick."""
+    """Fraction of ``efficiency_rotation_interval`` the rotating slot is held
+    for, clamped to [0, 1]; applied only while a single battery is active (see
+    :meth:`LoadBalancer._rotate_priority_head`). ``0.0`` parks the battery, by
+    way of :meth:`LoadBalancer._sync_pool` sinking it to the tail."""
 
     min_dc_output: float | None = None
     """Per-device MIN_DC_OUTPUT override in watts; ``None`` uses the global rule."""

--- a/src/astrameter/ct002/balancer.py
+++ b/src/astrameter/ct002/balancer.py
@@ -2405,7 +2405,8 @@ class LoadBalancer:
         Drops departed consumers, then appends new arrivals — heaviest
         efficiency window first, ties by id — each with a settling grace, so a
         fresh pool starts limiting from the battery with the most active time
-        to give.
+        to give.  (:meth:`force_rotation` is handed ids without reports, so the
+        arrivals it appends stay in id order.)
 
         Only a *zero*-weight battery is sunk to the back, and on every sync, so
         parking one takes effect as soon as its weight is set.  Ordering the

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -267,8 +267,9 @@ class Consumer:
     # Per-battery weight ([0, 1], neutral 1.0) scaling how much of the efficiency
     # rotation window this battery participates in: 1.0 = full participation,
     # 0.0 = skipped for efficiency (parked while limiting), intermediate =
-    # proportionally less active time / wear.  Tuned live via the MQTT
-    # "Efficiency Window Weight" entity.
+    # proportionally less active time / wear while low demand runs one battery
+    # at a time (above one active slot every turn is a full window).  Tuned live
+    # via the MQTT "Efficiency Window Weight" entity.
     efficiency_window_weight: float = 1.0
     # Per-device override (W) for the MIN_DC_OUTPUT wake floor; ``None`` inherits
     # the global setting.  Tuned live via the MQTT "Min DC Output" entity.
@@ -612,7 +613,8 @@ class CT002:
         participation in efficiency rotation); 0.0 skips the battery for
         efficiency (parked while limiting, as long as enough non-zero-weight
         batteries can fill the active slots); intermediate values give it
-        proportionally less active time.
+        proportionally less active time while low demand runs one battery at a
+        time; above one active slot every turn is a full window.
         """
         value = float(weight)
         if not math.isfinite(value) or not (0.0 <= value <= 1.0):

--- a/src/astrameter/mqtt_insights/discovery.py
+++ b/src/astrameter/mqtt_insights/discovery.py
@@ -377,7 +377,8 @@ def build_ct002_consumer_discovery(
     # Efficiency window weight — how much of the efficiency rotation window this
     # battery participates in, as a percentage.  100 % is neutral (full
     # participation); 0 % skips the battery for efficiency (parked while
-    # limiting); intermediate values give it proportionally less active time.
+    # limiting); intermediate values give it proportionally less active time
+    # while low demand runs one battery at a time.
     # Surfaced as a percentage; the internal value is a 0-1 fraction.  Only
     # meaningful when efficiency rotation is enabled (``min_efficient_power >
     # 0``); without it every battery stays active, so don't surface the entity.

--- a/tests/components/ct002/test_balancer_parity.py
+++ b/tests/components/ct002/test_balancer_parity.py
@@ -374,6 +374,28 @@ def _scenario_efficiency_window_weight() -> list[str]:
         lines.append("advance 1")
         lines.append("last x")
         lines.append("last y")
+    # Unequal non-zero weights (issue #647): the lighter unit holds the head for
+    # its own shorter window rather than being re-ranked behind the heavier one
+    # on every poll, so the two stacks have to agree on a rotation order that no
+    # longer follows from the weights alone.
+    uneven = [
+        _report("x", "A", 0, eff_weight=0.5),
+        _report("y", "A", 0, eff_weight=1.0),
+    ]
+    for _ in range(3):
+        lines.append(_target("x", uneven, grid=120))
+        lines.append(_target("y", uneven, grid=120))
+        lines.append("advance 1")
+    # Past "y"'s full window, then past "x"'s half window, then past a second
+    # full one: three handovers, each read back on both stacks.
+    for step in (910, 460, 910):
+        lines.append(f"advance {step}")
+        for _ in range(3):
+            lines.append(_target("x", uneven, grid=120))
+            lines.append(_target("y", uneven, grid=120))
+            lines.append("advance 1")
+            lines.append("last x")
+            lines.append("last y")
     return lines
 
 

--- a/tests/components/ct002/test_balancer_parity.py
+++ b/tests/components/ct002/test_balancer_parity.py
@@ -412,6 +412,36 @@ def _scenario_efficiency_window_weight() -> list[str]:
         lines.append("advance 1")
         lines.append("last a")
         lines.append("last b")
+    # Three units reporting 80 W against a 10 W grid: demand 250 over a
+    # min_efficient_power of 100 keeps *two* slots active, and a real reported
+    # power keeps the stall detector out of the rotation. Cycling far enough for
+    # the 0.25-weight unit to take the head twice is what discriminates: above
+    # one slot its turn must be a full interval on both stacks, not a quarter of
+    # one, or the two rotations drift apart at that handover.
+    trio = [
+        _report("p", "A", 80, eff_weight=1.0),
+        _report("q", "A", 80, eff_weight=1.0),
+        _report("r", "A", 80, eff_weight=0.25),
+    ]
+    # The demand estimate is an EMA that only advances when the sample changes,
+    # so the grid alternates to keep it climbing to the ~250 that limits three
+    # units to two slots. Warm it up first, then two full windows bring the
+    # 0.25-weight unit to the head; the 400 s step is the discriminator, sitting
+    # between the quarter-window (225 s) an ungated head would rotate on and the
+    # full one it has to hold once more than one battery is active.
+    grids = (10, 12)
+    for warm in range(24):
+        for cid in ("p", "q", "r"):
+            lines.append(_target(cid, trio, grid=grids[warm % 2]))
+        lines.append("advance 1")
+    for idx, step in enumerate((910, 910, 400, 910, 910, 400)):
+        lines.append(f"advance {step}")
+        for k in range(3):
+            for cid in ("p", "q", "r"):
+                lines.append(_target(cid, trio, grid=grids[(idx + k) % 2]))
+            lines.append("advance 1")
+            for cid in ("p", "q", "r"):
+                lines.append(f"last {cid}")
     return lines
 
 

--- a/tests/components/ct002/test_balancer_parity.py
+++ b/tests/components/ct002/test_balancer_parity.py
@@ -345,8 +345,10 @@ def _scenario_efficiency_lifecycle() -> list[str]:
 
 def _scenario_efficiency_window_weight() -> list[str]:
     """Per-battery efficiency-window weight: a parked unit (0) stays
-    deprioritized while limiting, and a half-weight head rotates out at half the
-    interval. Both stacks must agree poll-by-poll on the resulting targets."""
+    deprioritized while limiting, a half-weight head rotates out at half the
+    interval, unequal non-zero weights hand each unit a proportional turn, and a
+    fresh pool fills heaviest-first even when that contradicts id order. Both
+    stacks must agree poll-by-poll on the resulting targets."""
     lines = [_CFG_EFFICIENCY, "clock 5000"]
     # "y" is parked for efficiency (weight 0); under low demand it must stay
     # deprioritized while "x" carries the load.
@@ -396,6 +398,20 @@ def _scenario_efficiency_window_weight() -> list[str]:
             lines.append("advance 1")
             lines.append("last x")
             lines.append("last y")
+    # A brand-new pool whose id order contradicts its weight order: "a" sorts
+    # first by id but must arrive behind the heavier "b". Dropping x/y from the
+    # reports retires them, so both stacks fill the order from scratch and have
+    # to break the tie the same way round.
+    fresh = [
+        _report("a", "A", 0, eff_weight=0.5),
+        _report("b", "A", 0, eff_weight=1.0),
+    ]
+    for _ in range(4):
+        lines.append(_target("a", fresh, grid=120))
+        lines.append(_target("b", fresh, grid=120))
+        lines.append("advance 1")
+        lines.append("last a")
+        lines.append("last b")
     return lines
 
 

--- a/tests/components/ct002/test_balancer_parity.py
+++ b/tests/components/ct002/test_balancer_parity.py
@@ -442,6 +442,30 @@ def _scenario_efficiency_window_weight() -> list[str]:
             lines.append("advance 1")
             for cid in ("p", "q", "r"):
                 lines.append(f"last {cid}")
+    # Every battery parked: the sink has no one to promote, so a 0 weight
+    # reaches the head and both stacks have to agree on what an all-zero pool
+    # does. This pins that agreement, not the full-window fallback itself —
+    # with these reports the probe and saturation machinery owns the ordering
+    # here, so removing the fallback from one stack alone does not part them.
+    # The fallback is pinned on the Python side by
+    # test_all_zero_weight_pool_rotates_on_the_normal_interval.
+    parked_all = [
+        _report("m", "A", 0, eff_weight=0.0),
+        _report("n", "A", 0, eff_weight=0.0),
+    ]
+    for _ in range(6):
+        lines.append(_target("m", parked_all, grid=120))
+        lines.append(_target("n", parked_all, grid=120))
+        lines.append("advance 30")
+        lines.append("last m")
+        lines.append("last n")
+    lines.append("advance 910")
+    for _ in range(3):
+        lines.append(_target("m", parked_all, grid=120))
+        lines.append(_target("n", parked_all, grid=120))
+        lines.append("advance 1")
+        lines.append("last m")
+        lines.append("last n")
     return lines
 
 

--- a/tests/test_balancer_efficiency_window_weight.py
+++ b/tests/test_balancer_efficiency_window_weight.py
@@ -89,12 +89,16 @@ def test_zero_weight_battery_runs_when_all_needed() -> None:
     assert lb._deprioritized == set()
 
 
-def test_low_weight_battery_sinks_below_alphabetical_order() -> None:
-    """The weight sort overrides the alphabetical fill order."""
+def test_low_weight_battery_arrives_behind_a_heavier_peer() -> None:
+    """Weight decides the fill order of a fresh pool, over the id order.
+
+    Only the *fill* — once both are in the order, the rotation owns it (see
+    ``test_weight_sort_does_not_re_pin_the_head_every_tick``).
+    """
     clock = _FakeClock()
     lb = _make_balancer(clock)
-    # "a" sorts first alphabetically but has the lower weight, so it must end up
-    # behind "b" once the descending-by-weight stable sort runs.
+    # "a" sorts first by id but has the lower weight, so it must arrive behind
+    # "b" and be the one deprioritized on the first limiting poll.
     reports = {"a": _report(0.0, 0.2), "b": _report(0.0, 1.0)}
     clock.advance(1.0)
     lb._compute_efficiency_deprioritized(reports, (0,), 200.0)
@@ -143,15 +147,25 @@ def test_half_weight_head_rotates_after_half_interval() -> None:
     assert lb._last_rotation > rot0
 
 
+# A battery polls every second or so in the field.  The share each one ends up
+# with is only a clean ratio when the poll step is small against the rotation
+# interval: each handover costs a poll or two of probe settling, so at a coarse
+# step that overhead is a visible slice of every turn and the measured ratio
+# swings with where the run happens to stop (at a 60 s step the same 0.5 / 1.0
+# pool reads anywhere from 1.62 to 2.00 depending only on the horizon).  10 s is
+# fine-grained enough to be stable and still cheap to run.
+_POLL_STEP_S = 10.0
+
+
 def _run_rotation(
     lb: LoadBalancer,
     clock: _FakeClock,
     weights: dict[str, float],
     *,
-    minutes: int,
+    hours: float,
     load: float = 200.0,
-) -> dict[str, int]:
-    """Minutes each battery spends active over *minutes* one-minute polls.
+) -> dict[str, float]:
+    """Seconds each battery spends active over *hours* of polling.
 
     Feeds the balancer back what its own decision implies: whoever holds an
     active slot reports its share of *load* on the next poll, and a
@@ -160,17 +174,17 @@ def _run_rotation(
     probe hunting instead of leaving the rotation to run.
     """
     power = dict.fromkeys(weights, load / len(weights))
-    active_minutes = dict.fromkeys(weights, 0)
-    for i in range(minutes):
-        clock.advance(60.0)
+    active_seconds = dict.fromkeys(weights, 0.0)
+    for i in range(int(hours * 3600 / _POLL_STEP_S)):
+        clock.advance(_POLL_STEP_S)
         reports = {cid: _report(power[cid], weights[cid]) for cid in weights}
         deprioritized = lb._compute_efficiency_deprioritized(reports, (i,), 0.0)
         active = [cid for cid in weights if cid not in deprioritized]
         for cid in weights:
             power[cid] = load / len(active) if cid in active else 0.0
         for cid in active:
-            active_minutes[cid] += 1
-    return active_minutes
+            active_seconds[cid] += _POLL_STEP_S
+    return active_seconds
 
 
 def test_unequal_weights_split_active_time_in_proportion() -> None:
@@ -185,7 +199,7 @@ def test_unequal_weights_split_active_time_in_proportion() -> None:
     clock = _FakeClock()
     lb = _make_balancer(clock, rotation_interval=900.0)
 
-    active = _run_rotation(lb, clock, {"small": 0.5, "large": 1.0}, minutes=120)
+    active = _run_rotation(lb, clock, {"small": 0.5, "large": 1.0}, hours=6)
 
     assert active["small"] > 0
     assert 1.8 <= active["large"] / active["small"] <= 2.2
@@ -196,9 +210,9 @@ def test_equal_weights_split_active_time_evenly() -> None:
     clock = _FakeClock()
     lb = _make_balancer(clock, rotation_interval=900.0)
 
-    active = _run_rotation(lb, clock, {"a": 1.0, "b": 1.0}, minutes=120)
+    active = _run_rotation(lb, clock, {"a": 1.0, "b": 1.0}, hours=6)
 
-    assert 0.8 <= active["a"] / active["b"] <= 1.2
+    assert 0.9 <= active["a"] / active["b"] <= 1.1
 
 
 def test_weight_sort_does_not_re_pin_the_head_every_tick() -> None:
@@ -227,3 +241,54 @@ def test_weight_sort_does_not_re_pin_the_head_every_tick() -> None:
     clock.advance(60.0)
     lb._compute_efficiency_deprioritized(reports, (2,), 200.0)
     assert lb._priority[0] == "a"
+
+
+def test_saturation_swap_is_not_undone_by_the_weight_order() -> None:
+    """A saturated battery handed over must stay handed over.
+
+    The swap puts a healthy battery in the active slot; re-ranking the pool by
+    weight on the next poll would drag the saturated one — heavier here — back
+    to the head, and it would be reinstated on every poll for good.
+    """
+    clock = _FakeClock()
+    lb = _make_balancer(clock, rotation_interval=900.0)
+    reports = {"heavy": _report(0.0, 1.0), "light": _report(0.0, 0.5)}
+
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(reports, (0,), 200.0)
+    assert lb._priority[0] == "heavy"
+
+    # "heavy" stops following its target; the swap hands the slot to "light".
+    lb._get_consumer("heavy").saturation_score = 1.0
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(reports, (1,), 200.0)
+    assert lb._priority[0] == "light"
+
+    # It has to still be "light" on the polls that follow.
+    for i in range(2, 5):
+        clock.advance(1.0)
+        lb._compute_efficiency_deprioritized(reports, (i,), 200.0)
+        assert lb._priority[0] == "light"
+
+
+def test_force_rotation_is_not_undone_by_the_weight_order() -> None:
+    """A hand-forced rotation survives the next poll.
+
+    ``force_rotation`` is the dashboard's "rotate now" button, so a pool whose
+    weights differ must not snap straight back to the battery it rotated away
+    from.
+    """
+    clock = _FakeClock()
+    lb = _make_balancer(clock, rotation_interval=900.0)
+    reports = {"heavy": _report(0.0, 1.0), "light": _report(0.0, 0.5)}
+
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(reports, (0,), 200.0)
+    assert lb._priority[0] == "heavy"
+
+    lb.force_rotation(set(reports))
+    assert lb._priority[0] == "light"
+
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(reports, (1,), 200.0)
+    assert lb._priority[0] == "light"

--- a/tests/test_balancer_efficiency_window_weight.py
+++ b/tests/test_balancer_efficiency_window_weight.py
@@ -151,9 +151,9 @@ def test_half_weight_head_rotates_after_half_interval() -> None:
 # with is only a clean ratio when the poll step is small against the rotation
 # interval: each handover costs a poll or two of probe settling, so at a coarse
 # step that overhead is a visible slice of every turn and the measured ratio
-# swings with where the run happens to stop (at a 60 s step the same 0.5 / 1.0
-# pool reads anywhere from 1.62 to 2.00 depending only on the horizon).  10 s is
-# fine-grained enough to be stable and still cheap to run.
+# swings with where the run happens to stop: sweeping 60-480 polls at a 60 s
+# step, the same 0.5 / 1.0 pool reads anywhere from 1.62 to 2.25 on horizon
+# alone.  10 s is fine-grained enough to be stable and still cheap to run.
 _POLL_STEP_S = 10.0
 
 
@@ -303,7 +303,8 @@ def test_three_batteries_split_active_time_by_weight() -> None:
     total = sum(active.values())
     share = {cid: secs / total for cid, secs in active.items()}
 
-    # Ideal 0.571 / 0.286 / 0.143; the handover overhead costs each a little.
+    # Ideal 0.571 / 0.286 / 0.143.  Each handover costs a little settling time,
+    # which comes off the longest turn and slightly flatters the shortest.
     assert 0.53 <= share["big"] <= 0.61
     assert 0.25 <= share["mid"] <= 0.32
     assert 0.12 <= share["small"] <= 0.18

--- a/tests/test_balancer_efficiency_window_weight.py
+++ b/tests/test_balancer_efficiency_window_weight.py
@@ -465,13 +465,14 @@ def test_departing_battery_leaves_the_rotation_order_alone() -> None:
     assert "heavy" not in lb._deprioritized
 
 
-def test_all_zero_weight_pool_still_rotates() -> None:
-    """Every battery parked is not a state the pool can rest in.
+def test_all_zero_weight_pool_rotates_on_the_normal_interval() -> None:
+    """Every battery parked still rotates at the interval, not at every poll.
 
-    With nothing to promote, the zero-weight sink is a no-op and each head's
-    threshold is 0, so the pool keeps rotating.  Recorded as the behaviour
-    inherited from before the fix rather than endorsed: with every weight at 0
-    there is no battery the balancer is allowed to prefer.
+    The sink cannot promote anyone when nothing outranks anyone, so a 0 weight
+    reaches the head — the one case where it can.  Taken literally that is a 0
+    threshold and the slot changes hands on every poll the probe machinery
+    leaves free; before the fallback this pool moved roughly every 46 s against
+    a 900 s interval.
     """
     clock = _FakeClock()
     lb = _make_balancer(clock, rotation_interval=900.0)
@@ -481,6 +482,13 @@ def test_all_zero_weight_pool_still_rotates() -> None:
     lb._compute_efficiency_deprioritized(reports, (0,), 200.0)
     first = lb._priority[0]
 
-    clock.advance(1.0)
-    lb._compute_efficiency_deprioritized(reports, (1,), 200.0)
+    # Ten minutes of polling, well inside one window: the head holds.
+    for i in range(1, 600):
+        clock.advance(1.0)
+        lb._compute_efficiency_deprioritized(reports, (i,), 200.0)
+        assert lb._priority[0] == first
+
+    # Past the full interval it hands over like any other pool.
+    clock.advance(400.0)
+    lb._compute_efficiency_deprioritized(reports, (600,), 200.0)
     assert lb._priority[0] != first

--- a/tests/test_balancer_efficiency_window_weight.py
+++ b/tests/test_balancer_efficiency_window_weight.py
@@ -332,3 +332,67 @@ def test_weight_dropped_to_zero_parks_the_battery_on_the_next_poll() -> None:
     assert lb._priority[0] == "b"
     assert lb._priority[-1] == "a"
     assert lb._deprioritized == {"a"}
+
+
+def test_weights_do_not_skew_the_rotation_once_several_batteries_run() -> None:
+    """Above one active slot the rotation is even, whatever the weights.
+
+    A battery is active for its own turn *and* its predecessors', so scaling
+    each turn by the head's weight would hand two batteries weighted the same
+    very different shares as soon as a lighter third joins them.
+    """
+    clock = _FakeClock()
+    lb = _make_balancer(clock, rotation_interval=900.0)
+
+    # 400 W over three batteries leaves two active slots (400/150 -> 2).
+    active = _run_rotation(
+        lb, clock, {"a": 1.0, "b": 1.0, "c": 0.25}, hours=12, load=400.0
+    )
+    total = sum(active.values())
+    share = {cid: secs / total for cid, secs in active.items()}
+
+    # The two equally weighted batteries wear equally, and the light one is
+    # neither starved (the #647 bug) nor privileged.
+    assert abs(share["a"] - share["b"]) < 0.03
+    for cid in ("a", "b", "c"):
+        assert 0.30 <= share[cid] <= 0.37
+
+
+def test_heavier_battery_joining_a_running_pool_waits_its_turn() -> None:
+    """Arrivals go to the back, even a heavy one meeting a lighter head.
+
+    The weight fills a *fresh* order; it must not let a late arrival preempt a
+    battery that is part-way through its turn.
+    """
+    clock = _FakeClock()
+    lb = _make_balancer(clock, rotation_interval=900.0)
+    running = {"light": _report(0.0, 0.5), "mid": _report(0.0, 0.5)}
+
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(running, (0,), 200.0)
+    assert lb._priority[0] == "light"
+
+    joined = dict(running) | {"heavy": _report(0.0, 1.0)}
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(joined, (1,), 200.0)
+    assert lb._priority[0] == "light"
+    assert lb._priority[-1] == "heavy"
+
+
+def test_unparking_a_battery_puts_it_back_in_the_rotation() -> None:
+    """Raising a weight off 0 returns the battery to the rotation."""
+    clock = _FakeClock()
+    lb = _make_balancer(clock, rotation_interval=900.0)
+    parked = {"a": _report(0.0, 1.0), "b": _report(0.0, 0.0)}
+
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(parked, (0,), 200.0)
+    assert lb._deprioritized == {"b"}
+
+    # Un-parked, "b" is no longer pinned to the tail and takes the head at the
+    # end of "a"'s window.
+    running = {"a": _report(0.0, 1.0), "b": _report(0.0, 1.0)}
+    clock.advance(901.0)
+    lb._compute_efficiency_deprioritized(running, (1,), 200.0)
+    assert lb._priority[0] == "b"
+    assert lb._deprioritized == {"a"}

--- a/tests/test_balancer_efficiency_window_weight.py
+++ b/tests/test_balancer_efficiency_window_weight.py
@@ -194,7 +194,7 @@ def test_unequal_weights_split_active_time_in_proportion() -> None:
     serve.  Weights 0.5 / 1.0 are meant to hand the small one half the active
     window the large one gets; before the fix the every-poll weight sort put the
     large one straight back at the head, leaving the small one a single poll per
-    cycle (a ~14:1 split rather than 2:1).
+    cycle — 240 s against 21360 s over this run, nearer 89:1 than 2:1.
     """
     clock = _FakeClock()
     lb = _make_balancer(clock, rotation_interval=900.0)
@@ -292,3 +292,42 @@ def test_force_rotation_is_not_undone_by_the_weight_order() -> None:
     clock.advance(1.0)
     lb._compute_efficiency_deprioritized(reports, (1,), 200.0)
     assert lb._priority[0] == "light"
+
+
+def test_three_batteries_split_active_time_by_weight() -> None:
+    """Weights 1 / 0.5 / 0.25 give a 4:2:1 split of the rotation."""
+    clock = _FakeClock()
+    lb = _make_balancer(clock, rotation_interval=900.0)
+
+    active = _run_rotation(lb, clock, {"big": 1.0, "mid": 0.5, "small": 0.25}, hours=12)
+    total = sum(active.values())
+    share = {cid: secs / total for cid, secs in active.items()}
+
+    # Ideal 0.571 / 0.286 / 0.143; the handover overhead costs each a little.
+    assert 0.53 <= share["big"] <= 0.61
+    assert 0.25 <= share["mid"] <= 0.32
+    assert 0.12 <= share["small"] <= 0.18
+    assert share["big"] > share["mid"] > share["small"]
+
+
+def test_weight_dropped_to_zero_parks_the_battery_on_the_next_poll() -> None:
+    """Parking is the one thing the per-poll order still enforces.
+
+    A battery already holding the head has to be sunk as soon as its weight
+    reaches 0, rather than keeping the slot until its window happens to end.
+    """
+    clock = _FakeClock()
+    lb = _make_balancer(clock, rotation_interval=900.0)
+    running = {"a": _report(0.0, 1.0), "b": _report(0.0, 1.0)}
+
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(running, (0,), 200.0)
+    assert lb._priority[0] == "a"
+
+    # "a" is parked mid-window; "b" must take over on the very next poll.
+    parked = {"a": _report(0.0, 0.0), "b": _report(0.0, 1.0)}
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(parked, (1,), 200.0)
+    assert lb._priority[0] == "b"
+    assert lb._priority[-1] == "a"
+    assert lb._deprioritized == {"a"}

--- a/tests/test_balancer_efficiency_window_weight.py
+++ b/tests/test_balancer_efficiency_window_weight.py
@@ -5,7 +5,9 @@ active ones stay above ``min_efficient_power``) and rotates which one is active
 for fair wear. ``efficiency_window_weight`` (a report-dict field, ``[0, 1]``,
 neutral ``1.0``) biases that rotation: ``0.0`` parks a battery while limiting,
 ``1.0`` is full participation, and the active head holds its slot for
-``efficiency_rotation_interval`` scaled by its weight.
+``efficiency_rotation_interval`` scaled by its weight — the last of those only
+while a single battery is active, since above one slot a battery is active for
+its own turn and its predecessors' too.
 
 These poke the balancer internals (``_priority`` / ``_deprioritized`` /
 ``_last_rotation``) directly, matching the existing balancer unit tests. The
@@ -18,6 +20,7 @@ from astrameter.ct002.balancer import (
     BalancerConfig,
     ConsumerReport,
     LoadBalancer,
+    ProbeState,
 )
 
 
@@ -151,9 +154,10 @@ def test_half_weight_head_rotates_after_half_interval() -> None:
 # with is only a clean ratio when the poll step is small against the rotation
 # interval: each handover costs a poll or two of probe settling, so at a coarse
 # step that overhead is a visible slice of every turn and the measured ratio
-# swings with where the run happens to stop: sweeping 60-480 polls at a 60 s
-# step, the same 0.5 / 1.0 pool reads anywhere from 1.62 to 2.25 on horizon
-# alone.  10 s is fine-grained enough to be stable and still cheap to run.
+# swings with where the run happens to stop: sweeping every horizon from 60 to
+# 480 polls at a 60 s step, the same 0.5 / 1.0 pool reads anywhere from 1.60 to
+# 2.40 on horizon alone.  10 s is fine-grained enough to be stable and still
+# cheap to run.
 _POLL_STEP_S = 10.0
 
 
@@ -396,3 +400,38 @@ def test_unparking_a_battery_puts_it_back_in_the_rotation() -> None:
     lb._compute_efficiency_deprioritized(running, (1,), 200.0)
     assert lb._priority[0] == "b"
     assert lb._deprioritized == {"a"}
+
+
+def test_rejected_probe_leaves_its_candidate_at_the_back() -> None:
+    """A probe rejection sinks the battery that failed it; that has to stick.
+
+    ``_reject_probe`` rewrites the order deliberately, putting the candidate
+    last.  Re-ranking by weight on the next poll would pull it back to the head
+    when it happens to be the heaviest — re-promoting a battery that had just
+    failed to deliver.
+    """
+    clock = _FakeClock()
+    lb = _make_balancer(clock, rotation_interval=900.0)
+    reports = {"heavy": _report(0.0, 1.0), "light": _report(0.0, 0.5)}
+
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(reports, (0,), 200.0)
+    assert lb._priority[0] == "heavy"
+
+    now = clock()
+    lb._probe_state = ProbeState(
+        candidate_id="heavy",
+        active_ids=("heavy",),
+        backup_ids=("light",),
+        restore_active_ids=("light",),
+        deadline=now + 30.0,
+        started_at=now,
+    )
+    lb._reject_probe(now, "test")
+    assert lb._priority == ["light", "heavy"]
+
+    # The next polls must leave the failed candidate where the rejection put it.
+    for i in range(1, 4):
+        clock.advance(1.0)
+        lb._compute_efficiency_deprioritized(reports, (i,), 200.0)
+        assert lb._priority[0] == "light"

--- a/tests/test_balancer_efficiency_window_weight.py
+++ b/tests/test_balancer_efficiency_window_weight.py
@@ -141,3 +141,89 @@ def test_half_weight_head_rotates_after_half_interval() -> None:
     clock.advance(20.0)
     lb._compute_efficiency_deprioritized(reports, (2,), 200.0)
     assert lb._last_rotation > rot0
+
+
+def _run_rotation(
+    lb: LoadBalancer,
+    clock: _FakeClock,
+    weights: dict[str, float],
+    *,
+    minutes: int,
+    load: float = 200.0,
+) -> dict[str, int]:
+    """Minutes each battery spends active over *minutes* one-minute polls.
+
+    Feeds the balancer back what its own decision implies: whoever holds an
+    active slot reports its share of *load* on the next poll, and a
+    deprioritized battery reports 0.  A battery reporting 0 W while active
+    reads as one that cannot follow its target, which sends the efficiency
+    probe hunting instead of leaving the rotation to run.
+    """
+    power = dict.fromkeys(weights, load / len(weights))
+    active_minutes = dict.fromkeys(weights, 0)
+    for i in range(minutes):
+        clock.advance(60.0)
+        reports = {cid: _report(power[cid], weights[cid]) for cid in weights}
+        deprioritized = lb._compute_efficiency_deprioritized(reports, (i,), 0.0)
+        active = [cid for cid in weights if cid not in deprioritized]
+        for cid in weights:
+            power[cid] = load / len(active) if cid in active else 0.0
+        for cid in active:
+            active_minutes[cid] += 1
+    return active_minutes
+
+
+def test_unequal_weights_split_active_time_in_proportion() -> None:
+    """Issue #647: a half-weight battery gets half the active time, not one poll.
+
+    Two batteries in a 1:2 capacity ratio at a demand only one of them should
+    serve.  Weights 0.5 / 1.0 are meant to hand the small one half the active
+    window the large one gets; before the fix the every-poll weight sort put the
+    large one straight back at the head, leaving the small one a single poll per
+    cycle (a ~14:1 split rather than 2:1).
+    """
+    clock = _FakeClock()
+    lb = _make_balancer(clock, rotation_interval=900.0)
+
+    active = _run_rotation(lb, clock, {"small": 0.5, "large": 1.0}, minutes=120)
+
+    assert active["small"] > 0
+    assert 1.8 <= active["large"] / active["small"] <= 2.2
+
+
+def test_equal_weights_split_active_time_evenly() -> None:
+    """The neutral case stays even — the fix must not skew a 1:1 pool."""
+    clock = _FakeClock()
+    lb = _make_balancer(clock, rotation_interval=900.0)
+
+    active = _run_rotation(lb, clock, {"a": 1.0, "b": 1.0}, minutes=120)
+
+    assert 0.8 <= active["a"] / active["b"] <= 1.2
+
+
+def test_weight_sort_does_not_re_pin_the_head_every_tick() -> None:
+    """The weight order is a fill order, not a permanent rank.
+
+    Once the head rotates out it must stay out for the next battery's whole
+    window; re-sorting by weight on every poll would hand the slot straight
+    back to the heaviest battery.
+    """
+    clock = _FakeClock()
+    lb = _make_balancer(clock, rotation_interval=900.0)
+    reports = {"a": _report(0.0, 0.4), "b": _report(0.0, 1.0)}
+
+    # First tick fills the order by weight: the heavier battery leads.
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(reports, (0,), 200.0)
+    assert lb._priority[0] == "b"
+
+    # "b" holds a full interval, then hands over to "a" ...
+    clock.advance(901.0)
+    lb._compute_efficiency_deprioritized(reports, (1,), 200.0)
+    assert lb._priority[0] == "a"
+
+    # ... and keeps it for its own (shorter) window instead of being displaced
+    # on the very next poll.
+    clock.advance(60.0)
+    lb._compute_efficiency_deprioritized(reports, (2,), 200.0)
+    assert lb._priority[0] == "a"

--- a/tests/test_balancer_efficiency_window_weight.py
+++ b/tests/test_balancer_efficiency_window_weight.py
@@ -435,3 +435,52 @@ def test_rejected_probe_leaves_its_candidate_at_the_back() -> None:
         clock.advance(1.0)
         lb._compute_efficiency_deprioritized(reports, (i,), 200.0)
         assert lb._priority[0] == "light"
+
+
+def test_departing_battery_leaves_the_rotation_order_alone() -> None:
+    """A battery dropping out takes its slot with it and nothing else.
+
+    The other half of ``_sync_pool``'s reconciliation: the survivors keep their
+    order and the departed id is dropped from ``_deprioritized`` too, rather
+    than the pool being refilled by weight from scratch.
+    """
+    clock = _FakeClock()
+    lb = _make_balancer(clock, rotation_interval=900.0)
+    three = {
+        "heavy": _report(0.0, 1.0),
+        "mid": _report(0.0, 0.5),
+        "light": _report(0.0, 0.25),
+    }
+
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(three, (0,), 200.0)
+    assert lb._priority == ["heavy", "mid", "light"]
+
+    # "heavy" goes silent mid-window: "mid" inherits the head in place, and the
+    # order behind it is untouched.
+    two = {"mid": _report(0.0, 0.5), "light": _report(0.0, 0.25)}
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(two, (1,), 200.0)
+    assert lb._priority == ["mid", "light"]
+    assert "heavy" not in lb._deprioritized
+
+
+def test_all_zero_weight_pool_still_rotates() -> None:
+    """Every battery parked is not a state the pool can rest in.
+
+    With nothing to promote, the zero-weight sink is a no-op and each head's
+    threshold is 0, so the pool keeps rotating.  Recorded as the behaviour
+    inherited from before the fix rather than endorsed: with every weight at 0
+    there is no battery the balancer is allowed to prefer.
+    """
+    clock = _FakeClock()
+    lb = _make_balancer(clock, rotation_interval=900.0)
+    reports = {"a": _report(0.0, 0.0), "b": _report(0.0, 0.0)}
+
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(reports, (0,), 200.0)
+    first = lb._priority[0]
+
+    clock.advance(1.0)
+    lb._compute_efficiency_deprioritized(reports, (1,), 200.0)
+    assert lb._priority[0] != first


### PR DESCRIPTION
## Why

At low demand the balancer runs only some batteries and rotates which one is active. A battery set to a lower **Efficiency Window Weight** than its peers was supposed to take proportionally less of that active time; instead it barely took a turn at all. Reported in #647 by someone pairing a 5.12 kWh Venus E with a 10.24 kWh Venus D and wanting the night-time rotation split 1:2 rather than 15 minutes each.

`_sync_pool` re-sorted the whole priority queue by weight on **every** poll, which made the weight a permanent rank instead of a rotation bias: `_rotate_priority_head` sent the head to the back, and the next poll's sort put the heaviest battery straight back. Measured at a 10 s cadence over 6 hours, a 0.5 / 1.0 pair split **240 s against 21360 s** — nearer 89:1 than the intended 2:1. Even 0.99 / 1.0 collapsed the same way.

The same sort silently undid three other deliberate reorderings whenever weights differed: `_maybe_force_swap_saturated` (a saturated battery was reinstated at the head on the next poll, permanently), `force_rotation` (the dashboard's "rotate now" button), and `_reject_probe` (a battery that had just failed its probe was re-promoted).

Fixes #647.

## What changed

Weight now decides the **fill order** of a fresh pool only; once batteries are in the rotation, the order belongs to the rotation. The per-poll sort is reduced to sinking **zero**-weight batteries, so parking still takes effect the moment it is set.

The weight also now scales the rotation window only while a **single** battery holds the rotating slot. Above one slot a battery is active for its own turn *and* its predecessors', so scaling the head's turn spread *equally* weighted batteries unevenly — three at 1.0 / 1.0 / 0.25 with two slots measured 28 / 44 / 28 %, i.e. two batteries weighted the same wearing ~60 % apart. Gated, the same pool measures 33.5 / 33.5 / 33 %.

A **zero** weight at the head falls back to a full window too. That only happens when every battery in the pool is parked, and taken literally it is a zero threshold: the slot changed hands roughly every 46 s against the 900 s interval, each handover starting a probe. Found by CodeRabbit on this PR.

Mirrored in `esphome/components/ct002/balancer.cpp`.

## One judgement call worth your sign-off

This removes a capability that existed by accident. Previously a low-but-nonzero weight sank a battery to the permanent tail, so `25 %` among `100 %`s meant "excluded whenever the pool limits". Now an in-between weight has **no effect above one active slot**, and `0 %` is park-entirely — so "spare the old battery, but don't retire it" has no setting left in a 3+ battery pool.

I judged the equal-weight unfairness worse than losing that, but it is your call; reverting just the `active_slots <= 1` gate is a small change.

## Verification

- Full `ruff format` / `ruff check` / `mypy src/` / `pytest` green. `tests/components/ct002/test_host_protocol.py` cannot fetch the googletest tarball through the sandbox proxy, so those binaries were built from a git clone per the parity skill: all 8 pass (146 gtests).
- 13 new unit tests plus one rename; **8 of them fail** against `develop`.
- The parity scenario was extended and checked for teeth in both directions: reverting `balancer.cpp` wholesale fails `test_parity_efficiency_window_weight` plus fuzz seeds, and reverting **only** the `prev_slots <= 1` gate still fails it — both halves of that change are pinned, not just the obvious one.
- **Known coverage gap:** the all-zero segment added to the parity scenario pins that both stacks agree on an all-zero pool, but *not* the zero-weight fallback itself — with those reports the probe and saturation machinery owns the ordering, so removing the fallback from the C++ alone parts neither the scenario nor the fuzzer. That fallback is pinned on the Python side only, and the scenario comment says so.
- Post-fix shares at a 1 s field cadence: 0.5 / 1.0 → 2.01:1; three at 1.0 / 0.5 / 0.25 → 57.4 / 28.4 / 14.2 % against an ideal 57.1 / 28.6 / 14.3.
- Defaults cannot move: with every weight at 1.0 the new code is provably identical to the old (the arrival sort collapses to id order, the zero-sink is a no-op, the head window is a full interval either way), and the simulator never sets the field — borne out by the steering-eval gate, which reports 0 improved / 0 regressed / 15 unchanged across all 33 scenarios.

## Checklist

- [x] Base branch is `develop`, not `main`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest`
- [x] Python ↔ ESPHome parity held for shared CT002 behaviour
- [x] No `web/` changes, so no dashboard bundle rebuild
- [x] User-visible change: one bullet under `## Next` in CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qruTiYvafZMkP2429bjVQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved low-demand battery rotation so Efficiency Window Weight values proportionally reduce active time.
  - Batteries set to 0% remain held back when other batteries can cover demand.
  - Preserved full rotation intervals when multiple batteries run simultaneously; Distribution Weight continues to manage load sharing.

- **Documentation**
  - Clarified Efficiency Window Weight behavior, examples, and its relationship to Distribution Weight across user documentation and controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
