### PR TITLE
Step the meter filters aside during a battery's inspection sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Fixed** the brief self-test a Marstek battery runs every ~35 minutes turning into a minute of full-power charging against the house when the optional Hampel outlier filter was on ([#652](https://github.com/tomquist/astrameter/issues/652)).
+
 
 ## 2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** the brief self-test a Marstek battery runs every ~35 minutes turning into a minute of full-power charging against the house when the optional Hampel outlier filter was on ([#652](https://github.com/tomquist/astrameter/issues/652), [#653](https://github.com/tomquist/astrameter/pull/653)).
+- **Fixed** a battery being driven to full charge or discharge against the house for up to a minute after it ran its phase detection, on setups using the optional Hampel outlier filter ([#652](https://github.com/tomquist/astrameter/issues/652), [#653](https://github.com/tomquist/astrameter/pull/653)).
 
 
 ## 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** the brief self-test a Marstek battery runs every ~35 minutes turning into a minute of full-power charging against the house when the optional Hampel outlier filter was on ([#652](https://github.com/tomquist/astrameter/issues/652)).
+- **Fixed** the brief self-test a Marstek battery runs every ~35 minutes turning into a minute of full-power charging against the house when the optional Hampel outlier filter was on ([#652](https://github.com/tomquist/astrameter/issues/652), [#653](https://github.com/tomquist/astrameter/pull/653)).
 
 
 ## 2.3.0

--- a/docs/ct002-ct003-protocol.md
+++ b/docs/ct002-ct003-protocol.md
@@ -83,8 +83,18 @@ same ASCII wire field.
 - Any other value (observed: `0`, empty) is the **`'0'` unassigned bucket** — the
   **inspection mode** a device uses while it is still determining which phase it is on.
 - The emulator:
-  - **Responds** to the request (so the device can continue its phase detection), and
-  - **Does not** add an unassigned/inspection reporter's power to a committed‑phase aggregate.
+  - **Responds** to the request (so the device can continue its phase detection),
+  - **Does not** add an unassigned/inspection reporter's power to a committed‑phase aggregate, and
+  - **Resets the meter's conditioning wrappers** (Hampel window, EMA, deadband) on every
+    inspection poll and once more when the sweep ends — see below.
+- Inspection is **not** only a startup state: a Venus on firmware 1.50 was observed
+  re‑running it roughly every 35 minutes, and the routine is a *sweep* — the battery
+  takes itself off the CT and drives its own output to nearly full discharge and then
+  nearly full charge (~20 s) to watch the CT reading follow. Its grid swing is real and
+  is the whole point, so a rolling‑median filter must not reject it as a spike: it would
+  answer the sweep with a frozen pre‑sweep reading and then reject the true readings that
+  come back, steering the battery against an inverted grid sign once the sweep ends
+  (issue #652).
 - The `participate` flag (field 7) is an additional, explicit gate: even a fully phase‑committed reporter
   is **excluded from aggregation** when it sends `0`.
 

--- a/esphome/components/ct002/ct002.cpp
+++ b/esphome/components/ct002/ct002.cpp
@@ -355,6 +355,11 @@ void CT002Component::handle_request_(const uint8_t *data, size_t len,
                                 static_cast<float>(reported_power), meter_dev_type, addr_ip,
                                 participates);
 
+  // Before the dedupe decision, and before the pipeline read below: the sweep
+  // is under way whether or not this particular poll earns a reply. Mirrors
+  // ct002.py _handle_request ordering.
+  this->sync_inspection_filters_(consumer_id, in_inspection_mode);
+
   // Deduplication — drop repeat polls from the same consumer inside the
   // configured window (keyed by consumer_id so retransmits are suppressed
   // regardless of source UDP port). Disabled (default window 0) means every
@@ -439,6 +444,32 @@ void CT002Component::handle_request_(const uint8_t *data, size_t len,
   if (!in_inspection_mode) {
     for (auto &cb : this->consumer_event_listeners_) cb(consumer_id);
   }
+}
+
+// Keep the meter's conditioning filters out of an inspection sweep.
+//
+// A battery that polls with phase "0" has taken itself off the CT and is
+// sweeping its own output -- up to full discharge, then full charge -- to watch
+// the CT reading follow. Those kilowatt swings are real, and seeing them is the
+// entire point of the sweep, but to a rolling-median filter they look exactly
+// like the meter glitches it exists to reject: with hampel: set, the emulator
+// answers the whole sweep with the frozen pre-sweep reading, so the battery is
+// testing against a CT that never responds. The filter then adopts the sweep as
+// its new normal just as the sweep ends, and rejects the true readings that come
+// back -- which resumed active control against an inverted grid sign, driving the
+// battery to full charge while the house imported (issue #652).
+//
+// So reset the wrapper state on every inspection poll (the window never fills,
+// which is what makes the relay path genuinely raw) and once more on the first
+// committed-phase poll after the sweep. Mirrors ct002.py
+// _sync_inspection_filters.
+void CT002Component::sync_inspection_filters_(const std::string &consumer_id, bool inspecting) {
+  if (inspecting) {
+    this->inspecting_.insert(consumer_id);
+  } else if (this->inspecting_.erase(consumer_id) == 0) {
+    return;
+  }
+  for (auto &p : this->pipeline_) p->reset();
 }
 
 std::string CT002Component::consumer_key_(const std::string &meter_mac,
@@ -968,6 +999,10 @@ void CT002Component::evict_stale_consumers_() {
     for (auto &cb : this->consumer_removed_listeners_) cb(id);
     this->consumers_.erase(id);
     if (this->balancer_) this->balancer_->remove_consumer(id);
+    // A battery that fell silent mid-sweep never sends the committed-phase
+    // poll that ends the sweep, so drop it here rather than leave it marked as
+    // inspecting forever (mirrors Python's _cleanup_consumers).
+    this->inspecting_.erase(id);
   }
   if (!stale.empty()) {
     ESP_LOGD(TAG, "Evicted %u stale consumer(s)", static_cast<unsigned>(stale.size()));

--- a/esphome/components/ct002/ct002.h
+++ b/esphome/components/ct002/ct002.h
@@ -384,6 +384,14 @@ class CT002Component : public Component {
   // timestamp), matching RequestDeduplicator.should_process.
   bool dedup_should_process_(const std::string &consumer_id);
 
+  // Keeps the filter pipeline out of an inspection sweep: resets the wrapper
+  // state on every inspection poll and once more when the sweep ends, so the
+  // battery sees a CT that follows its own swing and the control loop restarts
+  // from a baseline the sweep did not write. Mirrors ct002.py
+  // _sync_inspection_filters — see its docstring for the full rationale
+  // (issue #652).
+  void sync_inspection_filters_(const std::string &consumer_id, bool inspecting);
+
   // Folds the gap since the previous reply to this consumer into its
   // answer_interval. Called right after a response goes out.
   void track_answer_(const std::string &consumer_id);
@@ -463,6 +471,10 @@ class CT002Component : public Component {
   // Pipeline: head is SensorBackedPowermeter, then optional wrappers.
   std::vector<std::unique_ptr<Powermeter>> pipeline_;
   Powermeter *pipeline_head_{nullptr};
+
+  // Consumers whose last poll was an inspection poll (phase "0"), mirroring
+  // ct002.py's _inspecting.
+  std::unordered_set<std::string> inspecting_;
 
   // Pending wrapper configs captured before setup() — applied at setup()
   // time when the SensorBackedPowermeter exists.

--- a/src/astrameter/ct002/ct002.py
+++ b/src/astrameter/ct002/ct002.py
@@ -475,6 +475,15 @@ class CT002:
         # battery.  A single in-flight handler per consumer emits the one
         # response for the next reading; duplicate polls are dropped.
         self._inflight_consumers: set[str] = set()
+        # Consumers whose last poll was an inspection poll (phase '0').  Used
+        # to keep the meter's conditioning filters out of the way for the whole
+        # sweep and to hand the control loop a fresh baseline once it ends —
+        # see _sync_inspection_filters.
+        self._inspecting: set[str] = set()
+        # Clears the powermeter wrappers' rolling state (Hampel window, EMA,
+        # deadband).  The balancer holds the same hook for its efficiency
+        # probe; the CT002 emulator uses it around an inspection sweep.
+        self._reset_fn = reset_fn
         self._info_idx_counter = 0
         # Use wall-clock (time.time) so the dedup shares a timebase with
         # _cleanup_consumers' purge; RequestDeduplicator would otherwise
@@ -771,6 +780,10 @@ class CT002:
             del self._consumers[key]
             self._balancer.remove_consumer(key)
             self._last_target_by_consumer.pop(key, None)
+            # A battery that fell silent mid-sweep never sends the committed-
+            # phase poll that ends the sweep, so drop it here rather than leave
+            # it marked as inspecting forever.
+            self._inspecting.discard(key)
         if stale:
             self._rev += 1
         # Dedup entries only matter within the dedupe window; with an adaptive
@@ -1251,6 +1264,9 @@ class CT002:
             source_ip=str(addr[0]),
             participates=request.participates,
         )
+        # Before the dedupe decision, and before the meter read in _serve: the
+        # sweep is under way whether or not this particular poll earns a reply.
+        self._sync_inspection_filters(consumer_id, request.in_inspection_mode)
 
         if not self._should_serve(request):
             return
@@ -1260,6 +1276,43 @@ class CT002:
             await self._serve(request, transport)
         finally:
             self._inflight_consumers.discard(consumer_id)
+
+    def _sync_inspection_filters(self, consumer_id: str, inspecting: bool) -> None:
+        """Keep the meter's conditioning filters out of an inspection sweep.
+
+        A battery that polls with phase ``'0'`` has taken itself off the CT and
+        is sweeping its own output — up to full discharge, then full charge —
+        to watch the CT reading follow.  Those kilowatt swings are real, and
+        seeing them is the entire point of the sweep, but to a rolling-median
+        filter they look exactly like the meter glitches it exists to reject:
+        with ``HAMPEL_WINDOW`` set, the emulator answers the whole sweep with
+        the frozen pre-sweep reading, so the battery is testing against a CT
+        that never responds.  The filter then adopts the sweep as its new
+        normal just as the sweep ends, and rejects the true readings that come
+        back — which resumed active control against an inverted grid sign,
+        driving the battery to full charge while the house imported (issue
+        #652).
+
+        So reset the wrapper state on every inspection poll (the window never
+        fills, which is what makes the relay path genuinely raw) and once more
+        on the first committed-phase poll after the sweep, so the control loop
+        restarts from a baseline the sweep did not write.  This is the same
+        hook, for the same reason, the balancer uses around an efficiency probe
+        — a deliberate power swing must not be filtered as noise.
+
+        The hook resets every configured powermeter, so a second battery
+        steering through the sweep loses its filtering too.  That is correct:
+        the swing is on the grid it shares, so those readings are just as real
+        for it.
+        """
+        if inspecting:
+            self._inspecting.add(consumer_id)
+        elif consumer_id in self._inspecting:
+            self._inspecting.discard(consumer_id)
+        else:
+            return
+        if self._reset_fn is not None:
+            self._reset_fn()
 
     def _decode_request(
         self, data: bytes, addr: tuple[str, int]

--- a/tests/test_issue652_inspection_sweep.py
+++ b/tests/test_issue652_inspection_sweep.py
@@ -1,0 +1,181 @@
+"""Regression for issue #652 — a Hampel-filtered CT sits out the sweep.
+
+A Venus on firmware 1.50 re-runs its CT inspection every ~35 minutes: it polls
+with phase ``'0'``, takes itself off the CT and sweeps its own output to nearly
+full discharge and then nearly full charge, watching the CT reading follow.
+
+With ``HAMPEL_WINDOW`` set, the reporter's log showed the emulator answering
+that whole sweep with the *frozen* pre-sweep reading (+34 W while the house was
+exporting 1712 W) — the battery was testing against a CT that never moved.  The
+filter then adopted the sweep's export readings as its new normal just as the
+sweep ended and rejected the true import readings that followed, so the resumed
+control loop steered against an inverted grid sign and drove the battery to full
+charge while the house imported 2.1 kW.
+
+The numbers below are the ones from that log (22:15:43-22:16:20).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from astrameter.ct002 import CT002
+from astrameter.ct002.protocol import build_payload, parse_request
+from astrameter.powermeter.base import Powermeter
+from astrameter.powermeter.wrappers import HampelPowermeter
+
+CT_MAC = "112233445566"
+BATTERY_MAC = "AABBCCDDEEFF"
+# The reporter's settings.
+HAMPEL_WINDOW = 7
+HAMPEL_MIN_THRESHOLD = 500.0
+
+# Readings from the log, in watts (positive = import).
+STEADY_GRID = 34.0
+SWEEP_EXPORT_GRID = -1712.0
+POST_SWEEP_IMPORT_GRID = 2103.0
+# What the battery reported at each stage.
+STEADY_OUTPUT = 271
+SWEEP_OUTPUT = 1993
+POST_SWEEP_OUTPUT = -1993
+
+
+class _FakeMeter(Powermeter):
+    """Single-phase source whose reading the test sets directly."""
+
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    async def get_powermeter_watts(self) -> list[float]:
+        return [self.value, 0.0, 0.0]
+
+
+class _CaptureTransport:
+    def __init__(self) -> None:
+        self.sent: bytes | None = None
+
+    def sendto(self, data: bytes, _addr: Any) -> None:
+        self.sent = data
+
+
+class _Rig:
+    """A CT002 reading through a real Hampel filter, wired like main.py."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.meter = _FakeMeter()
+        self.chain = HampelPowermeter(
+            self.meter,
+            window=HAMPEL_WINDOW,
+            min_threshold=HAMPEL_MIN_THRESHOLD,
+        )
+        self.resets = 0
+        self.device = CT002(ct_mac=CT_MAC, reset_fn=self._reset, **kwargs)
+
+        async def before_send(
+            _addr: Any, _request: Any, _consumer_id: str
+        ) -> list[float]:
+            return await self.chain.get_powermeter_watts()
+
+        self.device.before_send = before_send
+
+    def _reset(self) -> None:
+        self.resets += 1
+        self.chain.reset()
+
+    async def poll(self, phase: str, reported_power: int, grid: float) -> float:
+        """Drive one battery poll with the meter reading *grid*.
+
+        Returns the value the CT put in the grid field — the raw relay reading
+        in inspection mode, the steering delta under active control.
+        """
+        self.meter.value = grid
+        transport = _CaptureTransport()
+        request = build_payload(
+            ["HMG-50", BATTERY_MAC, "HME-4", CT_MAC, phase, str(reported_power)]
+        )
+        await self.device._handle_request(request, ("1.1.1.1", 12345), transport)
+        assert transport.sent is not None, "CT002 sent no response"
+        fields, error = parse_request(transport.sent)
+        assert error is None, error
+        assert fields is not None
+        return float(fields[4])
+
+    async def prime(self) -> None:
+        """Fill the Hampel window with the steady pre-sweep grid."""
+        for _ in range(HAMPEL_WINDOW):
+            await self.poll("A", STEADY_OUTPUT, STEADY_GRID)
+
+
+async def test_sweep_reading_reaches_the_battery() -> None:
+    """The battery must see the export its own sweep caused.
+
+    Relay-only (``active_control=False``) so the grid field carries the reading
+    itself: before the fix the filter answered -1712 W of export with the
+    pre-sweep +34 W, which is a CT that does not respond to a 2 kW swing.
+    """
+    rig = _Rig(active_control=False)
+    await rig.prime()
+
+    served = await rig.poll("0", SWEEP_OUTPUT, SWEEP_EXPORT_GRID)
+
+    assert served == SWEEP_EXPORT_GRID, (
+        f"inspection poll was answered with {served} W instead of the "
+        f"{SWEEP_EXPORT_GRID} W the meter actually read"
+    )
+
+
+async def test_post_sweep_control_is_not_inverted() -> None:
+    """Leaving inspection, the first command must follow the real grid.
+
+    The house is importing 2.1 kW with the battery parked at full charge, so
+    the only correct direction is *discharge more* (a positive delta).  Before
+    the fix the filter still held the sweep's export readings, rejected the
+    import, and the loop answered with a negative delta — charge harder.
+    """
+    rig = _Rig(active_control=True)
+    await rig.prime()
+
+    # The sweep: discharge hard, so the house exports for long enough that an
+    # un-reset window (4 of its 7 slots) would carry the export as its median.
+    for _ in range(HAMPEL_WINDOW // 2 + 1):
+        await rig.poll("0", SWEEP_OUTPUT, SWEEP_EXPORT_GRID)
+
+    delta = await rig.poll("A", POST_SWEEP_OUTPUT, POST_SWEEP_IMPORT_GRID)
+
+    assert delta > 0, (
+        f"post-sweep command was {delta} W: the battery is charging at "
+        f"{POST_SWEEP_OUTPUT} W while the house imports "
+        f"{POST_SWEEP_IMPORT_GRID} W, so it must be told to discharge"
+    )
+
+
+async def test_filters_are_reset_around_the_sweep_only() -> None:
+    """Ordinary polls leave the filter alone; inspection polls reset it."""
+    rig = _Rig(active_control=False)
+    await rig.prime()
+    assert rig.resets == 0, "steady-state polls must not reset the filter"
+
+    await rig.poll("0", SWEEP_OUTPUT, SWEEP_EXPORT_GRID)
+    await rig.poll("0", SWEEP_OUTPUT, SWEEP_EXPORT_GRID)
+    assert rig.resets == 2, "every inspection poll keeps the filter out of the way"
+
+    await rig.poll("A", POST_SWEEP_OUTPUT, POST_SWEEP_IMPORT_GRID)
+    assert rig.resets == 3, "the first committed-phase poll clears the sweep's state"
+
+    await rig.poll("A", POST_SWEEP_OUTPUT, POST_SWEEP_IMPORT_GRID)
+    assert rig.resets == 3, "and nothing resets it again once the sweep is over"
+
+
+async def test_genuine_spike_is_still_rejected() -> None:
+    """The filter still does its job between sweeps.
+
+    The reporter's meter emits ~1.7 kW single-sample spikes every couple of
+    minutes — the reason they enabled Hampel at all.  Resetting around a sweep
+    must not turn the filter off for the rest of the time.
+    """
+    rig = _Rig(active_control=False)
+    await rig.prime()
+
+    served = await rig.poll("A", STEADY_OUTPUT, 1800.0)
+
+    assert served == STEADY_GRID, f"spike was relayed as {served} W"


### PR DESCRIPTION
Fixes #652.

## Why

A Venus on firmware 1.50 re-runs its CT inspection roughly every 35 minutes. In the reporter's debug log it happens at 21:41:17 and 22:15:43 — 34 min 26 s apart — and it is a *sweep*: the battery polls with phase `'0'`, takes itself off the CT, and drives its own output to ~+1993 W discharge and then ~−1993 W charge over ~20 s, watching the CT reading follow. That sweep is the firmware's, not ours, and it is what the screenshot in the issue shows.

What AstraMeter added to it, on that setup (`HAMPEL_WINDOW = 7`, `HAMPEL_MIN_THRESHOLD = 500`, `DEDUPE_TIME_WINDOW = 3`):

- **During the sweep the CT never moved.** The readings served while the battery discharged 1603 → 1993 W were `+90, +35, +34, +34`, with the real meter at −1712 W export rejected three times as an outlier (`median=35.00 threshold=500.00`). The battery swung its output by 2 kW and the CT it was testing against sat still.
- **After the sweep the correction was inverted.** By 22:16:07 the filter had adopted the sweep's *export* level as its median, just as the battery flipped to charging and the house went to +2.1 kW import — so the true readings were rejected in turn (`raw=1483/2103/2122 median=−1712`) and active control resumed on a −1700 W grid, sending −30, −60, −100, −100 and driving the battery to its full −1993 W charge against a 2.1 kW import. Recovery then took ~90 s of paced ramping.

A ~20 s firmware self-test became a ~2.5 min multi-kW excursion. The earlier sweep in the same log, before the reporter enabled Hampel, shows the contrast: readings tracked it (566 → −1393) and there was no wrong-direction phase.

## What changed

The CT002 emulator now resets the meter's conditioning wrappers (Hampel window, EMA, deadband) on **every** inspection poll — the window never fills, which is what makes the documented "raw relay" path genuinely raw — and once more on the first committed-phase poll after the sweep, so control restarts from a baseline the sweep did not write.

This is the same hook, for the same reason, the balancer already uses around an efficiency probe (`_commit_probe` / `_reject_probe`): a deliberate power swing must not be filtered as noise. The reset is a no-op when no conditioning is configured.

Deliberately **not** changed: the dedupe window still applies to inspection polls. It exists for meters slower than the poll interval, and exempting them would answer the sweep with stale readings rather than absent ones.

Scope note: the reset clears every configured powermeter, so a second battery steering through another's sweep loses its filtering for the sweep's duration too. That is correct — the swing is on the grid it shares, so those readings are just as real for it.

Also documented the periodic sweep in `docs/ct002-ct003-protocol.md`, which previously described inspection as a startup-only phase-detection state.

## Verification

- `uv run ruff format . && uv run ruff check . && uv run mypy src/` — clean.
- `uv run pytest` — 1698 passed, 41 skipped. The skips are environmental (no mosquitto, no Docker, esphome-as-a-module for `test_codegen`); the ESPHome host-binary e2e suites ran, so the C++ side compiles and the cross-backend scenarios pass. `nm` confirms `sync_inspection_filters_` in the built `ct002-e2e-test` binary.
- Host gtests built per the sandbox workaround (`-DFETCHCONTENT_SOURCE_DIR_GOOGLETEST`, since the tarball fetch gets a 403 behind the proxy) — all 8 binaries pass; `test_host_protocol.py` itself can't run here because its own cmake invocation re-fetches googletest.
- New regression test `tests/test_issue652_inspection_sweep.py` replays the log's sweep through a real `HampelPowermeter`: three of its four cases fail on `develop` and pass here. The fourth asserts a genuine single-sample spike is *still* rejected between sweeps — the reporter's meter emits ~1.7 kW spikes every couple of minutes, which is why they enabled the filter in the first place.

Not attempted: whether the filter blinding the sweep is also what makes the firmware keep re-running it. Two sweeps is not enough to tell, and it needs the reporter to run with the fix (or with Hampel off) for a few hours.

## Checklist

- [x] Base branch is `develop`, not `main`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest`
- [x] Python ↔ ESPHome parity held for shared CT002 behaviour
- [x] `web/` changes: none
- [x] User-visible change: one bullet under `## Next` in CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lys1kPwTcwbhkDGvUJajgQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lys1kPwTcwbhkDGvUJajgQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed battery inspection sweeps so optional outlier filtering no longer prevents the battery from responding correctly to detected grid conditions.
  * Improved recovery after inspection sweeps and when a battery disconnects during inspection.

* **Documentation**
  * Documented inspection-sweep behavior, filter resets, and guidance for avoiding false spike rejection.

* **Tests**
  * Added regression coverage for inspection readings, post-sweep control, filter resets, and genuine power spikes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->