### PR TITLE
Send the cloud-report timestamp as ISO-8601, not a raw datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- **Fixed** the dashboard staying blank and `/api/status` returning nothing once cloud reporting had sent its first push ([#654](https://github.com/tomquist/astrameter/issues/654)).
+- **Fixed** the dashboard staying blank and `/api/status` returning nothing once cloud reporting had sent its first push ([#654](https://github.com/tomquist/astrameter/issues/654), [#656](https://github.com/tomquist/astrameter/pull/656)).
 
 
 ## 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- **Fixed** the dashboard staying blank and `/api/status` returning nothing once cloud reporting had sent its first push ([#654](https://github.com/tomquist/astrameter/issues/654)).
+
 
 ## 2.3.0
 

--- a/src/astrameter/status/registry.py
+++ b/src/astrameter/status/registry.py
@@ -272,11 +272,8 @@ def _as_wire_dict(snapshot: Any) -> dict[str, Any]:
 
     Their field names are already the wire names, so unlike the device
     snapshots they need no rename layer — only ``None``-dropping, nested
-    dataclass expansion, and the ``datetime`` → ISO-8601 step that makes every
-    ``_at`` field a string on the wire.  There is no second chance at that
-    last one: a ``datetime`` that survives here reaches the plain
-    ``json.dumps`` in ``web_guard.json_response``, and the ``TypeError`` it
-    raises takes down the whole status response.
+    dataclass expansion, and the per-value conversion :func:`_wire_value`
+    does.
     """
     if not dataclasses.is_dataclass(snapshot) or isinstance(snapshot, type):
         return {}
@@ -285,17 +282,42 @@ def _as_wire_dict(snapshot: Any) -> dict[str, Any]:
         value = getattr(snapshot, field.name)
         if value is None:
             continue
-        if dataclasses.is_dataclass(value) and not isinstance(value, type):
-            out[field.name] = _as_wire_dict(value)
-        elif isinstance(value, datetime):
-            out[field.name] = iso_datetime(value)
-        elif isinstance(value, (tuple, list)):
-            out[field.name] = [
-                _as_wire_dict(v)
-                if dataclasses.is_dataclass(v) and not isinstance(v, type)
-                else v
-                for v in value
-            ]
+        if isinstance(value, (tuple, list)):
+            out[field.name] = [_wire_value(v, field.name) for v in value]
         else:
-            out[field.name] = value
+            out[field.name] = _wire_value(value, field.name)
     return out
+
+
+#: The types ``json.dumps`` already writes as themselves.  ``bool`` is a
+#: subclass of ``int``, so it is covered.
+_WIRE_SCALARS = (str, int, float)
+
+
+def _wire_value(value: Any, field_name: str) -> Any:
+    """One integration-snapshot field, or one element of one, as its wire value.
+
+    Refuses a type with no wire form instead of passing it through.  The only
+    thing downstream of here is the plain ``json.dumps`` in
+    ``web_guard.json_response``, so an unconverted value is a ``TypeError``
+    that takes down the whole status response — and it surfaces in production
+    rather than in the suite, since a test comparing dicts cannot tell a live
+    ``datetime`` from the string it should have become.  Raising moves that
+    discovery into any test that reaches this path, and names the field; the
+    cost is one branch per new type, which is where the conversion belongs
+    anyway (``status/serialize.py``, beside :func:`iso` and
+    :func:`iso_datetime`).
+    """
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return _as_wire_dict(value)
+    if isinstance(value, datetime):
+        return iso_datetime(value)
+    # `None` is dropped a level up when it is a whole field; inside a sequence
+    # it is a position, so it stays as the `null` it serializes to.
+    if value is None or isinstance(value, _WIRE_SCALARS):
+        return value
+    raise TypeError(
+        f"{field_name}: a {type(value).__name__} has no wire form. Convert it "
+        "in status/serialize.py and give _wire_value a branch — reaching "
+        "json.dumps unconverted would drop the whole status response."
+    )

--- a/src/astrameter/status/registry.py
+++ b/src/astrameter/status/registry.py
@@ -24,6 +24,7 @@ from astrameter.status.serialize import (
     compact,
     ct002_to_wire,
     iso,
+    iso_datetime,
     powermeter_to_wire,
     round_or_none,
     shelly_to_wire,
@@ -270,8 +271,12 @@ def _as_wire_dict(snapshot: Any) -> dict[str, Any]:
     """Shallow dataclass → wire dict for the integration snapshots.
 
     Their field names are already the wire names, so unlike the device
-    snapshots they need no rename layer — only ``None``-dropping and nested
-    dataclass expansion.
+    snapshots they need no rename layer — only ``None``-dropping, nested
+    dataclass expansion, and the ``datetime`` → ISO-8601 step that makes every
+    ``_at`` field a string on the wire.  There is no second chance at that
+    last one: a ``datetime`` that survives here reaches the plain
+    ``json.dumps`` in ``web_guard.json_response``, and the ``TypeError`` it
+    raises takes down the whole status response.
     """
     if not dataclasses.is_dataclass(snapshot) or isinstance(snapshot, type):
         return {}
@@ -282,6 +287,8 @@ def _as_wire_dict(snapshot: Any) -> dict[str, Any]:
             continue
         if dataclasses.is_dataclass(value) and not isinstance(value, type):
             out[field.name] = _as_wire_dict(value)
+        elif isinstance(value, datetime):
+            out[field.name] = iso_datetime(value)
         elif isinstance(value, (tuple, list)):
             out[field.name] = [
                 _as_wire_dict(v)

--- a/src/astrameter/status/serialize.py
+++ b/src/astrameter/status/serialize.py
@@ -45,6 +45,19 @@ def iso(epoch: float | None) -> str | None:
     return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat()
 
 
+def iso_datetime(value: datetime | None) -> str | None:
+    """A ``datetime`` as ISO-8601 UTC, or ``None``.
+
+    The companion to :func:`iso` for state that already holds a ``datetime``
+    rather than an epoch.  A naive value is read as local time — that is what
+    ``datetime.now()`` produces and what ``astimezone()`` assumes — so the
+    wire carries an unambiguous instant either way.
+    """
+    if value is None:
+        return None
+    return value.astimezone(timezone.utc).isoformat()
+
+
 def round_or_none(value: float | None, digits: int = 1) -> float | None:
     """Round a float for the wire, preserving ``None``.
 

--- a/src/astrameter/status/status_test.py
+++ b/src/astrameter/status/status_test.py
@@ -18,6 +18,9 @@ from astrameter.cloud_reporting import (
 from astrameter.config.config_loader import new_config_parser
 from astrameter.config.ini_config import IniAppConfig
 from astrameter.ct002 import CT002
+from astrameter.mqtt_insights.marstek_mqtt import MarstekMqttBinding
+from astrameter.mqtt_insights.service import MqttInsightsConfig, MqttInsightsService
+from astrameter.powermeter.base import Powermeter
 from astrameter.powermeter.wrappers.health import HealthTrackingPowermeter
 from astrameter.status import StatusRegistry, detect_config_mode
 from astrameter.status.config_mode import materialize_config, target_path
@@ -526,3 +529,93 @@ def test_iso_datetime_reads_a_naive_stamp_as_local_time() -> None:
     aware = datetime(2026, 6, 18, 12, 0, 0, tzinfo=timezone.utc)
     assert iso_datetime(aware) == "2026-06-18T12:00:00+00:00"
     assert iso_datetime(aware.astimezone()) == "2026-06-18T12:00:00+00:00"
+
+
+# -- every subsystem at once ------------------------------------------
+
+
+class _StubMeter(Powermeter):
+    """Innermost meter, so the health wrapper has a pipeline to report."""
+
+    async def get_powermeter_watts(self) -> list[float]:
+        return [230.0, -14.0, 0.0]
+
+
+async def _everything() -> StatusRegistry:
+    """A registry with every optional subsystem populated.
+
+    The `/api/status` tests run against devices alone, and until #654 nothing
+    anywhere put a cloud reporter in a registry — which is exactly why a field
+    only that subsystem produces reached users unserialized.  This builds the
+    whole document instead, from the real objects rather than stand-ins, so
+    the assertion below covers each subsystem's own snapshot types.
+    """
+    from astrameter.shelly.shelly import Shelly
+
+    registry = _registry()
+    registry.register_device("ct-1", "ct002", _ct())
+
+    shelly = Shelly([], udp_port=2220, device_id="sh-1", device_type="shellypro3em_new")
+    shelly._track_battery_seen(("10.0.0.31", 1010))
+    registry.register_device("sh-1", "shellypro3em", shelly)
+
+    meter = HealthTrackingPowermeter(_StubMeter(), name="SCRIPT_1")
+    await meter.get_powermeter_watts()
+    registry.powermeters = [meter]
+
+    insights = MqttInsightsService(MqttInsightsConfig(broker="10.0.0.2"))
+    await insights.register_marstek(
+        MarstekMqttBinding(
+            device_id="ct-1",
+            ct_type="HME-4",
+            mac="02b250000001",
+            get_values=_StubMeter().get_powermeter_watts,
+            wifi_rssi=-55,
+        )
+    )
+    registry.insights = insights
+
+    registry.cloud_reporters["aabbccddeeff"] = await _reporter_that_has_pushed()
+    registry.managed_marstek["HME-4"] = ("02b250000001", 121)
+    return registry
+
+
+async def test_the_whole_status_document_is_json() -> None:
+    """The backstop for the class of bug #654 was: the serializer's contract
+    is JSON, but every test asserted dicts, and a dict holding a live
+    ``datetime`` compares equal to one holding a live ``datetime``.  Only
+    ``json.dumps`` can tell them apart, and before this nothing called it —
+    so the one thing that could was the running server.
+    """
+    registry = await _everything()
+
+    document = json.loads(json.dumps(registry.snapshot(ingress=False)))
+
+    # Pin what was covered, so a subsystem added later that `_everything`
+    # forgets shows up as this test going quiet rather than staying green.
+    assert len(document["devices"]) == 2
+    assert len(document["powermeters"]) == 1
+    assert set(document["integrations"]) == {
+        "mqtt_insights",
+        "cloud_reporting",
+        "marstek_account",
+    }
+    assert document["integrations"]["mqtt_insights"]["marstek_bindings"]
+
+
+def test_a_value_with_no_wire_form_is_refused_not_passed_through() -> None:
+    """The trapdoor #654 came through: `_as_wire_dict` wrote every unknown
+    type to the wire untouched, leaving `json.dumps` to fail on it at request
+    time.  Refusing here names the field and fails in the suite instead."""
+
+    @dataclasses.dataclass
+    class Snapshot:
+        ok: str = "fine"
+        rogue: Any = Path("/etc/passwd")
+
+    with pytest.raises(TypeError, match="rogue: a PosixPath has no wire form"):
+        _as_wire_dict(Snapshot())
+
+    # A sequence is the same wire, so it gets the same refusal.
+    with pytest.raises(TypeError, match="rogue: a PosixPath"):
+        _as_wire_dict(Snapshot(rogue=[Path("/etc/passwd")]))

--- a/src/astrameter/status/status_test.py
+++ b/src/astrameter/status/status_test.py
@@ -2,12 +2,19 @@
 
 import dataclasses
 import inspect
+import json
 from collections.abc import Callable
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+from astrameter.cloud_reporting import (
+    CloudReporter,
+    CloudReporterConfig,
+    CtMeasurement,
+)
 from astrameter.config.config_loader import new_config_parser
 from astrameter.config.ini_config import IniAppConfig
 from astrameter.ct002 import CT002
@@ -16,7 +23,7 @@ from astrameter.status import StatusRegistry, detect_config_mode
 from astrameter.status.config_mode import materialize_config, target_path
 from astrameter.status.registry import _as_wire_dict
 from astrameter.status.secrets import SENTINEL, redact_sections, restore_sections
-from astrameter.status.serialize import compact, iso, round_or_none
+from astrameter.status.serialize import compact, iso, iso_datetime, round_or_none
 
 
 def _registry(**kwargs: Any) -> StatusRegistry:
@@ -448,3 +455,74 @@ def test_as_wire_dict_expands_nested_dataclasses_and_drops_none() -> None:
 
     out = _as_wire_dict(Outer(items=(Inner(a=2),)))
     assert out == {"inner": {"a": 1}, "items": [{"a": 2}]}
+
+
+# -- integration snapshots on the wire ---------------------------------
+
+#: Local wall clock the fake reporter stamps its push with, as
+#: ``CloudReporter`` does with a naive ``datetime.now()``.
+_REPORTED_AT = datetime(2026, 6, 18, 12, 0, 0)
+
+
+async def _reporter_that_has_pushed() -> CloudReporter:
+    """A cloud reporter past its first push, so ``last_report_at`` is set."""
+
+    async def http_get(url: str) -> int | None:
+        return 200
+
+    async def gather() -> CtMeasurement:
+        return CtMeasurement(ap=10, bp=20, cp=30, dp=60)
+
+    reporter = CloudReporter(
+        CloudReporterConfig(ct_type="HME-4", device_id="aabbccddeeff"),
+        gather=gather,
+        http_get=http_get,
+        clock=lambda: _REPORTED_AT,
+    )
+    await reporter._report_once()
+    return reporter
+
+
+async def test_status_snapshot_is_json_serializable_once_the_cloud_has_reported() -> (
+    None
+):
+    """A ``datetime`` left on the wire takes the whole response down.
+
+    ``web_guard.json_response`` calls plain ``json.dumps``, so a snapshot
+    holding a ``datetime`` raised ``TypeError`` and dropped every
+    ``/api/status`` request — the dashboard went blank for anyone running
+    cloud reporting, as soon as it had pushed once.
+    """
+    registry = _registry()
+    registry.cloud_reporters["aabbccddeeff"] = await _reporter_that_has_pushed()
+
+    wire = json.loads(json.dumps(registry.snapshot(ingress=False)))
+
+    reported = wire["integrations"]["cloud_reporting"][0]
+    assert (
+        reported["last_report_at"] == _REPORTED_AT.astimezone(timezone.utc).isoformat()
+    )
+    assert reported["last_http_status"] == 200
+
+
+async def test_cloud_reporting_wire_dict_states_the_time_as_iso() -> None:
+    """The wire's ``_at`` fields are ISO-8601 strings whatever produced them."""
+    snapshot = (await _reporter_that_has_pushed()).status_snapshot()
+
+    assert _as_wire_dict(snapshot)["last_report_at"] == (
+        _REPORTED_AT.astimezone(timezone.utc).isoformat()
+    )
+
+
+def test_iso_datetime_reads_a_naive_stamp_as_local_time() -> None:
+    """``CloudReporter`` stamps with a naive ``datetime.now()``, so a value
+    carrying no zone is the local clock — not UTC — and names the same instant
+    its own ``timestamp()`` does, which is what the push URL is built from."""
+    assert iso_datetime(None) is None
+    assert iso_datetime(_REPORTED_AT) == (
+        datetime.fromtimestamp(_REPORTED_AT.timestamp(), tz=timezone.utc).isoformat()
+    )
+
+    aware = datetime(2026, 6, 18, 12, 0, 0, tzinfo=timezone.utc)
+    assert iso_datetime(aware) == "2026-06-18T12:00:00+00:00"
+    assert iso_datetime(aware.astimezone()) == "2026-06-18T12:00:00+00:00"


### PR DESCRIPTION
Fixes #654.

## Why

With cloud reporting on, the dashboard went blank and `/api/status` answered
nothing from the moment the reporter made its first push.
`CloudReporterSnapshot.last_report_at` is a `datetime`, `_as_wire_dict` passed
it through untouched, and `web_guard.json_response` renders with a plain
`json.dumps` — so every status request died on
`TypeError: Object of type datetime is not JSON serializable`. Nothing else
about the install was wrong, and nothing in the UI said why.

Reproduced against `develop` before fixing: a registry holding one reporter
that had reported once raises that exact `TypeError` on `json.dumps` of its
snapshot.

`_as_wire_dict` now converts a `datetime` the way the device snapshots already
convert their epochs, through a new `iso_datetime` beside `iso` in the one
serializer module — so `last_report_at` crosses as the ISO-8601 UTC string
every other `_at` field on the wire is, rather than being stringified
somewhere by a blanket `default=str` in whatever shape `str()` happens to
give. A naive stamp, which `CloudReporter`'s default clock produces, is read
as local time: the same reading its own `timestamp()` already gives the push
URL.

## Why it reached users, and what now stops the next one

Three things lined up, so the fix alone would leave the trapdoor open:

- **The tests asserted dicts, not JSON.** A dict holding a live `datetime`
  compares equal to a dict holding a live `datetime`, so no dict-equality test
  could see this. Nothing in the suite called `json.dumps` on a status
  snapshot at all — the only thing that could tell was the running server.
- **The route was covered; the state wasn't.** `web_server_test.py` drives the
  real `/api/status` through the real `json_response`, but no test registry
  ever held a cloud reporter — outside `main.py`, nothing populated
  `cloud_reporters`, so that branch never reached a served response.
- **Nobody reads the field.** The page renders `integrations.mqtt_insights`
  and nothing else, so no e2e or screenshot test touched `cloud_reporting`
  either.

Hence two additions beyond the one-line conversion:

1. `_everything()` builds a registry with every optional subsystem populated —
   both device kinds, a health-tracking powermeter, MQTT Insights with a
   Marstek binding, a cloud reporter that has pushed, a managed Marstek entry
   — from the real objects rather than stand-ins, and
   `test_the_whole_status_document_is_json` asserts the whole document
   survives `json.dumps`. It pins what it covered, so a subsystem added later
   that `_everything()` forgets shows up as the test going quiet.
2. The per-value conversion moves into `_wire_value`, shared by the scalar and
   sequence paths (the sequence had the same hole one level down), and a type
   with no wire form is now a `TypeError` naming the field instead of a value
   written straight to the wire. `snapshot()` only feeds `/api/status`, which
   already died on such a value at `json.dumps`, so the blast radius is
   unchanged — what improves is that the failure now happens in the suite, and
   says which field.

Every test here fails against the pre-fix behaviour, checked by reverting it.

## Checklist

- [x] Base branch is `develop`, not `main`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/ && uv run pytest` — 1655 passed, 98 skipped
- [x] Python ↔ ESPHome parity held for shared CT002 behaviour, or does not apply — does not apply: the firmware's `write_integrations` emits only `mqtt_insights`, never a `cloud_reporting` block. `uv run pytest tests/components/ct002/` is green (70 passed, 39 skipped — the skips need the `esphome` CLI).
- [x] `web/` changes: none
- [x] User-visible change: one bullet under `## Next` in CHANGELOG.md (the guard and the test are covered by it; no second bullet for tests-only work)

`develop` moved under the branch (#653), so it is merged in here; the only
conflict was the `## Next` changelog block, where both bullets now stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KjFr2aBNeQLGCpBzAnKxt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue that could leave the dashboard blank after cloud reporting sent its first update.
  - Restored responses from the `/api/status` endpoint following cloud reporting activity.
  - Improved status serialization, including consistent UTC ISO-8601 formatting for timestamps.
  - Prevented unsupported status values from being silently included in serialized responses.

- **Tests**
  - Added coverage for complete status-document JSON serialization.
  - Added validation for nested values and timezone-aware and timezone-naive timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->